### PR TITLE
Add parameters to function signatures to satisfy C23 strictness

### DIFF
--- a/src/actor/ac_arrange_room.c
+++ b/src/actor/ac_arrange_room.c
@@ -172,7 +172,7 @@ static void Arrange_Room_Actor_draw(ACTOR* actor, GAME* game) {
     aAR_DrawWall(&arrange_room->actor_class, &play->game);
 }
 
-static void Arrange_Room_Actor_move() {
+static void Arrange_Room_Actor_move(ACTOR* actor, GAME* game) {
 
 }
 

--- a/src/actor/ac_needlework_shop_move.c_inc
+++ b/src/actor/ac_needlework_shop_move.c_inc
@@ -189,12 +189,12 @@ static void aNW_setup_animation(STRUCTURE_ACTOR* shop, f32 speed) {
                             end_idx[idx], start_idx[idx], speed, 0.0f, cKF_FRAMECONTROL_STOP, NULL);
 }
 
-static void aNW_open_door_demo_ct() {
+static void aNW_open_door_demo_ct(ACTOR* actorx) {
     mDemo_Set_house_info(40.0f, 5);
     mDemo_Set_camera(CAMERA2_PROCESS_DOOR);
 }
 
-static void aNW_talk_door_demo_ct() {
+static void aNW_talk_door_demo_ct(ACTOR* actorx) {
     static rgba_t window_color = { 145, 60, 40, 255 };
 
     mDemo_Set_msg_num(MSG_2010);

--- a/src/actor/ac_post_office_move.c_inc
+++ b/src/actor/ac_post_office_move.c_inc
@@ -189,7 +189,7 @@ static void aPOFF_setup_animation(STRUCTURE_ACTOR* office, f32 speed) {
                             end_idx[idx], start_idx[idx], speed, 0.0f, cKF_FRAMECONTROL_STOP, NULL);
 }
 
-static void aPOFF_open_door_demo_ct() {
+static void aPOFF_open_door_demo_ct(ACTOR* actorx) {
     mDemo_Set_house_info(40.0f, 5);
     mDemo_Set_camera(CAMERA2_PROCESS_DOOR);
 }

--- a/src/actor/npc/ac_halloween_npc.c
+++ b/src/actor/npc/ac_halloween_npc.c
@@ -54,7 +54,7 @@ static void aHWN_set_force_talk_info(ACTOR* actorx);
 static void aHWN_force_talk_request(ACTOR* actorx, GAME* game);
 static void aHWN_set_norm_talk_info(HALLOWEEN_NPC_ACTOR* actorx);
 static void aHWN_norm_talk_request(ACTOR* actorx, GAME* game);
-static int aHWN_talk_init();
+static int aHWN_talk_init(ACTOR* actorx, GAME* game);
 static BOOL aHWN_talk_end_chk(ACTOR* actorx, GAME* game);
 
 static void aHWN_approach(HALLOWEEN_NPC_ACTOR* hwn_actor, GAME_PLAY* play);

--- a/src/actor/npc/ac_halloween_npc_talk.c_inc
+++ b/src/actor/npc/ac_halloween_npc_talk.c_inc
@@ -281,7 +281,7 @@ static void aHWN_norm_talk_request(ACTOR* actorx, GAME* game) {
     mDemo_Request(mDemo_TYPE_TALK, actorx, (mDemo_REQUEST_PROC)aHWN_set_norm_talk_info);
 }
 
-static int aHWN_talk_init() {
+static int aHWN_talk_init(ACTOR* actorx, GAME* game) {
     mDemo_Set_ListenAble();
     return TRUE;
 }

--- a/src/actor/npc/ac_harvest_npc1.c
+++ b/src/actor/npc/ac_harvest_npc1.c
@@ -93,9 +93,10 @@ static void aHT1_actor_move(ACTOR* actorx, GAME* game) {
     NPC_CLIP->move_proc(actorx, game);
 }
 
-static s16 aHT1_GetDefaultAngle(NPC_HARVEST_NPC1_ACTOR* actor) {
+static s16 aHT1_GetDefaultAngle() {
     return 0;
 }
+#define aHT1_GetDefaultAngle(...) aHT1_GetDefaultAngle()
 
 static void aHT1_actor_draw(ACTOR* actorx, GAME* game) {
     NPC_CLIP->draw_proc(actorx, game);

--- a/src/actor/npc/ac_harvest_npc1.c
+++ b/src/actor/npc/ac_harvest_npc1.c
@@ -93,7 +93,7 @@ static void aHT1_actor_move(ACTOR* actorx, GAME* game) {
     NPC_CLIP->move_proc(actorx, game);
 }
 
-static s16 aHT1_GetDefaultAngle() {
+static s16 aHT1_GetDefaultAngle(NPC_HARVEST_NPC1_ACTOR* actor) {
     return 0;
 }
 

--- a/src/actor/npc/ac_harvest_npc1.c
+++ b/src/actor/npc/ac_harvest_npc1.c
@@ -96,7 +96,6 @@ static void aHT1_actor_move(ACTOR* actorx, GAME* game) {
 static s16 aHT1_GetDefaultAngle() {
     return 0;
 }
-#define aHT1_GetDefaultAngle(...) aHT1_GetDefaultAngle()
 
 static void aHT1_actor_draw(ACTOR* actorx, GAME* game) {
     NPC_CLIP->draw_proc(actorx, game);

--- a/src/actor/npc/ac_harvest_npc1.c_inc
+++ b/src/actor/npc/ac_harvest_npc1.c_inc
@@ -17,7 +17,7 @@ static void aHT1_wait(NPC_HARVEST_NPC1_ACTOR* actor, GAME_PLAY* play) {
 }
 
 static void aHT1_to_default(NPC_HARVEST_NPC1_ACTOR* actor, GAME_PLAY* play) {
-    if (actor->actor.actor_class.shape_info.rotation.y == aHT1_GetDefaultAngle(actor)) {
+    if (actor->actor.actor_class.shape_info.rotation.y == aHT1_GetDefaultAngle()) {
         actor->_998 = 0;
         actor->actor.action.step = -1;
     }
@@ -64,7 +64,7 @@ static void aHT1_think_main_proc(NPC_HARVEST_NPC1_ACTOR* actor, GAME_PLAY* play)
                 actor->actor.collision.check_kind = aNPC_BG_CHECK_TYPE_ONLY_GROUND;
             } break;
             case aNPC_ACT_TALK: {
-                actor->actor.movement.mv_angl = aHT1_GetDefaultAngle(actor);
+                actor->actor.movement.mv_angl = aHT1_GetDefaultAngle();
                 aHT1_set_request_act(&actor->actor);
                 actor->actor.condition_info.demo_flg =
                     aNPC_COND_DEMO_SKIP_MOVE_RANGE_CHECK | aNPC_COND_DEMO_SKIP_MOVE_CIRCLE_REV;

--- a/src/actor/npc/ac_npc_hem.c_inc
+++ b/src/actor/npc/ac_npc_hem.c_inc
@@ -132,7 +132,7 @@ static void aNHM_change_talk_proc(NPC_HEM_ACTOR* hem, int talk_idx) {
     hem->talk_proc = process[talk_idx];
 }
 
-static void aNHM_set_force_talk_info_talk_request() {
+static void aNHM_set_force_talk_info_talk_request(ACTOR* actor) {
     mDemo_Set_msg_num(MSG_HEM_GOLD_AXE1);
     mPr_SetFreePossessionItem(Now_Private, ITM_GOLDEN_AXE, mPr_ITEM_COND_NORMAL);
     mSC_trophy_set(mSC_TROPHY_GOLDEN_AXE);

--- a/src/actor/npc/ac_npc_mask_cat.c
+++ b/src/actor/npc/ac_npc_mask_cat.c
@@ -23,7 +23,7 @@ static void aNMC_actor_init(ACTOR* actorx, GAME* game);
 static void aNMC_actor_draw(ACTOR* actorx, GAME* game);
 
 static void aNMC_set_painter_name_str();
-static void aNMC_set_talk_info();
+static void aNMC_set_talk_info(ACTOR* actorx);
 static void aNMC_actor_move(ACTOR* actorx, GAME* game);
 static void aNMC_talk_request(ACTOR* actorx, GAME* game);
 static int aNMC_talk_init(ACTOR* actorx, GAME* game);

--- a/src/actor/npc/ac_npc_mask_cat2.c
+++ b/src/actor/npc/ac_npc_mask_cat2.c
@@ -86,8 +86,8 @@ static void aNM2_sitdown_start_wait_init(NPC_MASK_CAT2_ACTOR* actorx, GAME_PLAY*
 static void aNM2_sitdown_init(NPC_MASK_CAT2_ACTOR* actorx, GAME_PLAY* play);
 static void aNM2_draw_menu_open_wait_init(NPC_MASK_CAT2_ACTOR* actorx, GAME_PLAY* play);
 static void aNM2_draw_menu_close_wait_init(NPC_MASK_CAT2_ACTOR* actorx, GAME_PLAY* play);
-static void aNM2_msg_win_open_wait_init();
-static void aNM2_talk_end_wait_init();
+static void aNM2_msg_win_open_wait_init(NPC_MASK_CAT2_ACTOR* actor, GAME_PLAY* play);
+static void aNM2_talk_end_wait_init(NPC_MASK_CAT2_ACTOR* actor, GAME_PLAY* play);
 static void aNM2_scene_change_wait_init(NPC_MASK_CAT2_ACTOR* actorx, GAME_PLAY* play);
 static void aNM2_init_proc(ACTOR* actorx, GAME* game, int init_proc_idx);
 static void aNM2_setupAction(ACTOR* actorx, GAME* game, int process_idx);

--- a/src/actor/npc/ac_npc_mask_cat2_move.c_inc
+++ b/src/actor/npc/ac_npc_mask_cat2_move.c_inc
@@ -728,12 +728,12 @@ static void aNM2_draw_menu_close_wait_init(NPC_MASK_CAT2_ACTOR* actorx, GAME_PLA
     mSM_open_submenu(&play->submenu, mSM_OVL_DESIGN, 0, 0);
 }
 
-static void aNM2_msg_win_open_wait_init() {
+static void aNM2_msg_win_open_wait_init(NPC_MASK_CAT2_ACTOR* actor, GAME_PLAY* play) {
     mPr_CopyPersonalID(&Save_Get(mask_cat.design.creator_pid), &Now_Private->player_ID);
     mMsg_REQUEST_MAIN_APPEAR_WAIT_TYPE1();
 }
 
-static void aNM2_talk_end_wait_init() {
+static void aNM2_talk_end_wait_init(NPC_MASK_CAT2_ACTOR* actor, GAME_PLAY* play) {
     Common_Set(sunlight_flag, TRUE);
     sAdo_TrgSeEcho(FALSE);
     sAdo_LevSeEcho(FALSE);

--- a/src/actor/npc/ac_npc_rtc_talk.c.inc
+++ b/src/actor/npc/ac_npc_rtc_talk.c.inc
@@ -206,7 +206,7 @@ static void aNRTC_change_talk_proc(NPC_RTC_ACTOR* rtc, int idx) {
     rtc->talk_proc = process[idx];
 }
 
-static void aNRTC_set_talk_info_talk_request() {
+static void aNRTC_set_talk_info_talk_request(ACTOR* actor) {
     int msg;
 
     switch (Common_Get(save_error_type)) {

--- a/src/actor/npc/ac_npc_shop_common.c
+++ b/src/actor/npc/ac_npc_shop_common.c
@@ -1675,7 +1675,7 @@ static void aNSC_set_talk_info_start_wait(ACTOR* actorx) {
     shop_common->next_action = 1;
 }
 
-static void aNSC_set_talk_info_start_wait1() {
+static void aNSC_set_talk_info_start_wait1(ACTOR* actor) {
     int msg_no = 0;
 
     u8 player_no = Common_Get(player_no);
@@ -1987,7 +1987,7 @@ static void aNSC_present_balloon_end_wait(NPC_SHOP_COMMON_ACTOR* shop_common, GA
 
 #endif
 
-static void aNSC_set_talk_info_request_Q_start_wait() {
+static void aNSC_set_talk_info_request_Q_start_wait(ACTOR* actor) {
     mDemo_Set_msg_num(aNSC_get_msg_no(aNSC_MSG_INTERACT_START));
     mDemo_Set_talk_turn(0x0);
 }
@@ -2822,7 +2822,7 @@ static void aNSC_turn(NPC_SHOP_COMMON_ACTOR* shop_common, GAME_PLAY* play) {
     }
 }
 
-static void aNSC_set_talk_info_goodbye_wait() {
+static void aNSC_set_talk_info_goodbye_wait(ACTOR* actor) {
     mDemo_Set_msg_num(aNSC_get_msg_no(aNSC_MSG_SAY_GOODBYE));
     mDemo_Set_camera(CAMERA2_PROCESS_NORMAL);
 }

--- a/src/actor/npc/ac_npc_totakeke.c
+++ b/src/actor/npc/ac_npc_totakeke.c
@@ -61,7 +61,7 @@ static void aNTT_actor_ct(ACTOR *actorx, GAME *game) {
         xyz_t wpos;
         NPC_TOTAKEKE_ACTOR *totakeke = (NPC_TOTAKEKE_ACTOR *)actorx;
 
-        totakeke->npc_class.schedule.schedule_proc = aNTT_schedule_proc;
+        totakeke->npc_class.schedule.schedule_proc = (aNPC_SCHEDULE_PROC)aNTT_schedule_proc;
         CLIP(npc_clip)->ct_proc(actorx, game, &ct_data);
         totakeke->npc_class.palActorIgnoreTimer = -1;
         totakeke->npc_class.condition_info.hide_flg = FALSE;

--- a/src/actor/npc/ac_npc_totakeke.c
+++ b/src/actor/npc/ac_npc_totakeke.c
@@ -10,7 +10,7 @@
 #include "m_string_data.h"
 #include "m_ledit_ovl.h"
 
-void aNTT_schedule_proc();
+void aNTT_schedule_proc(NPC_TOTAKEKE_ACTOR* totakeke, GAME_PLAY* play, int schedule_id);
 int aNTT_change_talk_proc(NPC_TOTAKEKE_ACTOR*, int);
 void aNTT_setup_think_proc(NPC_TOTAKEKE_ACTOR*, GAME_PLAY*, u8);
 int aNTT_enso_init(NPC_TOTAKEKE_ACTOR*);

--- a/src/actor/npc/event/ac_ev_majin_move.c_inc
+++ b/src/actor/npc/event/ac_ev_majin_move.c_inc
@@ -111,7 +111,7 @@ static void aEMJ_schedule_proc(NPC_ACTOR* actor, GAME_PLAY* play, int idx) {
     (*sche_proc[idx])(actor, play);
 }
 
-static void aEMJ_set_force_talk_info() {
+static void aEMJ_set_force_talk_info(ACTOR* actor) {
     int msg_num;
 
     switch (Common_Get(weather)) {

--- a/src/actor/npc/event/ac_ev_speech_soncho_talk.c_inc
+++ b/src/actor/npc/event/ac_ev_speech_soncho_talk.c_inc
@@ -142,7 +142,7 @@ void aESS_norm_talk_request(NPC_SPEECH_SONCHO* soncho, GAME_PLAY* play) {
     mDemo_Request(mDemo_TYPE_TALK, (ACTOR*)soncho, aESS_set_norm_talk_info);
 }
 
-void aESS_set_force_talk_info() {
+void aESS_set_force_talk_info(ACTOR* actor) {
     mDemo_Set_msg_num(mString_SPEECH_SONCHO_START);
     mDemo_Set_camera(CAMERA2_PROCESS_NUM);
 }

--- a/src/game/m_demo.c
+++ b/src/game/m_demo.c
@@ -875,7 +875,7 @@ static int check_speech_request() {
     return res;
 }
 
-static void emsg_set() {
+static void emsg_set(ACTOR* actor) {
     static rgba_t win_color = { 175, 255, 255, 255 };
 
     mDemo_Set_talk_window_color(&win_color);

--- a/src/game/m_design_ovl.c
+++ b/src/game/m_design_ovl.c
@@ -979,7 +979,7 @@ void mDE_paint(mDE_Ovl_c* design_ovl, int pal) {
     }
 }
 
-void mDE_print_texture() {
+void mDE_print_texture(mDE_Ovl_c* design_ovl) {
     return;
 }
 

--- a/src/game/m_field_assessment.c
+++ b/src/game/m_field_assessment.c
@@ -157,7 +157,7 @@ static int mFAs_CheckGrassOver(int tree_num, int grass_num) {
     return grass_num >= mFAs_GRASS_OVER_NUM;
 }
 
-static int mFAs_CheckNoCase() {
+static int mFAs_CheckNoCase(int tree_num, int grass_num) {
     return FALSE;
 }
 


### PR DESCRIPTION
There are functions with undeclared parameters in the signature that are passed in at the function call sites. This PR changes the function signatures to declare these parameters. 

~~There is one function `aHT1_GetDefaultAngle()` that is called both with and without a parameter. A macro is used to satisfy both codewarrior and clang compilers.~~