### PR TITLE
Add missing return to aAR_SecureDmaRam function.

### DIFF
--- a/src/actor/ac_arrange_room.c
+++ b/src/actor/ac_arrange_room.c
@@ -31,7 +31,7 @@ ACTOR_PROFILE Arrange_Room_Profile = {
 };
 
 static void* aAR_SecureDmaRam(GAME* game, size_t size) { 
-    zelda_malloc_align(size, 0x20); 
+    return zelda_malloc_align(size, 0x20); 
 }
 
 static void aAR_SetClip(ACTOR* actor, int flag) {


### PR DESCRIPTION
`aAR_SecureDmaRam()` signature declares a pointer return type but it doesn't have a return statement.