### PR TITLE
Various documentation improvements

### DIFF
--- a/docs/decomp_me_basics.md
+++ b/docs/decomp_me_basics.md
@@ -9,7 +9,7 @@ In order to create a new scratch, follow the steps below:
 2. Login or register for a new account.
 3. Click on `New scratch` in the top-right corner of the page.
 4. Select `Gamecube/Wii` as the target platform.
-5. Under the compiler section select from the "preset" dropdown either `Animal Crossing (REL)` or `Animal Crossing (DOL)` depending on where the function you are reverse engineering is located. For most game-specific code you will using the `REL` option.
+5. Under the compiler section, select from the "preset" dropdown either `Animal Crossing (REL)` or `Animal Crossing (DOL)` depending on where the function you are reverse engineering is located. For most game-specific code, you will using the `REL` option.
 
 ![decomp.me compiler settings](./doc_assets/decomp_me_compiler_settings.png)
 
@@ -18,9 +18,9 @@ In order to create a new scratch, follow the steps below:
 8. Press the `Create Scratch` button.
 
 ## Matching
-After your scratch has been created you can begin reverse engineering and writing your own C code. You can use tools such as [m2c](./m2c_basics.md) or [Ghidra](ghidra_basics.md) to help assist you. As you make modifications to your scratch you can see how close you are to matching the function.
+After your scratch has been created, you can begin reverse engineering and writing your own C code. You can use tools such as [m2c](./m2c_basics.md) or [Ghidra](ghidra_basics.md) to help assist you. As you make modifications to your scratch, you can see how close you are to matching the function.
 
 Some important notes when matching:
 * Variable ordering matters. If you're finding that you're stuck on the last percent or two of a function, try re-arranging the declaration of your variables.
-* What you write may affect the assembly the comes before or after it. You may find that as you fill out an earlier/later section that your function matching can increase.
-* Only include what you need in your pasted in context. If you include other functions/data you may find that it adds to the "matched" code. In these cases you may need to only forward-declare the respective function(s) and data.
+* What you write may affect the assembly that comes before or after it. You may find that as you fill out an earlier/later section that your function matching can increase.
+* Only include what you need in your pasted-in context. If you include other functions/data, you may find that it adds to the "matched" code. In these cases, you may need to only forward-declare the respective function(s) and data.

--- a/docs/extract_game.md
+++ b/docs/extract_game.md
@@ -1,7 +1,7 @@
 # Game Files Extraction
-As this repository does **not** contains any game assets you will first need to extract files from an existing copy of the game.
+As this repository does **not** contain any game assets, you will first need to extract files from an existing copy of the game.
 
-This repository support the US version of Animal Crossing:
+This repository supports the US version of Animal Crossing:
 - `GAFE01`: Rev 0 (USA) `ISO sha1: 2d2b1fa3883f49af779ce9ca133db3be17be8f32`
 
 ## Dolphin Emulator
