### PR TITLE
Add explicit return types to functions to comply with C17 strictness.

### DIFF
--- a/src/actor/ac_quest_talk_init.c
+++ b/src/actor/ac_quest_talk_init.c
@@ -907,7 +907,7 @@ static void aQMgr_actor_set_quest_info(QUEST_MANAGER_ACTOR* manager) {
     }
 }
 
-static aQMgr_actor_clear_client_quest_info(QUEST_MANAGER_ACTOR* manager) {
+static void aQMgr_actor_clear_client_quest_info(QUEST_MANAGER_ACTOR* manager) {
     mQst_ClearQuestInfo(&aQMgr_GET_CLIENT(manager)->npc_info.list->quest_info);
 }
 

--- a/src/game/m_all_grow_ovl.c
+++ b/src/game/m_all_grow_ovl.c
@@ -1756,7 +1756,7 @@ static int mAGrw_CheckTree000(mActor_name_t item) {
            item == GOLD_TREE_SAPLING;
 }
 
-static mAGrw_CheckTree001(mActor_name_t item) {
+static int mAGrw_CheckTree001(mActor_name_t item) {
     return item == TREE_S0 || item == TREE_APPLE_S0 || item == TREE_ORANGE_S0 || item == TREE_PEACH_S0 ||
            item == TREE_PEAR_S0 || item == TREE_CHERRY_S0 || item == TREE_1000BELLS_S0 || item == TREE_10000BELLS_S0 ||
            item == TREE_30000BELLS_S0 || item == TREE_1000BELLS_S0 || item == TREE_10000BELLS_S0 ||
@@ -1764,7 +1764,7 @@ static mAGrw_CheckTree001(mActor_name_t item) {
            item == GOLD_TREE_S0;
 }
 
-static mAGrw_CheckTree002(mActor_name_t item) {
+static int mAGrw_CheckTree002(mActor_name_t item) {
     return item == TREE_S1 || item == TREE_APPLE_S1 || item == TREE_ORANGE_S1 || item == TREE_PEACH_S1 ||
            item == TREE_PEAR_S1 || item == TREE_CHERRY_S1 || item == TREE_1000BELLS_S1 || item == TREE_10000BELLS_S1 ||
            item == TREE_30000BELLS_S1 || item == TREE_1000BELLS_S1 || item == TREE_10000BELLS_S1 ||
@@ -1772,7 +1772,7 @@ static mAGrw_CheckTree002(mActor_name_t item) {
            item == GOLD_TREE_S1;
 }
 
-static mAGrw_CheckTree003(mActor_name_t item) {
+static int mAGrw_CheckTree003(mActor_name_t item) {
     return item == TREE_S2 || item == TREE_APPLE_S2 || item == TREE_ORANGE_S2 || item == TREE_PEACH_S2 ||
            item == TREE_PEAR_S2 || item == TREE_CHERRY_S2 || item == TREE_1000BELLS_S2 || item == TREE_10000BELLS_S2 ||
            item == TREE_30000BELLS_S2 || item == TREE_1000BELLS_S2 || item == TREE_10000BELLS_S2 ||
@@ -1780,7 +1780,7 @@ static mAGrw_CheckTree003(mActor_name_t item) {
            item == GOLD_TREE_S2;
 }
 
-static mAGrw_CheckTree004(mActor_name_t item) {
+static int mAGrw_CheckTree004(mActor_name_t item) {
     return item == TREE || item == TREE_APPLE_FRUIT || item == TREE_ORANGE_FRUIT || item == TREE_PEACH_FRUIT ||
            item == TREE_PEAR_FRUIT || item == TREE_CHERRY_FRUIT || item == TREE_1000BELLS || item == TREE_10000BELLS ||
            item == TREE_30000BELLS || item == TREE_100BELLS || item == TREE_PALM_FRUIT || item == CEDAR_TREE ||

--- a/src/game/m_bgm.c
+++ b/src/game/m_bgm.c
@@ -273,7 +273,7 @@ static int mBGM_check_ignore_collect_insects_volume(u8 bgm_num) {
     return FALSE;
 }
 
-static mBGMElem_default_set(mBGMElem* elem) {
+static void mBGMElem_default_set(mBGMElem* elem) {
     static mBGMElem default_data = { 127, 0, 0, 0x168, 0x168 };
 
     bcopy(&default_data, elem, sizeof(mBGMElem));

--- a/src/game/m_player_main_hold.c_inc
+++ b/src/game/m_player_main_hold.c_inc
@@ -26,7 +26,7 @@ static int Player_actor_Check_able_request_main_hold(GAME* game) {
     }
 }
 
-static Player_actor_request_main_hold(GAME* game, int ftr_no, int index, const xyz_t* pos, f32 speed, int flags,
+static int Player_actor_request_main_hold(GAME* game, int ftr_no, int index, const xyz_t* pos, f32 speed, int flags,
                                       int priority) {
     if (Player_actor_check_request_main_able(game, mPlayer_INDEX_HOLD, priority) &&
         Player_actor_Check_able_request_main_hold(game)) {


### PR DESCRIPTION
A couple functions are missing explicit return types which throws an error when compiling with clang and C16+. This PR makes those return types explicit.