@@ -13,7 +13,7 @@ Files can be extracted from a copy of the game using [Dolphin Emulator](https://
 
 ![Dolphin Properties](./doc_assets/dolphin_properties.png)
 
-4. Select the "File System" tab at the top of the opened dialog.
+4. Select the "Filesystem" tab at the top of the opened dialog.
 5. Right-click on the disc.
 6. Select "Extract Entire Disc".
 
@@ -22,17 +22,17 @@ Files can be extracted from a copy of the game using [Dolphin Emulator](https://
 7. Select a convenient folder to extract to.
 
 ## WIT
-Alternatively you can extract the necessary game files using [WIT](https://wit.wiimm.de/). Follow these steps to extract the necessary files:
+Alternatively, you can extract the necessary game files using [WIT](https://wit.wiimm.de/). Follow these steps to extract the necessary files:
 1. Download the archive appropriate to your OS and architecture.
 2. Extract the contents of the archive. Follow the installation instructions included in the `INSTALL.txt` file.
-3. Once installed run the following command:
+3. Once installed, run the following command:
 
 ~~~~console
 wit EXTRACT <PATH_TO_GAME_COPY> <PATH_TO_OUPUT_FOLDER>
 ~~~~
 
 ## Extracted Files
-Once files have been extracted you will need to copy the following files into the `orig/GAFE01_00` folder at the root of the repository:
+Once files have been extracted, you will need to copy the following files into the `orig/GAFE01_00` folder at the root of the repository:
 - `main.dol`
 - `forest_1st.arc`
 - `forest_2nd.arc`

--- a/docs/extract_game.md
+++ b/docs/extract_game.md
@@ -2,7 +2,7 @@
 As this repository does **not** contains any game assets you will first need to extract files from an existing copy of the game.
 
 This repository support the US version of Animal Crossing:
-- `GAFE01`: Rev 0 (USA) `sha1: 2d2b1fa3883f49af779ce9ca133db3be17be8f32`
+- `GAFE01`: Rev 0 (USA) `ISO sha1: 2d2b1fa3883f49af779ce9ca133db3be17be8f32`
 
 ## Dolphin Emulator
 Files can be extracted from a copy of the game using [Dolphin Emulator](https://dolphin-emu.org/). Use the following steps to extract the necessary files:
@@ -32,13 +32,11 @@ wit EXTRACT <PATH_TO_GAME_COPY> <PATH_TO_OUPUT_FOLDER>
 ~~~~
 
 ## Extracted Files
-Once files have been extracted you will need to copy the following files into the `dump/` folder at the root of the repository:
+Once files have been extracted you will need to copy the following files into the `orig/GAFE01_00` folder at the root of the repository:
 - `main.dol`
 - `forest_1st.arc`
 - `forest_2nd.arc`
 - `foresta.rel.szs`
-
-Make sure to rename `main.dol` to `static.dol`.
 
 It is recommended that you also copy the following symbol maps for reference:
 - `foresta.map`

--- a/docs/generating_decomp_context.md
+++ b/docs/generating_decomp_context.md
@@ -1,30 +1,30 @@
 # Decompilation Context
-In order to use tools such as [decomp.me](https://decomp.me/), [m2c](https://simonsoftware.se/other/m2c.html), or [Ghidra](https://ghidra-sre.org/) more effectively you will need to generate a "context" file that contains all of the necessary functions and structures needed to properly parse extracted blocks.
+In order to use tools such as [decomp.me](https://decomp.me/), [m2c](https://simonsoftware.se/other/m2c.html), or [Ghidra](https://ghidra-sre.org/) more effectively, you will need to generate a "context" file that contains all of the necessary functions and structures needed to properly parse extracted blocks.
 
-To help make this easier you can use the [`decompctx.py`](../tools/decompctx.py) script located inside of the `tools/` folder. This script recursively includes and expands all of the header files used by the specified file.
+To help make this easier, you can use the [`decompctx.py`](../tools/decompctx.py) script located inside of the `tools/` folder. This script recursively includes and expands all of the header files used by the specified file.
 
 ## Generating Context
-In order to generate the context for a given file run the following command:
+To generate the context for a given file, run the following command:
 ~~~console
 ./tools/decompctx.py <PATH_TO_C_FILE>
 ~~~
 
-This will generate a `ctx.h` file at the root of the project. You can then copy the content of this file to the tool of your choice.
+This will generate a `ctx.h` file at the root of the project. You can then copy the contents of this file to the tool of your choice.
 
 The script attempts to use the `N64_SDK` environment path variable for the necessary [ultralib](https://github.com/decompals/ultralib) header files. If this environment variable has not been set, or if you'd like to use an alternative SDK path, a path can be provided by using the `--n64-sdk` flag (see below).
 
-If generating context for Ghidra or m2c, use the `--ghidra` or `--m2c` respectively as those tools require specific changes to be made to the generated context.
+If generating context for Ghidra or m2c, use the respective `--ghidra` or `--m2c` flags, as those tools require specific changes to be made to the generated context.
 
 ## Tool Arguments
-You can modify the output of the context by passing in specific arguments. Some tools may require specific options to be turned on or off. For convenience certains tools have flags that automatically set these options.
+You can modify the output of the context by passing specific arguments. Some tools may require specific options to be turned on or off. For convenience, certain tools have flags that automatically set these options.
 
 | Argument                    | Description                                                          |
 |-----------------------------|----------------------------------------------------------------------|
 | `--ghidra`                  | Outputs Ghidra-friendly context.                                     |
 | `--m2c`                     | Outputs m2c-friendly context.                                        |
-| `-o`                        | Specifies a specific path to output the context file to.             |
+| `-o`                        | Specifies a path to output the context file to.                      |
 | `-r`                        | If the context file should be output relative to the source file.    |
-| `--n64-sdk`                 | Specify the top-level path of the N64 SDK.                           |
+| `--n64-sdk`                 | Specify the top-level path of the N64 SDK headers.                   |
 | `--strip-attributes`        | If `__attribute__(())` usages should be stripped.                    |
 | `--strip-at-address`        | Strips out `AT_ADDRES()` and `:` uses.                               |
 | `--convert_binary_literals` | Converts binary literals (0bxxxx) to decimal format.                 |

--- a/docs/generating_decomp_context.md
+++ b/docs/generating_decomp_context.md
@@ -11,7 +11,7 @@ In order to generate the context for a given file run the following command:
 
 This will generate a `ctx.h` file at the root of the project. You can then copy the content of this file to the tool of your choice.
 
-The script attempts to use the `N64_SDK` environment path variable for the necessary [ultralib](https://github.com/decompals/ultralib) header files. If this environment variable has not been set, or if you'd like to use an alternative SDK path, a path can be provided by using the `--n64-sdK` flag (see below).
+The script attempts to use the `N64_SDK` environment path variable for the necessary [ultralib](https://github.com/decompals/ultralib) header files. If this environment variable has not been set, or if you'd like to use an alternative SDK path, a path can be provided by using the `--n64-sdk` flag (see below).
 
 If generating context for Ghidra or m2c, use the `--ghidra` or `--m2c` respectively as those tools require specific changes to be made to the generated context.
 

--- a/docs/ghidra_basics.md
+++ b/docs/ghidra_basics.md
@@ -9,20 +9,20 @@ You can change the signature of a function inside of Ghidra by right-clicking on
 ![Ghidra Edit Function Signature](./doc_assets/ghidra_edit_function_signature.png)
 
 ### Renaming Variables
-When reverse engineering a function it is often helpful to rename variables from their default names to more human-readable names. To do so click on the variable name and then either right-click and select "Rename Variable" or press the `L` key. Type in the new desired name and press "OK".
+When reverse engineering a function, it is often helpful to rename variables from their default names to more human-readable names. To do so, click on the variable name and then either right-click and select "Rename Variable" or press the `L` key. Type in the new desired name and press "OK".
 
 ![Ghidra Rename Variable](./doc_assets/ghidra_rename_variable.png)
 
 ### Retyping Variables
-Ghidra often mistypes variables when first importing and analyzing the game's binary file. As you use Ghidra you can retype variables in order to give you a better and more accurate decompile. To retype a variable, click on the variable's name **NOT** the variables type. Then either right-click and select "Retype Variable" or press `Ctrl + L`.
+Ghidra often mistypes variables when first importing and analyzing the game's binary file. As you use Ghidra, you can retype variables in order to give you a better and more accurate decompile. To retype a variable, click on the variable's name, **NOT** the variable's type. Then, either right-click and select "Retype Variable" or press `Ctrl + L`.
 
 ![Ghidra Retype Variable](./doc_assets/ghidra_retype_variable.png)
 
-In the dialog that comes up select the type you want to change to.
+In the dialog that comes up, select the type you want to change to.
 
 ![Ghidre Type Selection Dialog](./doc_assets/ghidra_data_type_dialog.png)
 
 ### Retyping Data
-You can also retype data to known structs by selecting the piece of data's name in the "Listing" view. Then either right-click and choose `Data->Choose Data Type` or press `T`. Select the data type you wish to apply. You may get a warning that it will clear existing data. If you are confident that the selected data type is correct you can click "Yes".
+You can also retype data to known structs by selecting the piece of data's name in the "Listing" view. Then, either right-click and choose `Data->Choose Data Type` or press `T`. Select the data type you wish to apply. You may get a warning that it will clear existing data. If you are confident that the selected data type is correct, you can click "Yes".
 
 ![Ghidra Choose Data Type](./doc_assets/ghidra_choose_data_type.png)

--- a/docs/ghidra_setup.md
+++ b/docs/ghidra_setup.md
@@ -5,11 +5,11 @@
 To install Ghidra, follow the [instruction on their project page](https://github.com/NationalSecurityAgency/ghidra?tab=readme-ov-file#install). This involves installing the listed requirements and downloading an archived release for your OS.
 
 ## Installing Ghidra GameCube Loader Plugin
-To properly import and analyze the [game files you extracted](./extract_game.md) you will need to install the [Ghidra GameCube Loader Plugin](https://github.com/Cuyler36/Ghidra-GameCube-Loader).
+To properly import and analyze the [game files you extracted](./extract_game.md), you will need to install the [Ghidra GameCube Loader Plugin](https://github.com/Cuyler36/Ghidra-GameCube-Loader).
 
 Follow the steps below to install the plugin:
 1. [Download an archived release](https://github.com/Cuyler36/Ghidra-GameCube-Loader/releases) of the plugin appropriate for the version of Ghidra you are using. Do not decompress the `.zip` file.
-2. Navigate to the folder where Ghidra was installed.
+2. Navigate to the folder where Ghidra is installed.
 3. Copy the plugin `.zip` file to `<Ghidra install directory>/Extensions/Ghidra/`
 4. Start Ghidra.
 5. Select `File->Install Extensions`.
@@ -23,7 +23,7 @@ Follow the steps below to install the plugin:
 7. Press "OK".
 
 # Importing Binaries
-With both Ghidra and the GameCube Loader plugin installed you can now import the binaries extracted from the game for analysis. To do so follow the steps below:
+With both Ghidra and the GameCube Loader plugin installed, you can now import the binaries extracted from the game for analysis. To do so, follow the steps below:
 1. Create a new Ghidra Project.
 2. Select `File->Import File`.
 
@@ -34,7 +34,7 @@ With both Ghidra and the GameCube Loader plugin installed you can now import the
 
 ![Ghidra Import Dialog](./doc_assets/ghidra_import_dialog.png)
 
-5. After import is complete, find the binary in the project view. Open it by double clicking it.
+5. After importing is complete, find the binary in the project view. Open it by double-clicking it.
 6. Upon opening the file, you will get a prompt to analyze the file. Select "Yes".
 7. On the Analyzer window, make sure that the `(GameCube/Wii) Program Analyzer` is checked. Click OK.
 
@@ -47,8 +47,8 @@ The analyzer will import symbols for some of the functions, structs, and data us
 ## Importing Context
 You can optionally import a [context file](generating_decomp_context.md) to help populate Ghidra with structs and typedefs used in our reverse-engineered C code. This allows us to redefine function signatures and retype variables.
 
-1. [Generate your context file](./generating_decomp_context.md) or copy your context from an existing source such as a [decomp.me](https://decomp.me/) scratch.
-2. Got to `File->Parse C Source`.
+1. [Generate your context file](./generating_decomp_context.md) or copy your context from an existing source, such as a [decomp.me](https://decomp.me/) scratch.
+2. Select `File->Parse C Source`.
 
 ![Parse C Source](./doc_assets/ghidra_parse_c_source.png)
 
@@ -63,7 +63,7 @@ You can optionally import a [context file](generating_decomp_context.md) to help
 > :warning: Due to Ghidra's C parser not properly parsing certain attributes, some additional modifications will need to be made.
 
 #### Struct Aligments
-The Ghidra C parser does not properly parse alignments specified by the `_Alignas()` keyword or the  `__attribute__((aligned()))` attribute. After importing your context, search for any uses of the `_Alignas()` or `__attribute__((aligned()))` and make note of the structs using them and the aligment values for each.
+The Ghidra C parser does not properly parse alignments specified by the `_Alignas()` keyword or the  `__attribute__((aligned()))` attribute. After importing your context, search for any uses of the `_Alignas()` or `__attribute__((aligned()))` and make note of the structs using them and the alignment values for each.
 
 An example of a structure that would need to be fixed can be seen below:
 
@@ -73,7 +73,7 @@ typedef struct original_texture_s {
 } __attribute__((aligned(32))) mNW_original_tex_c;
 ~~~
 
-In the above case, `mNW_original_tex_c` is aligned to `32` bytes. However, when imported to Ghidra, it will have an alignment of `1`. To fix the alignment follow these steps:
+In the above case, `mNW_original_tex_c` is aligned to `32` bytes. However, when imported to Ghidra, it will have an alignment of `1`. To fix the alignment, follow these steps:
 1. Open your project in Ghidra.
 2. Navigate to the "Data Tpe Manager".
 3. Search for the struct you need to re-align.
@@ -85,11 +85,11 @@ In the above case, `mNW_original_tex_c` is aligned to `32` bytes. However, when 
 
 ![Struct Editor Dialog](./doc_assets/ghidra_struct_editor_dialog.png)
 
-6. Hit the save button near the top of the dialog, or close the dialog and press "Yes" when prompted to save the changes to the struct.
+6. Click the save button near the top of the dialog, or close the dialog and press "Yes" when prompted to save the changes to the struct.
 
-Please note that if you re-import an entire context file any previous modifications to structs will be discarded. It is strongly recommended that after doing an initial import that you import any new functions and structs on a case-by-case basis. Otherwise, remember to re-apply the alignment changes.
+Please note that if you re-import an entire context file, any previous modifications to structs will be discarded. After doing an initial import, it is strongly recommended that you import any new functions and structs on a case-by-case basis. Otherwise, remember to re-apply the alignment changes.
 
 ## Inline Functions
-While browsing through decompiled code in Ghidra you may come across calls to functions with names following a pattern of `Fun_XXXX`. The functions correspond to the built-in saved register functions and should be inlined and have a `void` return type in order to give a more correct decompilation. It is also recommended to change the name of the function to `FUNCTION_NAME` or another consistent name format to help you keep track of which functions you've made modifications to.
+While browsing through decompiled code in Ghidra, you may come across calls to functions with names following a pattern of `Fun_XXXX`. The functions correspond to the built-in saved register functions and should be inlined and have a `void` return type in order to give a more correct decompilation. It is also recommended to change the name of the function to `FUNCTION_NAME`, or another consistent name format to help you keep track of which functions you've made modifications to.
 
 ![Inline Func Settings](./doc_assets/ghidra_inline_register_function.png)

--- a/docs/ghidra_setup.md
+++ b/docs/ghidra_setup.md
@@ -29,7 +29,7 @@ With both Ghidra and the GameCube Loader plugin installed you can now import the
 
 ![Ghidra Import File Dropdown](./doc_assets/ghidra_import_file.png)
 
-3. Select one of the binary files you extracted: `foresta.rel.szs` or `static.dol`.
+3. Select one of the binary files you extracted: `foresta.rel.szs` or `main.dol`.
 4. In the Import dialog, make sure that `Nintendo GameCube/Wii Binary` is selected for the format. Click OK.
 
 ![Ghidra Import Dialog](./doc_assets/ghidra_import_dialog.png)

--- a/docs/m2c_basics.md
+++ b/docs/m2c_basics.md
@@ -1,5 +1,5 @@
 # M2C Basics
-m2c is another decompilation tool that can be used to reverse engineer functions. It is avaialbe as both a [web tool](https://simonsoftware.se/other/m2c.html) and also as a [standalone tool](https://github.com/matt-kempster/m2c).
+m2c is another decompilation tool that can be used to reverse engineer functions. It is available as both a [web tool](https://simonsoftware.se/other/m2c.html) and also as a [standalone tool](https://github.com/matt-kempster/m2c).
 
 ## Using M2C (Web)
 In order to use m2c you will need to [generate, and then copy the assembly](./decomp_basics.md) for the function you'd like to reverse engineer and also [generate and copy the context](./generating_decomp_context.md) for the function. When generating context, make sure that the `--m2c` flag is used as m2c does not support preprocessor statements and requires additional cleanup for certain formatting issues. Make sure to delete any unneccesary data or functions if generating context from an in-progress C file.

--- a/docs/m2c_basics.md
+++ b/docs/m2c_basics.md
@@ -2,15 +2,15 @@
 m2c is another decompilation tool that can be used to reverse engineer functions. It is available as both a [web tool](https://simonsoftware.se/other/m2c.html) and also as a [standalone tool](https://github.com/matt-kempster/m2c).
 
 ## Using M2C (Web)
-In order to use m2c you will need to [generate, and then copy the assembly](./decomp_basics.md) for the function you'd like to reverse engineer and also [generate and copy the context](./generating_decomp_context.md) for the function. When generating context, make sure that the `--m2c` flag is used as m2c does not support preprocessor statements and requires additional cleanup for certain formatting issues. Make sure to delete any unneccesary data or functions if generating context from an in-progress C file.
+In order to use m2c, you will need to [generate, and then copy the assembly](./decomp_basics.md) for the function you'd like to reverse engineer and also [generate and copy the context](./generating_decomp_context.md) for the function. When generating context, make sure that the `--m2c` flag is used, as m2c does not support preprocessor statements and requires additional cleanup for certain formatting issues. Make sure to delete any unneccesary data or functions if generating context from an in-progress C file.
 
-Below the "Exisiting C Source" section, make sure that the `Compiler and Language` setting is set to `PPC, MWW, C`:
+Below the "Existing C Source" section, make sure that the `Compiler and Language` setting is set to `PPC, MWW, C`:
 
 ![m2c compiler settings](./doc_assets/m2c_compiler_settings.png)
 
-Click on the `Decompile` button and m2c will generate its closests approximation of reverse-engineered C code.
+Click on the `Decompile` button and m2c will generate its closest approximation of reverse-engineered C code.
 
 ## Hinting Function Arguments
-In order to have a slightly more human-readable decompilation generated it is recommended that you forward-declare the function that you are reverse engineering at the bottom of the `Existing C source` section. This just allows `m2c` to more accurately generate C code.
+In order to have a slightly more human-readable decompilation generated, it is recommended that you forward-declare the function that you are reverse engineering at the bottom of the `Existing C source` section. This just allows `m2c` to more accurately generate C code.
 
-In some cases where "fake" inheritance is used such as with actors, it may be more useful to forward-declare the function with the "inherited" struct argument type (such as `STRUCTURE_ACTOR` instead of just `ACTOR`) so that any struct-specific named variables can be used instead of defaulting to using memory offsets.
+In some cases where "fake" inheritance is used, such as with actors, it may be more useful to forward-declare the function with the "inherited" struct argument type (such as `STRUCTURE_ACTOR` instead of just `ACTOR`) so that any struct-specific named variables can be used instead of defaulting to using memory offsets.


### PR DESCRIPTION
This pull mainly consists of typo/grammar fixes, a few phrasing changes to make things a bit clearer, and fixes for some dated references from pre-DTK.

Should be all done except for decomp_basics.md, which refers to `tu_config.py`, which no longer exists, so I need to know what should go there instead.