### PR TITLE
Dynamic dialog

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -5224,6 +5224,58 @@ config.progress_report_args = [
     # "--config functionRelocDiffs=data_value",
 ]
 
+###
+# Optional: dynamic villager/character dialog.
+#
+# If dialog/dialog.json exists and an original forest_2nd.arc can be found, wire
+# a post-build step that repacks the rewritten dialog into
+# build/<version>/forest_2nd.arc every time you run ninja. When either the JSON
+# or the source archive is missing, this is skipped entirely so the normal
+# matching build is never affected.
+###
+dialog_json = Path("dialog") / "dialog.json"
+dialog_tool = config.tools_dir / "dialog_tool.py"
+dialog_source_candidates = [
+    Path("dump") / "forest_2nd.arc",
+    Path("orig") / config.version / "forest_2nd.arc",
+    Path("orig") / config.version / "files" / "forest_2nd.arc",
+]
+dialog_source_arc = next((p for p in dialog_source_candidates if p.exists()), None)
+
+if dialog_json.exists() and dialog_source_arc is not None:
+    dialog_out_arc = Path(config.build_dir) / config.version / "forest_2nd.arc"
+    config.custom_build_rules = [
+        {
+            "name": "dialog_pack",
+            "command": (
+                f"$python {dialog_tool} --quiet build "
+                "--json $in --in-arc $dialog_src --out-arc $out"
+            ),
+            "description": "DIALOG $out",
+        }
+    ]
+    config.custom_build_steps = {
+        "post-build": [
+            {
+                "rule": "dialog_pack",
+                "outputs": dialog_out_arc,
+                "inputs": dialog_json,
+                "implicit": [
+                    dialog_tool,
+                    config.tools_dir / "msg_tool.py",
+                    dialog_source_arc,
+                ],
+                "variables": {"dialog_src": dialog_source_arc.as_posix()},
+            }
+        ]
+    }
+    print(f" INFO Dialog packing enabled -> {dialog_out_arc}")
+elif dialog_json.exists():
+    print(
+        " INFO dialog/dialog.json found but no source forest_2nd.arc "
+        "(looked in dump/ and orig/); dialog packing skipped."
+    )
+
 if args.mode == "configure":
     # Write build.ninja and objdiff.json
     generate_build(config)

--- a/dialog/README.md
+++ b/dialog/README.md
@@ -1,0 +1,110 @@
+# Dynamic villager / character dialog
+
+This folder drives a dialog rewrite pipeline. You edit a single JSON file, then
+run **one command** to bake your rewritten text straight into a playable `.iso`.
+
+## Quick start (single command → patched .iso)
+
+```sh
+# 1. Pull the editable dialog out of your game disc (run once):
+python tools/dialog_tool.py extract-iso \
+  --iso "orig/GAFE01_00/Animal Crossing (USA).iso" \
+  --out dialog/dialog.json
+
+# 2. Edit the "new" fields in dialog/dialog.json (see below).
+
+# 3. Bake the changes into a new .iso in one shot:
+python tools/dialog_tool.py apply-iso \
+  --iso "orig/GAFE01_00/Animal Crossing (USA).iso" \
+  --json dialog/dialog.json \
+  --out "build/GAFE01_00/Animal Crossing (USA) (dialog).iso"
+```
+
+Load the produced `.iso` in Dolphin. Step 3 is the "single command" you re-run
+whenever you change dialog — it reads the original disc, rebuilds
+`forest_2nd.arc` with your text, and writes a patched disc. Only that one file
+(and its FST entry) ever changes; every other file on the disc is left
+byte-for-byte identical.
+
+## How it works
+
+All in-game dialog lives inside `forest_2nd.arc` as two binary blobs:
+
+- `message_data.bin` — raw concatenated message text
+- `message_data_table.bin` — cumulative end offsets that split the text into
+  individual messages
+
+The tool [`tools/dialog_tool.py`](../tools/dialog_tool.py) reads and rewrites
+those blobs for you; you never touch the binaries directly. The disc itself is
+read/patched by [`tools/gcm.py`](../tools/gcm.py) (a minimal GameCube disc
+patcher) — no external tools like `wit` are required.
+
+## Why messages are indexed, not per-villager
+
+Villager dialog is **personality-based**, not per-character. The game stores one
+shared pool of lines per personality and injects the specific villager's name at
+runtime via control codes (e.g. `<<STR_TALKNAME>>`). So the natural unit of
+editing is a single **message index**. Each JSON entry carries a best-effort
+`label` (derived from known message-table ranges) to help you orient yourself,
+but there is no reliable one-to-one "this line belongs to villager X" mapping.
+
+## Editing `dialog/dialog.json`
+
+Each entry looks like:
+
+```json
+{
+  "index": 1234,
+  "label": "MSG_...",
+  "original": "Original text with <<CONTROL>> codes<<MSGEND>>",
+  "new": "Original text with <<CONTROL>> codes<<MSGEND>>"
+}
+```
+
+- Only change the **`new`** field. Leave `index`, `label`, and `original`
+  alone (they are how the tool maps text back and shows you what it was).
+- Keep every `<<...>>` **control code** intact — they drive text speed,
+  colors, name/item substitution, line breaks, choices, message jumps, and
+  termination. Removing `<<MSGEND>>`, `<<BTN>>`, `<<MSGCLEAR>>` or a
+  pause/prompt code can corrupt the text box or break the conversation flow.
+- Any entry with `"decode_error": true` could not be fully decoded; **do not
+  edit it** — it is packed back byte-for-byte unchanged.
+- Entries whose `new` still equals `original` are packed byte-for-byte
+  unchanged, so an unedited JSON reproduces a **byte-identical** disc.
+
+Keeping each visible line roughly the same length as the original avoids
+overflowing the in-game text window.
+
+## Alternative: pack a loose `forest_2nd.arc` / wire into `ninja`
+
+If you'd rather work with an extracted archive instead of the `.iso`:
+
+```sh
+# extract from a loose arc
+python tools/dialog_tool.py extract --arc dump/forest_2nd.arc --out dialog/dialog.json
+
+# repack a loose arc
+python tools/dialog_tool.py build --json dialog/dialog.json \
+  --in-arc dump/forest_2nd.arc --out-arc build/GAFE01_00/forest_2nd.arc
+```
+
+`configure.py` also auto-wires an **optional** post-build step: if
+`dialog/dialog.json` exists *and* a source arc is found (in `dump/`,
+`orig/GAFE01_00/`, or `orig/GAFE01_00/files/`), a plain `ninja` regenerates
+`build/GAFE01_00/forest_2nd.arc` with your changes. If neither exists, the
+dialog step is silently skipped and the normal matching build is unaffected.
+
+Add `--compression {auto,none,szs,szp}` to any pack command to override archive
+compression (`auto`, the default, preserves whatever the source used).
+
+## Safety notes
+
+- `apply-iso` copies your disc image and patches the copy; it never modifies the
+  original `.iso` unless you explicitly point `--out` at it.
+- Only `forest_2nd.arc`'s data and its single FST entry change — every other
+  file on the disc stays byte-for-byte identical (verified for `famicom.arc`,
+  `forest_1st.arc`, etc.).
+- Nothing here touches the DOL/REL matching build or any source under `src/`.
+- Text re-encoding is only applied to entries you actually change; everything
+  else is copied verbatim, so you can't accidentally corrupt untouched lines.
+

--- a/dialog/README.md
+++ b/dialog/README.md
@@ -1,38 +1,71 @@
 # Dynamic villager / character dialog
 
-This folder drives a dialog rewrite pipeline. You edit a single JSON file, then
+This folder drives a text rewrite pipeline. You edit a single JSON file, then
 run **one command** to bake your rewritten text straight into a playable `.iso`.
+
+Two kinds of text are supported:
+
+- **`message`** — the main villager/character dialog (in `forest_2nd.arc`).
+  Lives in [dialog.json](dialog.json).
+- **`mail`** — the letters villagers send you (in `forest_1st.arc`). Lives in
+  [mail.json](mail.json).
+
+Both use the same commands and the same format; you pick which with
+`--resource message` (default) or `--resource mail`.
 
 ## Quick start (single command → patched .iso)
 
 ```sh
-# 1. Pull the editable dialog out of your game disc (run once):
+# Dialog:
 python tools/dialog_tool.py extract-iso \
   --iso "orig/GAFE01_00/Animal Crossing (USA).iso" \
-  --out dialog/dialog.json
+  --out dialog/dialog.json --resource message
 
-# 2. Edit the "new" fields in dialog/dialog.json (see below).
-
-# 3. Bake the changes into a new .iso in one shot:
 python tools/dialog_tool.py apply-iso \
   --iso "orig/GAFE01_00/Animal Crossing (USA).iso" \
   --json dialog/dialog.json \
   --out "build/GAFE01_00/Animal Crossing (USA) (dialog).iso"
+
+# Mail (letters):
+python tools/dialog_tool.py extract-iso \
+  --iso "orig/GAFE01_00/Animal Crossing (USA).iso" \
+  --out dialog/mail.json --resource mail
+
+python tools/dialog_tool.py apply-iso \
+  --iso "orig/GAFE01_00/Animal Crossing (USA).iso" \
+  --json dialog/mail.json \
+  --out "build/GAFE01_00/Animal Crossing (USA) (mail).iso"
 ```
 
-Load the produced `.iso` in Dolphin. Step 3 is the "single command" you re-run
-whenever you change dialog — it reads the original disc, rebuilds
-`forest_2nd.arc` with your text, and writes a patched disc. Only that one file
-(and its FST entry) ever changes; every other file on the disc is left
-byte-for-byte identical.
+Each `apply-iso` is the "single command" you re-run whenever you change that
+text. It reads the original disc, rebuilds the relevant archive, and writes a
+patched disc. Only that one archive (and its FST entry) ever changes; every
+other file on the disc is left byte-for-byte identical. The `--resource` is read
+automatically from the JSON, so you don't need to repeat it on `apply-iso`.
+
+### Applying dialog *and* mail into one .iso
+
+Pass multiple JSONs to a single `apply-iso` and all their changes are baked into
+**one** output disc:
+
+```sh
+python tools/dialog_tool.py apply-iso \
+  --iso "orig/GAFE01_00/Animal Crossing (USA).iso" \
+  --json dialog/dialog.json dialog/mail.json \
+  --out "build/GAFE01_00/Animal Crossing (USA) (modded).iso"
+```
+
+Each JSON declares its own resource, so the tool rebuilds `forest_2nd.arc`
+(dialog) and `forest_1st.arc` (mail) and writes them both into the single
+`(modded).iso`. Every other file on the disc stays byte-for-byte identical.
 
 ## How it works
 
-All in-game dialog lives inside `forest_2nd.arc` as two binary blobs:
-
-- `message_data.bin` — raw concatenated message text
-- `message_data_table.bin` — cumulative end offsets that split the text into
-  individual messages
+Each resource is one or more `*_data.bin` / `*_data_table.bin` blob pairs inside
+an archive: the data blob is concatenated text, and the table holds cumulative
+end offsets that split it into individual entries. `mail` has four blobs
+(`mail`, `maila`, `mailb`, `mailc`); each entry in `mail.json` is tagged with
+its `group`.
 
 The tool [`tools/dialog_tool.py`](../tools/dialog_tool.py) reads and rewrites
 those blobs for you; you never touch the binaries directly. The disc itself is
@@ -48,21 +81,23 @@ editing is a single **message index**. Each JSON entry carries a best-effort
 `label` (derived from known message-table ranges) to help you orient yourself,
 but there is no reliable one-to-one "this line belongs to villager X" mapping.
 
-## Editing `dialog/dialog.json`
+## Editing the JSON
 
-Each entry looks like:
+Each entry looks like this (mail entries also carry a `group`):
 
 ```json
 {
+  "group": "maila",
   "index": 1234,
-  "label": "MSG_...",
-  "original": "Original text with <<CONTROL>> codes<<MSGEND>>",
-  "new": "Original text with <<CONTROL>> codes<<MSGEND>>"
+  "label": "",
+  "original": "Original text with <<CONTROL>> codes",
+  "new": "Original text with <<CONTROL>> codes"
 }
 ```
 
-- Only change the **`new`** field. Leave `index`, `label`, and `original`
-  alone (they are how the tool maps text back and shows you what it was).
+- Only change the **`new`** field. Leave `group`, `index`, `label`, and
+  `original` alone (they are how the tool maps text back and shows you what it
+  was).
 - Keep every `<<...>>` **control code** intact — they drive text speed,
   colors, name/item substitution, line breaks, choices, message jumps, and
   termination. Removing `<<MSGEND>>`, `<<BTN>>`, `<<MSGCLEAR>>` or a

--- a/dialog/README.md
+++ b/dialog/README.md
@@ -69,8 +69,10 @@ Each entry looks like:
   pause/prompt code can corrupt the text box or break the conversation flow.
 - Any entry with `"decode_error": true` could not be fully decoded; **do not
   edit it** — it is packed back byte-for-byte unchanged.
-- Entries whose `new` still equals `original` are packed byte-for-byte
-  unchanged, so an unedited JSON reproduces a **byte-identical** disc.
+- Only the lines you actually change are re-encoded; every entry whose `new`
+  still equals `original` keeps its exact original message bytes. (The
+  `forest_2nd.arc` container itself is repacked, so its internal layout differs
+  from the retail file, but the message content is preserved verbatim.)
 
 Keeping each visible line roughly the same length as the original avoids
 overflowing the in-game text window.

--- a/dialog/README.md
+++ b/dialog/README.md
@@ -112,6 +112,59 @@ Each entry looks like this (mail entries also carry a `group`):
 Keeping each visible line roughly the same length as the original avoids
 overflowing the in-game text window.
 
+## Understanding conversation flow
+
+Entries are **not** connected by being next to each other in the JSON — they're
+wired together by the control codes at the **end** of each entry:
+
+| Ending | Meaning |
+|---|---|
+| `<<MSGEND>>` | The conversation ends here. |
+| `<<SETNEXTMSGx [hi lo]>>` + `<<MSGCONTINUE>>` | Jump to the explicit index in the two bytes (`[09 C9]` = index 2505). |
+| `<<OPENCHOICE>>` + `<<SETNEXTMSG0>>` / `<<SETNEXTMSG1>>` | A menu; option 0 / option 1 go to different indices. |
+| `<<MSGCONTINUE>>` **alone** | There's more, but the **next index is chosen by the villager's code at runtime** — it isn't stored in the text. |
+
+Codes *inside* an entry (`<<BTN>>` = wait for button, `<<MSGCLEAR>>` = new page)
+are page breaks **within** one entry, not links between entries.
+
+### The `flow` field
+
+`extract` / `extract-iso` add a read-only **`flow`** summary to each entry so a
+model can see how conversations connect:
+
+```json
+"flow": { "continues": true, "choice": true, "next": [2505, 2523] }
+```
+
+- `next` — explicit target indices this entry can jump to (follow these to
+  rewrite a whole branch consistently).
+- `choice` — this entry shows a menu; the `next` list is the per-option targets.
+- `ends` — ends with `<<MSGEND>>`.
+- `continues` **without** `next` — a runtime-driven continuation: the successor
+  is picked by game code, so treat the entry as a self-contained beat that must
+  read well on its own and match the tone of its neighbours (contiguous entries
+  sharing the same `<<DEMONPCx [..]>>` tag are the same NPC/mood pool).
+
+`flow` is derived from `original`; don't hand-edit it. Run `annotate` to refresh
+it after pulling new data:
+
+```sh
+python tools/dialog_tool.py annotate --json dialog/dialog.json
+```
+
+### Tracing a conversation
+
+`trace` prints the whole tree reachable from a starting index (following
+`next`), with choice branches, `END` markers, cycle detection, and
+`CONTINUE→runtime` flags:
+
+```sh
+python tools/dialog_tool.py trace --json dialog/dialog.json --index 2503
+```
+
+Use it to gather the full context of a conversation before rewriting it, so the
+question and all of its answers stay coherent.
+
 ## Alternative: pack a loose `forest_2nd.arc` / wire into `ninja`
 
 If you'd rather work with an extracted archive instead of the `.iso`:

--- a/dialog/mail.json
+++ b/dialog/mail.json
@@ -1,0 +1,14971 @@
+{
+  "version": 1,
+  "resource": "mail",
+  "source_arc": "forest_1st.arc",
+  "groups": [
+    {
+      "name": "mail",
+      "data_file": "mail_data.bin",
+      "table_file": "mail_data_table.bin",
+      "entry_count": 1500
+    },
+    {
+      "name": "maila",
+      "data_file": "maila_data.bin",
+      "table_file": "maila_data_table.bin",
+      "entry_count": 750
+    },
+    {
+      "name": "mailb",
+      "data_file": "mailb_data.bin",
+      "table_file": "mailb_data_table.bin",
+      "entry_count": 750
+    },
+    {
+      "name": "mailc",
+      "data_file": "mailc_data.bin",
+      "table_file": "mailc_data_table.bin",
+      "entry_count": 750
+    }
+  ],
+  "entries": [
+    {
+      "group": "mail",
+      "index": 0,
+      "label": "",
+      "original": "This is mail 0\n\n\n\n\n\n",
+      "new": "This is mail 0\n\n\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 1,
+      "label": "",
+      "original": "This is mail 1.\n\"<<STR_FREE10>>\" \"<<STR_FREE11>>\"\n\"<<STR_FREE12>>\" \"<<STR_FREE13>>\"\n<<STR_FREE15>> <<STR_FREE16>>, <<STR_FREE14>>\n<<STR_FREE17>> <<STR_FREE18>>, <<STR_FREE19>>\n\n",
+      "new": "This is mail 1.\n\"<<STR_FREE10>>\" \"<<STR_FREE11>>\"\n\"<<STR_FREE12>>\" \"<<STR_FREE13>>\"\n<<STR_FREE15>> <<STR_FREE16>>, <<STR_FREE14>>\n<<STR_FREE17>> <<STR_FREE18>>, <<STR_FREE19>>\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 2,
+      "label": "",
+      "original": "Are you lacking that special\nsomething to bring your\nroom together? At <<STR_FREE19>>\non <<STR_FREE17>> <<STR_FREE18>>, we'll\nhave a very special\n<<CUTARTICLE>><<STR_FREE7>> on sale!\n",
+      "new": "Are you lacking that special\nsomething to bring your\nroom together? At <<STR_FREE19>>\non <<STR_FREE17>> <<STR_FREE18>>, we'll\nhave a very special\n<<CUTARTICLE>><<STR_FREE7>> on sale!\n"
+    },
+    {
+      "group": "mail",
+      "index": 3,
+      "label": "",
+      "original": "We're selling off rare\ncarpets at a discount, so\nhurry on in! We have only\n<<STR_FREE0>> in stock! This one-hour\nsale starts at <<STR_FREE19>>\non <<STR_FREE17>> <<STR_FREE18>>!\n",
+      "new": "We're selling off rare\ncarpets at a discount, so\nhurry on in! We have only\n<<STR_FREE0>> in stock! This one-hour\nsale starts at <<STR_FREE19>>\non <<STR_FREE17>> <<STR_FREE18>>!\n"
+    },
+    {
+      "group": "mail",
+      "index": 4,
+      "label": "",
+      "original": "We've just received a rush\nshipment of perfectly stunning\nwallpaper, but I only have \n<<STR_FREE0>> left! The sale lasts\none hour, starting at <<STR_FREE19>>\non <<STR_FREE17>> <<STR_FREE18>>!\n",
+      "new": "We've just received a rush\nshipment of perfectly stunning\nwallpaper, but I only have \n<<STR_FREE0>> left! The sale lasts\none hour, starting at <<STR_FREE19>>\non <<STR_FREE17>> <<STR_FREE18>>!\n"
+    },
+    {
+      "group": "mail",
+      "index": 5,
+      "label": "",
+      "original": "Wearing the same outfit day\nin and day out is boring!\nWhy not show off with\nsome unique new fashions?\nThe sale begins at <<STR_FREE19>>\non <<STR_FREE17>> <<STR_FREE18>>!\n",
+      "new": "Wearing the same outfit day\nin and day out is boring!\nWhy not show off with\nsome unique new fashions?\nThe sale begins at <<STR_FREE19>>\non <<STR_FREE17>> <<STR_FREE18>>!\n"
+    },
+    {
+      "group": "mail",
+      "index": 6,
+      "label": "",
+      "original": "Are you lacking that special\nsomething that will bring\nyour room to life? Then\ncome to our one-hour\nRarities Sale at <<STR_FREE19>>\non <<STR_FREE17>> <<STR_FREE18>>.\n",
+      "new": "Are you lacking that special\nsomething that will bring\nyour room to life? Then\ncome to our one-hour\nRarities Sale at <<STR_FREE19>>\non <<STR_FREE17>> <<STR_FREE18>>.\n"
+    },
+    {
+      "group": "mail",
+      "index": 7,
+      "label": "",
+      "original": "We're having a surprise sale\non a shipment of gloriously\nextravagant carpets! The one-\nhour sale begins at <<STR_FREE19>>\non <<STR_FREE17>> <<STR_FREE18>>. Don't\nget cold feet!\n",
+      "new": "We're having a surprise sale\non a shipment of gloriously\nextravagant carpets! The one-\nhour sale begins at <<STR_FREE19>>\non <<STR_FREE17>> <<STR_FREE18>>. Don't\nget cold feet!\n"
+    },
+    {
+      "group": "mail",
+      "index": 8,
+      "label": "",
+      "original": "We just got some beautiful, \nhand-drawn wallpaper in\nstock! These special rolls\nwill be sold in an exclusive\none-hour sale at <<STR_FREE19>>\non <<STR_FREE17>> <<STR_FREE18>>!\n",
+      "new": "We just got some beautiful, \nhand-drawn wallpaper in\nstock! These special rolls\nwill be sold in an exclusive\none-hour sale at <<STR_FREE19>>\non <<STR_FREE17>> <<STR_FREE18>>!\n"
+    },
+    {
+      "group": "mail",
+      "index": 9,
+      "label": "",
+      "original": "Do you dread the boredom of\nyour wardrobe? Show off\nyour originality with some\none-of-a-kind duds! Our sale\nbegins at <<STR_FREE19>>\non <<STR_FREE17>> <<STR_FREE18>>!\n",
+      "new": "Do you dread the boredom of\nyour wardrobe? Show off\nyour originality with some\none-of-a-kind duds! Our sale\nbegins at <<STR_FREE19>>\non <<STR_FREE17>> <<STR_FREE18>>!\n"
+    },
+    {
+      "group": "mail",
+      "index": 10,
+      "label": "",
+      "original": "Is your room lacking that\nunique something to make\nit really shine? We'll have\n<<STR_FREE0>> available in our one-\nhour sale, at <<STR_FREE19>>\non <<STR_FREE17>> <<STR_FREE18>>.\n",
+      "new": "Is your room lacking that\nunique something to make\nit really shine? We'll have\n<<STR_FREE0>> available in our one-\nhour sale, at <<STR_FREE19>>\non <<STR_FREE17>> <<STR_FREE18>>.\n"
+    },
+    {
+      "group": "mail",
+      "index": 11,
+      "label": "",
+      "original": "We're having a surprise sale\non a shipment of gloriously\nextravagant carpets! The\none-hour sale begins at\n<<STR_FREE19>> on <<STR_FREE17>>\n<<STR_FREE18>>. Don't miss out!\n",
+      "new": "We're having a surprise sale\non a shipment of gloriously\nextravagant carpets! The\none-hour sale begins at\n<<STR_FREE19>> on <<STR_FREE17>>\n<<STR_FREE18>>. Don't miss out!\n"
+    },
+    {
+      "group": "mail",
+      "index": 12,
+      "label": "",
+      "original": "We just got some beautiful, \nhand-drawn wallpaper in\nstock! These special rolls\nwill be sold in an exclusive\none-hour sale at <<STR_FREE19>>\non <<STR_FREE17>> <<STR_FREE18>>!\n",
+      "new": "We just got some beautiful, \nhand-drawn wallpaper in\nstock! These special rolls\nwill be sold in an exclusive\none-hour sale at <<STR_FREE19>>\non <<STR_FREE17>> <<STR_FREE18>>!\n"
+    },
+    {
+      "group": "mail",
+      "index": 13,
+      "label": "",
+      "original": "Do you dread the boredom of\nyour wardrobe? Isn't it time\nfor a change? Come buy some\nunique new fashions! The\nsale begins at <<STR_FREE19>>\non <<STR_FREE17>> <<STR_FREE18>>!\n",
+      "new": "Do you dread the boredom of\nyour wardrobe? Isn't it time\nfor a change? Come buy some\nunique new fashions! The\nsale begins at <<STR_FREE19>>\non <<STR_FREE17>> <<STR_FREE18>>!\n"
+    },
+    {
+      "group": "mail",
+      "index": 14,
+      "label": "",
+      "original": "Are you lacking that special\nrare piece that will bring\nyour room to life? Look no\nfurtherーwe'll have <<STR_FREE0>>\non sale for an hour at <<STR_FREE19>>\non <<STR_FREE17>> <<STR_FREE18>>.\n",
+      "new": "Are you lacking that special\nrare piece that will bring\nyour room to life? Look no\nfurtherーwe'll have <<STR_FREE0>>\non sale for an hour at <<STR_FREE19>>\non <<STR_FREE17>> <<STR_FREE18>>.\n"
+    },
+    {
+      "group": "mail",
+      "index": 15,
+      "label": "",
+      "original": "We're having a surprise sale\non a shipment of gloriously\nextravagant carpets! The one-\nhour sale begins at <<STR_FREE19>>\non <<STR_FREE17>> <<STR_FREE18>>. Don't\nget cold feet!\n",
+      "new": "We're having a surprise sale\non a shipment of gloriously\nextravagant carpets! The one-\nhour sale begins at <<STR_FREE19>>\non <<STR_FREE17>> <<STR_FREE18>>. Don't\nget cold feet!\n"
+    },
+    {
+      "group": "mail",
+      "index": 16,
+      "label": "",
+      "original": "We just got some beautiful, \nhand-drawn wallpaper in\nstock! These special rolls\nwill be sold in an exclusive\none-hour sale at <<STR_FREE19>>\non <<STR_FREE17>> <<STR_FREE18>>!\n",
+      "new": "We just got some beautiful, \nhand-drawn wallpaper in\nstock! These special rolls\nwill be sold in an exclusive\none-hour sale at <<STR_FREE19>>\non <<STR_FREE17>> <<STR_FREE18>>!\n"
+    },
+    {
+      "group": "mail",
+      "index": 17,
+      "label": "",
+      "original": "Do you dread the boredom of\nyour wardrobe? Show off\nyour originality with some\none-of-a-kind duds! Our sale\nbegins at <<STR_FREE19>>\non <<STR_FREE17>> <<STR_FREE18>>!\n",
+      "new": "Do you dread the boredom of\nyour wardrobe? Show off\nyour originality with some\none-of-a-kind duds! Our sale\nbegins at <<STR_FREE19>>\non <<STR_FREE17>> <<STR_FREE18>>!\n"
+    },
+    {
+      "group": "mail",
+      "index": 18,
+      "label": "",
+      "original": "DON'T MISS OUT!!!\nA special shipment of \nextremely rare items came\nin today. If you miss this\nopportunity, you'll never see\nitems this exquisite again!\n",
+      "new": "DON'T MISS OUT!!!\nA special shipment of \nextremely rare items came\nin today. If you miss this\nopportunity, you'll never see\nitems this exquisite again!\n"
+    },
+    {
+      "group": "mail",
+      "index": 19,
+      "label": "",
+      "original": "A Special Notice, For Our\nMost Special Customers:\nFor today only, we have a\nselection of items you\nwon't find anywhere else!\n\n",
+      "new": "A Special Notice, For Our\nMost Special Customers:\nFor today only, we have a\nselection of items you\nwon't find anywhere else!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 20,
+      "label": "",
+      "original": "Today's special in home\ndecor is none other than the\namazing <<STR_FREE7>>!\nWhat are you waiting for!?\n\n\n",
+      "new": "Today's special in home\ndecor is none other than the\namazing <<STR_FREE7>>!\nWhat are you waiting for!?\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 21,
+      "label": "",
+      "original": "Today, our home-decor\ndepartment boasts a very\nfine <<CUTARTICLE>><<STR_FREE7>>.\nCome right away, or you\nmight miss your chance!\n\n",
+      "new": "Today, our home-decor\ndepartment boasts a very\nfine <<CUTARTICLE>><<STR_FREE7>>.\nCome right away, or you\nmight miss your chance!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 22,
+      "label": "",
+      "original": "We have a special offer\ntoday on a stunning\n<<CUTARTICLE>><<STR_FREE7>>. As\nalways, we have a wide\nvariety of other items as\nwell. Why not stop by?\n",
+      "new": "We have a special offer\ntoday on a stunning\n<<CUTARTICLE>><<STR_FREE7>>. As\nalways, we have a wide\nvariety of other items as\nwell. Why not stop by?\n"
+    },
+    {
+      "group": "mail",
+      "index": 23,
+      "label": "",
+      "original": "One day only! Drop by today\nto see our <<CUTARTICLE>><<STR_FREE7>>!\nWe can't wait to see your\nsmiling face, so come on by!\n\n\n",
+      "new": "One day only! Drop by today\nto see our <<CUTARTICLE>><<STR_FREE7>>!\nWe can't wait to see your\nsmiling face, so come on by!\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 24,
+      "label": "",
+      "original": "Thanks to all of you, I've \nsaved up a fair bit of money,\nso on <<STR_FREE0>> <<STR_FREE1>>,\n<<STR_FREE2>>, I'm closing the\nshop for remodeling!\nThanks for your patience! \n",
+      "new": "Thanks to all of you, I've \nsaved up a fair bit of money,\nso on <<STR_FREE0>> <<STR_FREE1>>,\n<<STR_FREE2>>, I'm closing the\nshop for remodeling!\nThanks for your patience! \n"
+    },
+    {
+      "group": "mail",
+      "index": 25,
+      "label": "",
+      "original": "I've decided it's high time I\nremodeled my store, so we'll\nbe closed on <<STR_FREE0>>\n<<STR_FREE1>>, <<STR_FREE2>>. It is\nmy sincerest hope that this\nwon't be too inconvenient!\n",
+      "new": "I've decided it's high time I\nremodeled my store, so we'll\nbe closed on <<STR_FREE0>>\n<<STR_FREE1>>, <<STR_FREE2>>. It is\nmy sincerest hope that this\nwon't be too inconvenient!\n"
+    },
+    {
+      "group": "mail",
+      "index": 26,
+      "label": "",
+      "original": "Thanks to everyone's\npatronage, I have the means\nto expand my store again!\nWe will be closed <<STR_FREE0>>\n<<STR_FREE1>>, <<STR_FREE2>>. Thank\nyou for your understanding.\n",
+      "new": "Thanks to everyone's\npatronage, I have the means\nto expand my store again!\nWe will be closed <<STR_FREE0>>\n<<STR_FREE1>>, <<STR_FREE2>>. Thank\nyou for your understanding.\n"
+    },
+    {
+      "group": "mail",
+      "index": 27,
+      "label": "",
+      "original": "Thank you so very much for\nyour business! It is my\npleasure to announce a\ncomplete store renovation!\nCome enjoy our wider\nselection of product!\n",
+      "new": "Thank you so very much for\nyour business! It is my\npleasure to announce a\ncomplete store renovation!\nCome enjoy our wider\nselection of product!\n"
+    },
+    {
+      "group": "mail",
+      "index": 28,
+      "label": "",
+      "original": "Many thanks for all of your\nbusiness! Today is the\ngrand opening of my newly\nrenovated shop, so be sure\nto stop in. I look forward\nto your future patronage!\n",
+      "new": "Many thanks for all of your\nbusiness! Today is the\ngrand opening of my newly\nrenovated shop, so be sure\nto stop in. I look forward\nto your future patronage!\n"
+    },
+    {
+      "group": "mail",
+      "index": 29,
+      "label": "",
+      "original": "At last, the day has arrived!\nI'm delighted to announce\nthe grand opening of\nNookington's Department\nStore! We look forward to\nserving your shopping needs!\n",
+      "new": "At last, the day has arrived!\nI'm delighted to announce\nthe grand opening of\nNookington's Department\nStore! We look forward to\nserving your shopping needs!\n"
+    },
+    {
+      "group": "mail",
+      "index": 30,
+      "label": "",
+      "original": "   ーNoticeー\nAll town residents and\nvisitors are free to use\nthis bulletin board to post\nnotices and messages.\nLet's keep it tasteful, folks.\n",
+      "new": "   ーNoticeー\nAll town residents and\nvisitors are free to use\nthis bulletin board to post\nnotices and messages.\nLet's keep it tasteful, folks.\n"
+    },
+    {
+      "group": "mail",
+      "index": 31,
+      "label": "",
+      "original": "The Happy Room Academy is\nnow recruiting! Just lay out\nyour room, and it will be\njudged! Please come drop by\nmy shop if you're interested.\n                  Tom Nook\n",
+      "new": "The Happy Room Academy is\nnow recruiting! Just lay out\nyour room, and it will be\njudged! Please come drop by\nmy shop if you're interested.\n                  Tom Nook\n"
+    },
+    {
+      "group": "mail",
+      "index": 32,
+      "label": "",
+      "original": "   ーP.S.ー\nHere's a rough guide\nto the point system:\n10,000 points: Slob Alert! \n20,000 points: A Bit Stylish\n70,000 points: Hip and Hot!\n",
+      "new": "   ーP.S.ー\nHere's a rough guide\nto the point system:\n10,000 points: Slob Alert! \n20,000 points: A Bit Stylish\n70,000 points: Hip and Hot!\n"
+    },
+    {
+      "group": "mail",
+      "index": 33,
+      "label": "",
+      "original": "    ーAdding Messagesー\nPress the A Button to start\nwriting a new message. Use\nthe C Stick to flip pages.\nPress the B Button to quit.\nGo on, give it a try!\n",
+      "new": "    ーAdding Messagesー\nPress the A Button to start\nwriting a new message. Use\nthe C Stick to flip pages.\nPress the B Button to quit.\nGo on, give it a try!\n"
+    },
+    {
+      "group": "mail",
+      "index": 34,
+      "label": "",
+      "original": "Travel is good for the soul.\nVisiting new lands, meeting\nnew folks... Doesn't it sound\nexciting? My path will lead\nme here again some fair day.\nUntil then, have a good life!\n",
+      "new": "Travel is good for the soul.\nVisiting new lands, meeting\nnew folks... Doesn't it sound\nexciting? My path will lead\nme here again some fair day.\nUntil then, have a good life!\n"
+    },
+    {
+      "group": "mail",
+      "index": 35,
+      "label": "",
+      "original": "  I take leave of my life.\n  My footsteps carry me\n     like clouds upon wind,\n   drifting in the pale light\n     of the dawning day...\nI go in search of adventure.\n",
+      "new": "  I take leave of my life.\n  My footsteps carry me\n     like clouds upon wind,\n   drifting in the pale light\n     of the dawning day...\nI go in search of adventure.\n"
+    },
+    {
+      "group": "mail",
+      "index": 36,
+      "label": "",
+      "original": "Listen, now, and hear the\nwisdom I have to share!\nTrees are life! Do not hew\nthem recklessly! Swing your\naxe with wisdom, for the\nbenefit of all!\n",
+      "new": "Listen, now, and hear the\nwisdom I have to share!\nTrees are life! Do not hew\nthem recklessly! Swing your\naxe with wisdom, for the\nbenefit of all!\n"
+    },
+    {
+      "group": "mail",
+      "index": 37,
+      "label": "",
+      "original": "When I first came, there was\nnothing. The emptiness\nsaddened me, and I bent my\nwill to planting flowers.\nIs this village not better for\nmy efforts?\n",
+      "new": "When I first came, there was\nnothing. The emptiness\nsaddened me, and I bent my\nwill to planting flowers.\nIs this village not better for\nmy efforts?\n"
+    },
+    {
+      "group": "mail",
+      "index": 38,
+      "label": "",
+      "original": "Composing tunes doesn't\nrequire a whole lot of\nthought. First, write a tune\nwith the ♪ notes, then\nsimply fix the ♪ notes\nthat don't quite fit.\n",
+      "new": "Composing tunes doesn't\nrequire a whole lot of\nthought. First, write a tune\nwith the ♪ notes, then\nsimply fix the ♪ notes\nthat don't quite fit.\n"
+    },
+    {
+      "group": "mail",
+      "index": 39,
+      "label": "",
+      "original": "My friend, I hope your life\nis neither too hard nor too\nsoftーtrue joy lies in the\ncreamy middle. Now heed my\nwords: plant trees only in\nsunshineーthey hate shadows.\n",
+      "new": "My friend, I hope your life\nis neither too hard nor too\nsoftーtrue joy lies in the\ncreamy middle. Now heed my\nwords: plant trees only in\nsunshineーthey hate shadows.\n"
+    },
+    {
+      "group": "mail",
+      "index": 40,
+      "label": "",
+      "original": "Hola! How ya doin'? I've got\nHUGE news! HUGE! Totakeke,\nthe traveling musician, is on\nhis way to your village!\nNow's your chance to get\nhis latest, greatest song!\n",
+      "new": "Hola! How ya doin'? I've got\nHUGE news! HUGE! Totakeke,\nthe traveling musician, is on\nhis way to your village!\nNow's your chance to get\nhis latest, greatest song!\n"
+    },
+    {
+      "group": "mail",
+      "index": 41,
+      "label": "",
+      "original": "♪Listen for his voice, then\n search both high and low.\nCreep with care beneath\n the gently swaying bough.\n A swift net wins the show!\n     -The Singing Bug Boy\n",
+      "new": "♪Listen for his voice, then\n search both high and low.\nCreep with care beneath\n the gently swaying bough.\n A swift net wins the show!\n     -The Singing Bug Boy\n"
+    },
+    {
+      "group": "mail",
+      "index": 42,
+      "label": "",
+      "original": "A wide world awaits the one\nwith an adventurous spirit.\nBrave the strange wind.\nHave courage. Bend your\nthoughts and dreams toward\nthe unknown to see wonders.\n",
+      "new": "A wide world awaits the one\nwith an adventurous spirit.\nBrave the strange wind.\nHave courage. Bend your\nthoughts and dreams toward\nthe unknown to see wonders.\n"
+    },
+    {
+      "group": "mail",
+      "index": 43,
+      "label": "",
+      "original": "Do        JQQQQk\nyou         ~     ~\nthink       Q    Q\nI'm           /\ncute ?        >\n\n",
+      "new": "Do        JQQQQk\nyou         ~     ~\nthink       Q    Q\nI'm           /\ncute ?        >\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 44,
+      "label": "",
+      "original": "I passed through your town\nthe other day, and it's quite\ndarling! All the trees, those\ncute houses...and the fish in\nyour riverーyummy! Maybe I\nshould move in...\n",
+      "new": "I passed through your town\nthe other day, and it's quite\ndarling! All the trees, those\ncute houses...and the fish in\nyour riverーyummy! Maybe I\nshould move in...\n"
+    },
+    {
+      "group": "mail",
+      "index": 45,
+      "label": "",
+      "original": "Do you like music? Do the\nsounds of chirping insects\nsoothe your heart? This\nvillage is full of interesting\nnoises. Some sounds, only\nyou can hear. Seek them out!\n",
+      "new": "Do you like music? Do the\nsounds of chirping insects\nsoothe your heart? This\nvillage is full of interesting\nnoises. Some sounds, only\nyou can hear. Seek them out!\n"
+    },
+    {
+      "group": "mail",
+      "index": 46,
+      "label": "",
+      "original": "By the time you read this, I\nwill already be on the train.\nI am but a troubled traveler\nwho passed a few moments\nin your home. Remember, an\nopen door is an invitation.\n",
+      "new": "By the time you read this, I\nwill already be on the train.\nI am but a troubled traveler\nwho passed a few moments\nin your home. Remember, an\nopen door is an invitation.\n"
+    },
+    {
+      "group": "mail",
+      "index": 47,
+      "label": "",
+      "original": "Hello. I am this child's\nmother. Since my child has\nnever been out in the world\nalone, I'm beside myself with\nworry. Please, befriend this\nsweet, lonely child of mine!\n",
+      "new": "Hello. I am this child's\nmother. Since my child has\nnever been out in the world\nalone, I'm beside myself with\nworry. Please, befriend this\nsweet, lonely child of mine!\n"
+    },
+    {
+      "group": "mail",
+      "index": 48,
+      "label": "",
+      "original": "Have you found any furniture\nyou like? I bet there's lots\nyou've never even seen! Try\nout every kind to see if you\nhave what's right for you!\nI'm obsessed with furniture.\n",
+      "new": "Have you found any furniture\nyou like? I bet there's lots\nyou've never even seen! Try\nout every kind to see if you\nhave what's right for you!\nI'm obsessed with furniture.\n"
+    },
+    {
+      "group": "mail",
+      "index": 49,
+      "label": "",
+      "original": "Crazy Redd here! I'm just\nwriting to let you know that\nI'm CRAZY!!! Oh, and I'll\nbe in your neighborhood on\n<<STR_FREE0>> <<STR_FREE1>> at <<STR_FREE2>>!\nGet ready for insane deals!\n",
+      "new": "Crazy Redd here! I'm just\nwriting to let you know that\nI'm CRAZY!!! Oh, and I'll\nbe in your neighborhood on\n<<STR_FREE0>> <<STR_FREE1>> at <<STR_FREE2>>!\nGet ready for insane deals!\n"
+    },
+    {
+      "group": "mail",
+      "index": 50,
+      "label": "",
+      "original": "Crazy Redd here! I'll be\nbringing my fine furniture\nand insane bargains to your\ntown at <<STR_FREE2>> on\n<<STR_FREE0>> <<STR_FREE1>>! No sane\nindividual has deals like me!\n",
+      "new": "Crazy Redd here! I'll be\nbringing my fine furniture\nand insane bargains to your\ntown at <<STR_FREE2>> on\n<<STR_FREE0>> <<STR_FREE1>>! No sane\nindividual has deals like me!\n"
+    },
+    {
+      "group": "mail",
+      "index": 51,
+      "label": "",
+      "original": "When you see the bargains\nI've got, you'll want to have\nol' Crazy Redd committed!\nI'll be coming to town on\n<<STR_FREE0>> <<STR_FREE1>> at <<STR_FREE2>>!\nCome one, come all!\n",
+      "new": "When you see the bargains\nI've got, you'll want to have\nol' Crazy Redd committed!\nI'll be coming to town on\n<<STR_FREE0>> <<STR_FREE1>> at <<STR_FREE2>>!\nCome one, come all!\n"
+    },
+    {
+      "group": "mail",
+      "index": 52,
+      "label": "",
+      "original": "Your current design earns\n<<STR_FREE0>> points. We suppose\nit's livable, but it most\ncertainly isn't attractive.\n     <<STR_FREE4>> <<STR_FREE5>>, <<STR_FREE3>>\n\n",
+      "new": "Your current design earns\n<<STR_FREE0>> points. We suppose\nit's livable, but it most\ncertainly isn't attractive.\n     <<STR_FREE4>> <<STR_FREE5>>, <<STR_FREE3>>\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 53,
+      "label": "",
+      "original": "Your current design earns\n<<STR_FREE0>> points. It's nice\nand humble, yet comfortable.\nWe also like your fine set of\nmatching furniture. Kudos!\n     <<STR_FREE4>> <<STR_FREE5>>, <<STR_FREE3>>\n",
+      "new": "Your current design earns\n<<STR_FREE0>> points. It's nice\nand humble, yet comfortable.\nWe also like your fine set of\nmatching furniture. Kudos!\n     <<STR_FREE4>> <<STR_FREE5>>, <<STR_FREE3>>\n"
+    },
+    {
+      "group": "mail",
+      "index": 54,
+      "label": "",
+      "original": "Your current layout earns\n<<STR_FREE0>> points. You have\na complete furniture set!\nNow, try matching your\ncarpet and wallpaper!\n     <<STR_FREE4>> <<STR_FREE5>>, <<STR_FREE3>>\n",
+      "new": "Your current layout earns\n<<STR_FREE0>> points. You have\na complete furniture set!\nNow, try matching your\ncarpet and wallpaper!\n     <<STR_FREE4>> <<STR_FREE5>>, <<STR_FREE3>>\n"
+    },
+    {
+      "group": "mail",
+      "index": 55,
+      "label": "",
+      "original": "Your current layout earns\n<<STR_FREE0>> points. Only\ntalented designers do this\nwell! <<CAPTIALIZE>><<STR_FREE1>>\nwould bring it all together!\n     <<STR_FREE4>> <<STR_FREE5>>, <<STR_FREE3>>\n",
+      "new": "Your current layout earns\n<<STR_FREE0>> points. Only\ntalented designers do this\nwell! <<CAPTIALIZE>><<STR_FREE1>>\nwould bring it all together!\n     <<STR_FREE4>> <<STR_FREE5>>, <<STR_FREE3>>\n"
+    },
+    {
+      "group": "mail",
+      "index": 56,
+      "label": "",
+      "original": "Your current design earns\nyou <<STR_FREE0>> points!\nYou're perfectly coordinated!\nNow try adding a little of\nyour personal flair!\n     <<STR_FREE4>> <<STR_FREE5>>, <<STR_FREE3>>\n",
+      "new": "Your current design earns\nyou <<STR_FREE0>> points!\nYou're perfectly coordinated!\nNow try adding a little of\nyour personal flair!\n     <<STR_FREE4>> <<STR_FREE5>>, <<STR_FREE3>>\n"
+    },
+    {
+      "group": "mail",
+      "index": 57,
+      "label": "",
+      "original": "Your room design earns you\n<<STR_FREE0>> points, but\nwe think your room could\nbe even more dynamic.\nShow us what you can do!\n     <<STR_FREE4>> <<STR_FREE5>>, <<STR_FREE3>>\n",
+      "new": "Your room design earns you\n<<STR_FREE0>> points, but\nwe think your room could\nbe even more dynamic.\nShow us what you can do!\n     <<STR_FREE4>> <<STR_FREE5>>, <<STR_FREE3>>\n"
+    },
+    {
+      "group": "mail",
+      "index": 58,
+      "label": "",
+      "original": "Your current design earns\n<<STR_FREE0>> points. Congrats\non completing your \n<<STR_FREE2>> collection!\nNow, add your own flair!\n     <<STR_FREE4>> <<STR_FREE5>>, <<STR_FREE3>>\n",
+      "new": "Your current design earns\n<<STR_FREE0>> points. Congrats\non completing your \n<<STR_FREE2>> collection!\nNow, add your own flair!\n     <<STR_FREE4>> <<STR_FREE5>>, <<STR_FREE3>>\n"
+    },
+    {
+      "group": "mail",
+      "index": 59,
+      "label": "",
+      "original": "Your room design earns you\n<<STR_FREE0>> points, but your\n<<STR_FREE2>> series is\nbeing wasted! Poor placement\nruins a room's atmosphere!\n     <<STR_FREE4>> <<STR_FREE5>>, <<STR_FREE3>>\n",
+      "new": "Your room design earns you\n<<STR_FREE0>> points, but your\n<<STR_FREE2>> series is\nbeing wasted! Poor placement\nruins a room's atmosphere!\n     <<STR_FREE4>> <<STR_FREE5>>, <<STR_FREE3>>\n"
+    },
+    {
+      "group": "mail",
+      "index": 60,
+      "label": "",
+      "original": "Your current design earns\n<<STR_FREE0>> points, but come\nnow! Why own furniture if\nyou're not going to use it?\nPay more attention to layout!\n     <<STR_FREE4>> <<STR_FREE5>>, <<STR_FREE3>>\n",
+      "new": "Your current design earns\n<<STR_FREE0>> points, but come\nnow! Why own furniture if\nyou're not going to use it?\nPay more attention to layout!\n     <<STR_FREE4>> <<STR_FREE5>>, <<STR_FREE3>>\n"
+    },
+    {
+      "group": "mail",
+      "index": 61,
+      "label": "",
+      "original": "Your current design earns\n<<STR_FREE0>> points, but you\nlost points for filthiness;\nyou live like an animal! Tidy\nup and put your junk away!\n     <<STR_FREE4>> <<STR_FREE5>>, <<STR_FREE3>>\n",
+      "new": "Your current design earns\n<<STR_FREE0>> points, but you\nlost points for filthiness;\nyou live like an animal! Tidy\nup and put your junk away!\n     <<STR_FREE4>> <<STR_FREE5>>, <<STR_FREE3>>\n"
+    },
+    {
+      "group": "mail",
+      "index": 62,
+      "label": "",
+      "original": "Your current design earns\n<<STR_FREE0>> points. Now focus\non finding interesting items\nto add a spicy dash of\ncreativity to your design.\n     <<STR_FREE4>> <<STR_FREE5>>, <<STR_FREE3>>\n",
+      "new": "Your current design earns\n<<STR_FREE0>> points. Now focus\non finding interesting items\nto add a spicy dash of\ncreativity to your design.\n     <<STR_FREE4>> <<STR_FREE5>>, <<STR_FREE3>>\n"
+    },
+    {
+      "group": "mail",
+      "index": 63,
+      "label": "",
+      "original": "Your current design earns\n<<STR_FREE0>> points. You've\nreally chosen a direction\nand run with it, we see.\nNow, bring it all together!\n     <<STR_FREE4>> <<STR_FREE5>>, <<STR_FREE3>>\n",
+      "new": "Your current design earns\n<<STR_FREE0>> points. You've\nreally chosen a direction\nand run with it, we see.\nNow, bring it all together!\n     <<STR_FREE4>> <<STR_FREE5>>, <<STR_FREE3>>\n"
+    },
+    {
+      "group": "mail",
+      "index": 64,
+      "label": "",
+      "original": "Your current design earns\n<<STR_FREE0>> points. Your room\nis splendid, but it's missing\nthat special something. Don't\ngive up! It's almost perfect!\n     <<STR_FREE4>> <<STR_FREE5>>, <<STR_FREE3>>\n",
+      "new": "Your current design earns\n<<STR_FREE0>> points. Your room\nis splendid, but it's missing\nthat special something. Don't\ngive up! It's almost perfect!\n     <<STR_FREE4>> <<STR_FREE5>>, <<STR_FREE3>>\n"
+    },
+    {
+      "group": "mail",
+      "index": 65,
+      "label": "",
+      "original": "Your current design earns\n<<STR_FREE0>> points. Your room\nis almost perfect, but... Well,\nsomething's just missing.\nWe're not sure what, but...\n     <<STR_FREE4>> <<STR_FREE5>>, <<STR_FREE3>>\n",
+      "new": "Your current design earns\n<<STR_FREE0>> points. Your room\nis almost perfect, but... Well,\nsomething's just missing.\nWe're not sure what, but...\n     <<STR_FREE4>> <<STR_FREE5>>, <<STR_FREE3>>\n"
+    },
+    {
+      "group": "mail",
+      "index": 66,
+      "label": "",
+      "original": "Your current design earns\n<<STR_FREE0>> points. Honestly,\nwe're quite horrifiedーyour\nroom is barely livable. At\nleast get yourself a bed!\n     <<STR_FREE4>> <<STR_FREE5>>, <<STR_FREE3>>\n",
+      "new": "Your current design earns\n<<STR_FREE0>> points. Honestly,\nwe're quite horrifiedーyour\nroom is barely livable. At\nleast get yourself a bed!\n     <<STR_FREE4>> <<STR_FREE5>>, <<STR_FREE3>>\n"
+    },
+    {
+      "group": "mail",
+      "index": 67,
+      "label": "",
+      "original": "Your current layout earns\n<<STR_FREE0>> points. To be\nblunt, your house is too\nsmall. You don't have the\nspace for a pleasant layout.\n     <<STR_FREE4>> <<STR_FREE5>>, <<STR_FREE3>>\n",
+      "new": "Your current layout earns\n<<STR_FREE0>> points. To be\nblunt, your house is too\nsmall. You don't have the\nspace for a pleasant layout.\n     <<STR_FREE4>> <<STR_FREE5>>, <<STR_FREE3>>\n"
+    },
+    {
+      "group": "mail",
+      "index": 68,
+      "label": "",
+      "original": "Your current layout earns\n<<STR_FREE0>> points. If we may\nsay so, your house is quite\nspacious. It's up to you\nwhether you expand it again.\n     <<STR_FREE4>> <<STR_FREE5>>, <<STR_FREE3>>\n",
+      "new": "Your current layout earns\n<<STR_FREE0>> points. If we may\nsay so, your house is quite\nspacious. It's up to you\nwhether you expand it again.\n     <<STR_FREE4>> <<STR_FREE5>>, <<STR_FREE3>>\n"
+    },
+    {
+      "group": "mail",
+      "index": 69,
+      "label": "",
+      "original": "Your current layout earns\n<<STR_FREE0>> points. A big\nhouse does not always make\na nice house. In fact, yours\nlooks like a warehouse!\n     <<STR_FREE4>> <<STR_FREE5>>, <<STR_FREE3>>\n",
+      "new": "Your current layout earns\n<<STR_FREE0>> points. A big\nhouse does not always make\na nice house. In fact, yours\nlooks like a warehouse!\n     <<STR_FREE4>> <<STR_FREE5>>, <<STR_FREE3>>\n"
+    },
+    {
+      "group": "mail",
+      "index": 70,
+      "label": "",
+      "original": "Your current layout earns\n<<STR_FREE0>> points. While we\nat the Academy feel you've\nmade good progress, your\nhome is far from perfect.\n     <<STR_FREE4>> <<STR_FREE5>>, <<STR_FREE3>>\n",
+      "new": "Your current layout earns\n<<STR_FREE0>> points. While we\nat the Academy feel you've\nmade good progress, your\nhome is far from perfect.\n     <<STR_FREE4>> <<STR_FREE5>>, <<STR_FREE3>>\n"
+    },
+    {
+      "group": "mail",
+      "index": 71,
+      "label": "",
+      "original": "Your current layout earns\n<<STR_FREE0>> points. Mercy,\nwhat a delightful house!\nNow your challenge is to\nimprove upon it. Great job!\n     <<STR_FREE4>> <<STR_FREE5>>, <<STR_FREE3>>\n",
+      "new": "Your current layout earns\n<<STR_FREE0>> points. Mercy,\nwhat a delightful house!\nNow your challenge is to\nimprove upon it. Great job!\n     <<STR_FREE4>> <<STR_FREE5>>, <<STR_FREE3>>\n"
+    },
+    {
+      "group": "mail",
+      "index": 72,
+      "label": "",
+      "original": "Your current layout earns\n<<STR_FREE0>> points. Never\nhave we seen such stunningly\noriginal interior design!\nTruly a fine home. Bravo!\n     <<STR_FREE4>> <<STR_FREE5>>, <<STR_FREE3>>\n",
+      "new": "Your current layout earns\n<<STR_FREE0>> points. Never\nhave we seen such stunningly\noriginal interior design!\nTruly a fine home. Bravo!\n     <<STR_FREE4>> <<STR_FREE5>>, <<STR_FREE3>>\n"
+    },
+    {
+      "group": "mail",
+      "index": 73,
+      "label": "",
+      "original": "Here's the <<CUTARTICLE>><<STR_FREE0>>\nyou ordered. We hope it\nbrings you satisfaction!\n\nThank you for ordering\nthrough the catalog!\n",
+      "new": "Here's the <<CUTARTICLE>><<STR_FREE0>>\nyou ordered. We hope it\nbrings you satisfaction!\n\nThank you for ordering\nthrough the catalog!\n"
+    },
+    {
+      "group": "mail",
+      "index": 74,
+      "label": "",
+      "original": "Your <<CUTARTICLE>><<STR_FREE0>> has\nfinally arrived! We apologize\nfor any inconvenience the\ndelay may have caused.\nWe look forward to your\nnext order!\n",
+      "new": "Your <<CUTARTICLE>><<STR_FREE0>> has\nfinally arrived! We apologize\nfor any inconvenience the\ndelay may have caused.\nWe look forward to your\nnext order!\n"
+    },
+    {
+      "group": "mail",
+      "index": 75,
+      "label": "",
+      "original": "Your <<CUTARTICLE>><<STR_FREE0>> has\nfinally arrived. We would\nlike to offer our apologies\nfor any delay in shipping.\n\nThank you for your order!\n",
+      "new": "Your <<CUTARTICLE>><<STR_FREE0>> has\nfinally arrived. We would\nlike to offer our apologies\nfor any delay in shipping.\n\nThank you for your order!\n"
+    },
+    {
+      "group": "mail",
+      "index": 76,
+      "label": "",
+      "original": "The <<CUTARTICLE>><<STR_FREE0>> you\nordered has arrived.\n\nNookington's looks forward\nto meeting all of your future\nhome-decor needs.\n",
+      "new": "The <<CUTARTICLE>><<STR_FREE0>> you\nordered has arrived.\n\nNookington's looks forward\nto meeting all of your future\nhome-decor needs.\n"
+    },
+    {
+      "group": "mail",
+      "index": 77,
+      "label": "",
+      "original": "The <<CUTARTICLE>><<STR_FREE0>> you\nordered has arrived.\nThank you for ordering\nthrough our catalog. We\nlook forward to serving\nyou in the future!\n",
+      "new": "The <<CUTARTICLE>><<STR_FREE0>> you\nordered has arrived.\nThank you for ordering\nthrough our catalog. We\nlook forward to serving\nyou in the future!\n"
+    },
+    {
+      "group": "mail",
+      "index": 78,
+      "label": "",
+      "original": "\n\n\n\n\n\n",
+      "new": "\n\n\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 79,
+      "label": "",
+      "original": "\n\n\n\n\n\n",
+      "new": "\n\n\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 80,
+      "label": "",
+      "original": "\n\n\n\n\n\n",
+      "new": "\n\n\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 81,
+      "label": "",
+      "original": "\n\n\n\n\n\n",
+      "new": "\n\n\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 82,
+      "label": "",
+      "original": "\n\n\n\n\n\n",
+      "new": "\n\n\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 83,
+      "label": "",
+      "original": "This month's prizes are\n   1st place: <<STR_FREE1>>\n   2nd place: <<STR_FREE2>>\n   3rd place: <<STR_FREE3>>\nBe there on <<STR_FREE4>> <<STR_FREE5>>\nto see if you win!\n",
+      "new": "This month's prizes are\n   1st place: <<STR_FREE1>>\n   2nd place: <<STR_FREE2>>\n   3rd place: <<STR_FREE3>>\nBe there on <<STR_FREE4>> <<STR_FREE5>>\nto see if you win!\n"
+    },
+    {
+      "group": "mail",
+      "index": 84,
+      "label": "",
+      "original": "This month's prizes are\n   1st place: <<STR_FREE1>>\n   2nd place: <<STR_FREE2>>\n   3rd place: <<STR_FREE3>>\nBe there on <<STR_FREE4>> <<STR_FREE5>>\nto see if you win!\n",
+      "new": "This month's prizes are\n   1st place: <<STR_FREE1>>\n   2nd place: <<STR_FREE2>>\n   3rd place: <<STR_FREE3>>\nBe there on <<STR_FREE4>> <<STR_FREE5>>\nto see if you win!\n"
+    },
+    {
+      "group": "mail",
+      "index": 85,
+      "label": "",
+      "original": "This month's prizes are\n   1st place: <<STR_FREE1>>\n   2nd place: <<STR_FREE2>>\n   3rd place: <<STR_FREE3>>\nBe there on <<STR_FREE4>> <<STR_FREE5>>\nto see if you win!\n",
+      "new": "This month's prizes are\n   1st place: <<STR_FREE1>>\n   2nd place: <<STR_FREE2>>\n   3rd place: <<STR_FREE3>>\nBe there on <<STR_FREE4>> <<STR_FREE5>>\nto see if you win!\n"
+    },
+    {
+      "group": "mail",
+      "index": 86,
+      "label": "",
+      "original": "This month's prizes are\n   1st place: <<STR_FREE1>>\n   2nd place: <<STR_FREE2>>\n   3rd place: <<STR_FREE3>>\nBe there on <<STR_FREE4>> <<STR_FREE5>>\nto see if you win!\n",
+      "new": "This month's prizes are\n   1st place: <<STR_FREE1>>\n   2nd place: <<STR_FREE2>>\n   3rd place: <<STR_FREE3>>\nBe there on <<STR_FREE4>> <<STR_FREE5>>\nto see if you win!\n"
+    },
+    {
+      "group": "mail",
+      "index": 87,
+      "label": "",
+      "original": "Here are those raffle tickets\nI was unable to give you\nearlier. Sorry for the delay!\nDon't forget to bring all your\nraffle tickets with you on the\nlast day of <<STR_FREE4>>!\n",
+      "new": "Here are those raffle tickets\nI was unable to give you\nearlier. Sorry for the delay!\nDon't forget to bring all your\nraffle tickets with you on the\nlast day of <<STR_FREE4>>!\n"
+    },
+    {
+      "group": "mail",
+      "index": 88,
+      "label": "",
+      "original": "It's <<STR_FREE4>> <<STR_FREE5>>, and\nyou know what that means...\nIt's Raffle Ticket Day!\nWe're open from 10 a.m.\nuntil 8 p.m., so come by and\nredeem your raffle tickets!\n",
+      "new": "It's <<STR_FREE4>> <<STR_FREE5>>, and\nyou know what that means...\nIt's Raffle Ticket Day!\nWe're open from 10 a.m.\nuntil 8 p.m., so come by and\nredeem your raffle tickets!\n"
+    },
+    {
+      "group": "mail",
+      "index": 89,
+      "label": "",
+      "original": "It's <<STR_FREE4>> <<STR_FREE5>>, and\nyou know what that means...\nIt's Raffle Ticket Day!\nWe're open from 10 a.m.\nuntil 8 p.m., so come by and\nredeem your raffle tickets!\n",
+      "new": "It's <<STR_FREE4>> <<STR_FREE5>>, and\nyou know what that means...\nIt's Raffle Ticket Day!\nWe're open from 10 a.m.\nuntil 8 p.m., so come by and\nredeem your raffle tickets!\n"
+    },
+    {
+      "group": "mail",
+      "index": 90,
+      "label": "",
+      "original": "It's <<STR_FREE4>> <<STR_FREE5>>, and\nyou know what that means...\nIt's Raffle Ticket Day!\nWe're open from 10 a.m.\nuntil 8 p.m., so come by and\nredeem your raffle tickets!\n",
+      "new": "It's <<STR_FREE4>> <<STR_FREE5>>, and\nyou know what that means...\nIt's Raffle Ticket Day!\nWe're open from 10 a.m.\nuntil 8 p.m., so come by and\nredeem your raffle tickets!\n"
+    },
+    {
+      "group": "mail",
+      "index": 91,
+      "label": "",
+      "original": "It's <<STR_FREE4>> <<STR_FREE5>>, and\nyou know what that means...\nIt's Raffle Ticket Day!\nWe're open from 10 a.m.\nuntil 8 p.m., so come by and\nredeem your raffle tickets!\n",
+      "new": "It's <<STR_FREE4>> <<STR_FREE5>>, and\nyou know what that means...\nIt's Raffle Ticket Day!\nWe're open from 10 a.m.\nuntil 8 p.m., so come by and\nredeem your raffle tickets!\n"
+    },
+    {
+      "group": "mail",
+      "index": 92,
+      "label": "",
+      "original": "\n\n\n\n\n\n",
+      "new": "\n\n\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 93,
+      "label": "",
+      "original": "\n\n\n\n\n\n",
+      "new": "\n\n\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 94,
+      "label": "",
+      "original": "\n\n\n\n\n\n",
+      "new": "\n\n\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 95,
+      "label": "",
+      "original": "\n\n\n\n\n\n",
+      "new": "\n\n\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 96,
+      "label": "",
+      "original": "\nYou're the one I like the\nmost. Don't tell anyone.\nIt's not right to boast!\n\n\n",
+      "new": "\nYou're the one I like the\nmost. Don't tell anyone.\nIt's not right to boast!\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 97,
+      "label": "",
+      "original": "<<STR_FREE0>>, thank you\nfor being so kind to me\nall the time. I can only\nhope we grow closer as\ntime goes by.\n\n",
+      "new": "<<STR_FREE0>>, thank you\nfor being so kind to me\nall the time. I can only\nhope we grow closer as\ntime goes by.\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 98,
+      "label": "",
+      "original": "<<STR_FREE0>>, I know we've\nnever been close, and I\nguess maybe it's partly\nmy fault, but I hope you\nand I can try to be\nfriends from now on.\n",
+      "new": "<<STR_FREE0>>, I know we've\nnever been close, and I\nguess maybe it's partly\nmy fault, but I hope you\nand I can try to be\nfriends from now on.\n"
+    },
+    {
+      "group": "mail",
+      "index": 99,
+      "label": "",
+      "original": "My dearest <<STR_FREE0>>!\nIn all my life, I've never met\nanyone even slightly as cool\nas you! You're a dream made\nreal! Please, stay by my side\nforever! Promise?\n",
+      "new": "My dearest <<STR_FREE0>>!\nIn all my life, I've never met\nanyone even slightly as cool\nas you! You're a dream made\nreal! Please, stay by my side\nforever! Promise?\n"
+    },
+    {
+      "group": "mail",
+      "index": 100,
+      "label": "",
+      "original": "Yoo-hoo! It's Valentine's\nDay today, you know! Since\nyou've been so great, I'm\nsending you a special gift!\nDon't ever change! I like\nyou the way you are!\n",
+      "new": "Yoo-hoo! It's Valentine's\nDay today, you know! Since\nyou've been so great, I'm\nsending you a special gift!\nDon't ever change! I like\nyou the way you are!\n"
+    },
+    {
+      "group": "mail",
+      "index": 101,
+      "label": "",
+      "original": "Roses, they are red.\nViolets, they are blue.\nIt's the day of valentines,\nso here's a giftie-poo!\n\nBye!\n",
+      "new": "Roses, they are red.\nViolets, they are blue.\nIt's the day of valentines,\nso here's a giftie-poo!\n\nBye!\n"
+    },
+    {
+      "group": "mail",
+      "index": 102,
+      "label": "",
+      "original": "More than sweet snacks\n and afternoon cat-naps,\n   I\n    adore\n       you!\n\n",
+      "new": "More than sweet snacks\n and afternoon cat-naps,\n   I\n    adore\n       you!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 103,
+      "label": "",
+      "original": "Old friend, you've done so\nmuch for me. I looked long\nand hard for a Valentine's\nDay gift you'd dig... I hope\nour our friendship stays\nas cool as ever!\n",
+      "new": "Old friend, you've done so\nmuch for me. I looked long\nand hard for a Valentine's\nDay gift you'd dig... I hope\nour our friendship stays\nas cool as ever!\n"
+    },
+    {
+      "group": "mail",
+      "index": 104,
+      "label": "",
+      "original": "It just hit meーtoday is\nValentine's Day! I don't\nknow if you sent me any\ngifts, but I figured I'd\nbetter send you one...\nYou know, just to be safe!\n",
+      "new": "It just hit meーtoday is\nValentine's Day! I don't\nknow if you sent me any\ngifts, but I figured I'd\nbetter send you one...\nYou know, just to be safe!\n"
+    },
+    {
+      "group": "mail",
+      "index": 105,
+      "label": "",
+      "original": "Oh, <<STR_FREE0>>.\nNo one can match my love\nfor you!\nWhenever you leave, I find\nmyself gazing longingly\nafter you...\n",
+      "new": "Oh, <<STR_FREE0>>.\nNo one can match my love\nfor you!\nWhenever you leave, I find\nmyself gazing longingly\nafter you...\n"
+    },
+    {
+      "group": "mail",
+      "index": 106,
+      "label": "",
+      "original": "Well, today's Valentine's Day.\nThis is sort of awkward,\nbut...I hope you like this\npresent. Just junk it if you\ndon't! Anyway...we should go\nfishing together sometime!\n",
+      "new": "Well, today's Valentine's Day.\nThis is sort of awkward,\nbut...I hope you like this\npresent. Just junk it if you\ndon't! Anyway...we should go\nfishing together sometime!\n"
+    },
+    {
+      "group": "mail",
+      "index": 107,
+      "label": "",
+      "original": "Yeah, so today's Valentine's\nDay, I guess, and I didn't\nhave anyone else to send a\ncard to, so I figured I'd\nsend a present, even though\nI often get sick of you.\n",
+      "new": "Yeah, so today's Valentine's\nDay, I guess, and I didn't\nhave anyone else to send a\ncard to, so I figured I'd\nsend a present, even though\nI often get sick of you.\n"
+    },
+    {
+      "group": "mail",
+      "index": 108,
+      "label": "",
+      "original": "Look, don't go making a big\ndeal over this or anything.\nJust take it. Think of it as,\nI don't know, just a little\nsomething for my precious\nlittle <<STR_FREE0>>.\n",
+      "new": "Look, don't go making a big\ndeal over this or anything.\nJust take it. Think of it as,\nI don't know, just a little\nsomething for my precious\nlittle <<STR_FREE0>>.\n"
+    },
+    {
+      "group": "mail",
+      "index": 109,
+      "label": "",
+      "original": "This little Valentine's Day\ncard is just my way of \nsaying thanks for all that\nyou've done for me lately,\n<<STR_FREE0>>.\n\n",
+      "new": "This little Valentine's Day\ncard is just my way of \nsaying thanks for all that\nyou've done for me lately,\n<<STR_FREE0>>.\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 110,
+      "label": "",
+      "original": "I despise froufrou holidays\nlike Valentine's Day, but I'm\nnot one to break a custom,\nso I suppose I just have to\nsend you a card. Don't go\ngetting all emotional on me.\n",
+      "new": "I despise froufrou holidays\nlike Valentine's Day, but I'm\nnot one to break a custom,\nso I suppose I just have to\nsend you a card. Don't go\ngetting all emotional on me.\n"
+    },
+    {
+      "group": "mail",
+      "index": 111,
+      "label": "",
+      "original": "I know I'm always hard\non you, <<STR_FREE0>>, but\nyou know what? Out of\neveryone I know, I actually\nlike you the best. Go figure!\n\n",
+      "new": "I know I'm always hard\non you, <<STR_FREE0>>, but\nyou know what? Out of\neveryone I know, I actually\nlike you the best. Go figure!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 112,
+      "label": "",
+      "original": "Here's a Valentine's gift\nfor my good friend,\n<<STR_FREE0>>!\n\nP.S. You better not have\nforgotten to send me one!\n",
+      "new": "Here's a Valentine's gift\nfor my good friend,\n<<STR_FREE0>>!\n\nP.S. You better not have\nforgotten to send me one!\n"
+    },
+    {
+      "group": "mail",
+      "index": 113,
+      "label": "",
+      "original": "Today is Valentine's Day, but\nknowing how you treat\npeople, I figure you won't\nget any valentines. I felt\nbad for you, so...here's one\ngift, at least.\n",
+      "new": "Today is Valentine's Day, but\nknowing how you treat\npeople, I figure you won't\nget any valentines. I felt\nbad for you, so...here's one\ngift, at least.\n"
+    },
+    {
+      "group": "mail",
+      "index": 114,
+      "label": "",
+      "original": "    You're in for a\n    <<STR_FREE4>> year!\nLuck: <<STR_FREE0>>\nLove: <<STR_FREE1>>\nWealth: <<STR_FREE2>>\nHealth: <<STR_FREE3>>\n",
+      "new": "    You're in for a\n    <<STR_FREE4>> year!\nLuck: <<STR_FREE0>>\nLove: <<STR_FREE1>>\nWealth: <<STR_FREE2>>\nHealth: <<STR_FREE3>>\n"
+    },
+    {
+      "group": "mail",
+      "index": 115,
+      "label": "",
+      "original": "    You're in for a\n    <<STR_FREE4>> year!\nLuck: <<STR_FREE0>>\nLove: <<STR_FREE1>>\nWealth: <<STR_FREE2>>\nHealth: <<STR_FREE3>>\n",
+      "new": "    You're in for a\n    <<STR_FREE4>> year!\nLuck: <<STR_FREE0>>\nLove: <<STR_FREE1>>\nWealth: <<STR_FREE2>>\nHealth: <<STR_FREE3>>\n"
+    },
+    {
+      "group": "mail",
+      "index": 116,
+      "label": "",
+      "original": "    You're in for a\n    <<STR_FREE4>> year!\nLuck: <<STR_FREE0>>\nLove: <<STR_FREE1>>\nWealth: <<STR_FREE2>>\nHealth: <<STR_FREE3>>\n",
+      "new": "    You're in for a\n    <<STR_FREE4>> year!\nLuck: <<STR_FREE0>>\nLove: <<STR_FREE1>>\nWealth: <<STR_FREE2>>\nHealth: <<STR_FREE3>>\n"
+    },
+    {
+      "group": "mail",
+      "index": 117,
+      "label": "",
+      "original": "Was that a letter or some\nstrange code? I didn't\nunderstand what you were\ntrying to say. Next time,\njust write simpler sentences\nso I can understand you.\n",
+      "new": "Was that a letter or some\nstrange code? I didn't\nunderstand what you were\ntrying to say. Next time,\njust write simpler sentences\nso I can understand you.\n"
+    },
+    {
+      "group": "mail",
+      "index": 118,
+      "label": "",
+      "original": "Hey! Your letter really\ncreeped me out. I have NO\nidea what you were trying\nsay, crazy person!\nWhat a waste of paper!\n\n",
+      "new": "Hey! Your letter really\ncreeped me out. I have NO\nidea what you were trying\nsay, crazy person!\nWhat a waste of paper!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 119,
+      "label": "",
+      "original": "I don't get it....\nYou go to all the trouble of\nwriting a letter, but then\nmake it too tough to read.\nDo you have to make\neverything so complicated?\n",
+      "new": "I don't get it....\nYou go to all the trouble of\nwriting a letter, but then\nmake it too tough to read.\nDo you have to make\neverything so complicated?\n"
+    },
+    {
+      "group": "mail",
+      "index": 120,
+      "label": "",
+      "original": "Yo, what's the deal?\nI hate getting letters I can't\nread. Tell you what: don't\nbother writing me letters\nanymore if you're just going\nto make me feel stupid!\n",
+      "new": "Yo, what's the deal?\nI hate getting letters I can't\nread. Tell you what: don't\nbother writing me letters\nanymore if you're just going\nto make me feel stupid!\n"
+    },
+    {
+      "group": "mail",
+      "index": 121,
+      "label": "",
+      "original": "What's the deal?!? Are you\ntrying to make me feel dim?\nAre you saying I'm stupid?\nWell, I don't need it, and I\ndon't need any more of your\nfreakish letters!\n",
+      "new": "What's the deal?!? Are you\ntrying to make me feel dim?\nAre you saying I'm stupid?\nWell, I don't need it, and I\ndon't need any more of your\nfreakish letters!\n"
+    },
+    {
+      "group": "mail",
+      "index": 122,
+      "label": "",
+      "original": "I'm afraid your writing style\nmay be a bit over my head.\nYou don't need to use \nsuch difficult words. Next\ntime, just get to the point!\n\n",
+      "new": "I'm afraid your writing style\nmay be a bit over my head.\nYou don't need to use \nsuch difficult words. Next\ntime, just get to the point!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 123,
+      "label": "",
+      "original": "I'm writing to thank you\nfor your letter, but I must\nsay it was a little over my\nhead. Next time, use simpler\nlanguage, OK?\n\n",
+      "new": "I'm writing to thank you\nfor your letter, but I must\nsay it was a little over my\nhead. Next time, use simpler\nlanguage, OK?\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 124,
+      "label": "",
+      "original": "You know what? I tried\nreally, really hard to\nunderstand your letter,\nbut I just didn't get it. Was\nit a code? You can tell me!\n\n",
+      "new": "You know what? I tried\nreally, really hard to\nunderstand your letter,\nbut I just didn't get it. Was\nit a code? You can tell me!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 125,
+      "label": "",
+      "original": "Thanks for the letter, but\nit put me to sleep. That\nalways happens when I get\nlost when I'm reading. Sorry.\nMaybe I'll study up so I can\nunderstand your next one.\n",
+      "new": "Thanks for the letter, but\nit put me to sleep. That\nalways happens when I get\nlost when I'm reading. Sorry.\nMaybe I'll study up so I can\nunderstand your next one.\n"
+    },
+    {
+      "group": "mail",
+      "index": 126,
+      "label": "",
+      "original": "Wow! You're such a good\nwriter! I bet you could\nwrite books and stuff!\nNot me, though. In fact,\nI couldn't even understand\na word you wrote!\n",
+      "new": "Wow! You're such a good\nwriter! I bet you could\nwrite books and stuff!\nNot me, though. In fact,\nI couldn't even understand\na word you wrote!\n"
+    },
+    {
+      "group": "mail",
+      "index": 127,
+      "label": "",
+      "original": "Are you calling me stupid?!?\nYou must be! Otherwise,\nyou wouldn't write such a\ncomplicated letter! It hurts,\nI tell you! It hurts...\n\n",
+      "new": "Are you calling me stupid?!?\nYou must be! Otherwise,\nyou wouldn't write such a\ncomplicated letter! It hurts,\nI tell you! It hurts...\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 128,
+      "label": "",
+      "original": "So, did you think I don't\nbother to read the letters\nyou send me? Well, I do.\nOr at least, I try to.\nBut I just couldn't\nunderstand your last one!\n",
+      "new": "So, did you think I don't\nbother to read the letters\nyou send me? Well, I do.\nOr at least, I try to.\nBut I just couldn't\nunderstand your last one!\n"
+    },
+    {
+      "group": "mail",
+      "index": 129,
+      "label": "",
+      "original": "Thank you for your letter.\nI appreciate you writing so\nmuch, but it was little more\nthan I could take. I didn't\nunderstand most of it. I'm\nsorry. But write again, OK?\n",
+      "new": "Thank you for your letter.\nI appreciate you writing so\nmuch, but it was little more\nthan I could take. I didn't\nunderstand most of it. I'm\nsorry. But write again, OK?\n"
+    },
+    {
+      "group": "mail",
+      "index": 130,
+      "label": "",
+      "original": "Thanks for your letter!\nBut you wrote so much, I\nhad to read it, like, three\ntimes. I still didn't get it.\nDon't be mad! Write me\nagain, OK?\n",
+      "new": "Thanks for your letter!\nBut you wrote so much, I\nhad to read it, like, three\ntimes. I still didn't get it.\nDon't be mad! Write me\nagain, OK?\n"
+    },
+    {
+      "group": "mail",
+      "index": 131,
+      "label": "",
+      "original": "Thanks for the letter. Do you\nmind if I show it to people?\nI just want everyone to know\nwhat a cool friend you are.\n\n\n",
+      "new": "Thanks for the letter. Do you\nmind if I show it to people?\nI just want everyone to know\nwhat a cool friend you are.\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 132,
+      "label": "",
+      "original": "Hey, thanks! I liked your\nletterーnot that I understood\nit, but whatever! I'm just\ngoing to show it to a few\nfriends and see if they\nget it or not.\n",
+      "new": "Hey, thanks! I liked your\nletterーnot that I understood\nit, but whatever! I'm just\ngoing to show it to a few\nfriends and see if they\nget it or not.\n"
+    },
+    {
+      "group": "mail",
+      "index": 133,
+      "label": "",
+      "original": "What's the deal??? Why do\nyou write me these pointless\nletters? I can't show this to\nmy friends! They'll think\nI'm a big, mean jerk!\n\n",
+      "new": "What's the deal??? Why do\nyou write me these pointless\nletters? I can't show this to\nmy friends! They'll think\nI'm a big, mean jerk!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 134,
+      "label": "",
+      "original": "Thank you for writing, but it\nwas such a trivial letter.\nYou're much more interesting\nin person. Can't you put\na little personality into\nyour next letter?\n",
+      "new": "Thank you for writing, but it\nwas such a trivial letter.\nYou're much more interesting\nin person. Can't you put\na little personality into\nyour next letter?\n"
+    },
+    {
+      "group": "mail",
+      "index": 135,
+      "label": "",
+      "original": "Thanks for your letter.\nIt would be nice if you'd\ntake the time to write a bit\nmore, though. I like reading\nabout your life. I hope you\nlike getting clothes!\n",
+      "new": "Thanks for your letter.\nIt would be nice if you'd\ntake the time to write a bit\nmore, though. I like reading\nabout your life. I hope you\nlike getting clothes!\n"
+    },
+    {
+      "group": "mail",
+      "index": 136,
+      "label": "",
+      "original": "Yoo-hoo! Thanks for the\nletter, but I'd be much more\ngrateful if you'd written\nmore! Tell you what: wear\nthis outfit, then write me\nand tell me how you like it!\n",
+      "new": "Yoo-hoo! Thanks for the\nletter, but I'd be much more\ngrateful if you'd written\nmore! Tell you what: wear\nthis outfit, then write me\nand tell me how you like it!\n"
+    },
+    {
+      "group": "mail",
+      "index": 137,
+      "label": "",
+      "original": "Thanks for the letter, but it\nreally felt like you just\nwanted to send something,\nand you didn't pay attention\nto your writing. Next time,\nwrite me about this outfit.\n",
+      "new": "Thanks for the letter, but it\nreally felt like you just\nwanted to send something,\nand you didn't pay attention\nto your writing. Next time,\nwrite me about this outfit.\n"
+    },
+    {
+      "group": "mail",
+      "index": 138,
+      "label": "",
+      "original": "Yo! I got your letter. But it\nwas short. I wanted a longer\nletter! ...Not that this one's\nall that long. Oh, hey, want\nthese clothes? I hope you\nlike them.\n",
+      "new": "Yo! I got your letter. But it\nwas short. I wanted a longer\nletter! ...Not that this one's\nall that long. Oh, hey, want\nthese clothes? I hope you\nlike them.\n"
+    },
+    {
+      "group": "mail",
+      "index": 139,
+      "label": "",
+      "original": "Thanks for that depressing\nletter. Just 'cause you wrote\na lot doesn't mean it's good.\nHere are some clothes, so\nwrite me again. But make the\nnext one more interesting.\n",
+      "new": "Thanks for that depressing\nletter. Just 'cause you wrote\na lot doesn't mean it's good.\nHere are some clothes, so\nwrite me again. But make the\nnext one more interesting.\n"
+    },
+    {
+      "group": "mail",
+      "index": 140,
+      "label": "",
+      "original": "Thanks for your brief note.\nAre you a lazy writer?\nBecause it'd be nice if you'd\nwrite more. Then I could\nshow it to someone. Anyway,\nwrite me again soon!\n",
+      "new": "Thanks for your brief note.\nAre you a lazy writer?\nBecause it'd be nice if you'd\nwrite more. Then I could\nshow it to someone. Anyway,\nwrite me again soon!\n"
+    },
+    {
+      "group": "mail",
+      "index": 141,
+      "label": "",
+      "original": "Thanks for the letter.\nYou seem kind of lonely,\nand since you wrote me,\nI've decided to send you\n<<STR_FREE0>>. I hope\nyou like it.\n",
+      "new": "Thanks for the letter.\nYou seem kind of lonely,\nand since you wrote me,\nI've decided to send you\n<<STR_FREE0>>. I hope\nyou like it.\n"
+    },
+    {
+      "group": "mail",
+      "index": 142,
+      "label": "",
+      "original": "Thanks for dropping me a\nline! I'm gonna show that\nletter to everyone I know!\nOh, want <<STR_FREE0>>?\nI don't, so you can have it!\n\n",
+      "new": "Thanks for dropping me a\nline! I'm gonna show that\nletter to everyone I know!\nOh, want <<STR_FREE0>>?\nI don't, so you can have it!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 143,
+      "label": "",
+      "original": "I was wondering when\nsomeone might send me a\nletter. Thanks. Talking takes\na lot out of me, so I really\nlike getting letters.\n\n",
+      "new": "I was wondering when\nsomeone might send me a\nletter. Thanks. Talking takes\na lot out of me, so I really\nlike getting letters.\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 144,
+      "label": "",
+      "original": "Hey! How's it going? Thanks\nfor the letter. I'm going to\nshow it off to my pals next\ntime I get the chance!\nI guarantee it!\n\n",
+      "new": "Hey! How's it going? Thanks\nfor the letter. I'm going to\nshow it off to my pals next\ntime I get the chance!\nI guarantee it!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 145,
+      "label": "",
+      "original": "Thanks. Your letter wasn't\nas painful as I thought it\nwas going to be. Anyway, I\nfigured I ought to write a\nresponse. I'm done now.\n\n",
+      "new": "Thanks. Your letter wasn't\nas painful as I thought it\nwas going to be. Anyway, I\nfigured I ought to write a\nresponse. I'm done now.\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 146,
+      "label": "",
+      "original": "Your letter was very frank,\nvery sincere. I didn't expect\nthat of you, so thank you.\nI hope you have need of\n<<STR_FREE0>>, because\nthat's what I'm sending you.\n",
+      "new": "Your letter was very frank,\nvery sincere. I didn't expect\nthat of you, so thank you.\nI hope you have need of\n<<STR_FREE0>>, because\nthat's what I'm sending you.\n"
+    },
+    {
+      "group": "mail",
+      "index": 147,
+      "label": "",
+      "original": "Thanks for your letter.\nI was so happy to find it\nin my box! I've decided\nthat you can have this...\nConsider it my way of\nsaying thanks.\n",
+      "new": "Thanks for your letter.\nI was so happy to find it\nin my box! I've decided\nthat you can have this...\nConsider it my way of\nsaying thanks.\n"
+    },
+    {
+      "group": "mail",
+      "index": 148,
+      "label": "",
+      "original": "Thanks soooo much for the\nletter! It was so long! I so\nloved it! As a matter of\nfact, I'm in such a good\nmood, I want you to have\nthis <<CUTARTICLE>><<STR_FREE0>>.\n",
+      "new": "Thanks soooo much for the\nletter! It was so long! I so\nloved it! As a matter of\nfact, I'm in such a good\nmood, I want you to have\nthis <<CUTARTICLE>><<STR_FREE0>>.\n"
+    },
+    {
+      "group": "mail",
+      "index": 149,
+      "label": "",
+      "original": "Thanks. I like long letters.\nIt did make me a bit sleepy\nthough, but that's always a\ngood thing. If you write me\nagain, I promise I'll try to\nread all the way to the end!\n",
+      "new": "Thanks. I like long letters.\nIt did make me a bit sleepy\nthough, but that's always a\ngood thing. If you write me\nagain, I promise I'll try to\nread all the way to the end!\n"
+    },
+    {
+      "group": "mail",
+      "index": 150,
+      "label": "",
+      "original": "Right on! That was a great\nletter! Don't feel like you\nhave to write so much next\ntime! It made my head hurt!\nOh, I found this in the back\nof my closet. Want it?\n",
+      "new": "Right on! That was a great\nletter! Don't feel like you\nhave to write so much next\ntime! It made my head hurt!\nOh, I found this in the back\nof my closet. Want it?\n"
+    },
+    {
+      "group": "mail",
+      "index": 151,
+      "label": "",
+      "original": "I got your letter. I haven't\nread it yet, though. I like\nwriting responses before\nreading the letter. You know,\njust in case....\n\n",
+      "new": "I got your letter. I haven't\nread it yet, though. I like\nwriting responses before\nreading the letter. You know,\njust in case....\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 152,
+      "label": "",
+      "original": "Thanks for that novel you\nwrote me. Anyhow, I was\ncleaning my room, and I\nfound this old piece of junk.\nIt looked like something\nyou'd like, so here, take it.\n",
+      "new": "Thanks for that novel you\nwrote me. Anyhow, I was\ncleaning my room, and I\nfound this old piece of junk.\nIt looked like something\nyou'd like, so here, take it.\n"
+    },
+    {
+      "group": "mail",
+      "index": 153,
+      "label": "",
+      "original": "Thanks for that weird letter.\nI really liked the gift you\nsent. Anyway, I thought I'd\nbetter send you something.\nHave some fruit, and be sure\nto write again!\n",
+      "new": "Thanks for that weird letter.\nI really liked the gift you\nsent. Anyway, I thought I'd\nbetter send you something.\nHave some fruit, and be sure\nto write again!\n"
+    },
+    {
+      "group": "mail",
+      "index": 154,
+      "label": "",
+      "original": "Hello there! I saw your\nletter! It was totally\nfreakish! But it was so cool\nof you to send a present, so\nI'll let it slide! Plus, I'm\nsending you a gift in return!\n",
+      "new": "Hello there! I saw your\nletter! It was totally\nfreakish! But it was so cool\nof you to send a present, so\nI'll let it slide! Plus, I'm\nsending you a gift in return!\n"
+    },
+    {
+      "group": "mail",
+      "index": 155,
+      "label": "",
+      "original": "That was the weirdest letter\nI ever got. That's cool. That\npresent you sent was even\ncooler! I like presents. Send\nme stuff again sometime!\n\n",
+      "new": "That was the weirdest letter\nI ever got. That's cool. That\npresent you sent was even\ncooler! I like presents. Send\nme stuff again sometime!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 156,
+      "label": "",
+      "original": "Wow! Thanks for the gift!\nThat letter was pretty wack,\nthough. So, you wanna play\nfootball sometime? It builds\ncharacter, trust me!\n\n",
+      "new": "Wow! Thanks for the gift!\nThat letter was pretty wack,\nthough. So, you wanna play\nfootball sometime? It builds\ncharacter, trust me!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 157,
+      "label": "",
+      "original": "That was the oddest thing\nI'd ever read! It was like a\nwatching a artsy movie\nunfold on paper! The present\nmade up for it, though.\n\n",
+      "new": "That was the oddest thing\nI'd ever read! It was like a\nwatching a artsy movie\nunfold on paper! The present\nmade up for it, though.\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 158,
+      "label": "",
+      "original": "You don't really know how\nto write good notes, do you?\nLittle presents can't hide a\nlack of writing skills. Here,\nI'll give you this, so maybe\nyou'll try harder next time.\n",
+      "new": "You don't really know how\nto write good notes, do you?\nLittle presents can't hide a\nlack of writing skills. Here,\nI'll give you this, so maybe\nyou'll try harder next time.\n"
+    },
+    {
+      "group": "mail",
+      "index": 159,
+      "label": "",
+      "original": "Hello. Thanks for your\nletter! Your present had me\nso excited, I skimmed over\nmost of it. Here's a present\nfor you. I hope you like it.\n\n",
+      "new": "Hello. Thanks for your\nletter! Your present had me\nso excited, I skimmed over\nmost of it. Here's a present\nfor you. I hope you like it.\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 160,
+      "label": "",
+      "original": "Hello? Are you there? That\npresent you sent me was\njust the greatest ever!!\nThe letter, well...never mind.\nI don't want to bring you\ndown. But here, take this!\n",
+      "new": "Hello? Are you there? That\npresent you sent me was\njust the greatest ever!!\nThe letter, well...never mind.\nI don't want to bring you\ndown. But here, take this!\n"
+    },
+    {
+      "group": "mail",
+      "index": 161,
+      "label": "",
+      "original": "Thanks for the present. I\nlove getting surprises.\nI also like giving surprises,\nso here. It's not much, but\nit's the thought that counts,\nam I right?\n",
+      "new": "Thanks for the present. I\nlove getting surprises.\nI also like giving surprises,\nso here. It's not much, but\nit's the thought that counts,\nam I right?\n"
+    },
+    {
+      "group": "mail",
+      "index": 162,
+      "label": "",
+      "original": "Yowza! How you doin'? Did I\njust write that? Anyway,\nthanks for the present. It\ntotally rocked! I was SO not\nnot expecting it!\n\n",
+      "new": "Yowza! How you doin'? Did I\njust write that? Anyway,\nthanks for the present. It\ntotally rocked! I was SO not\nnot expecting it!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 163,
+      "label": "",
+      "original": "Thanks for the letter, but\nwhat's the deal? You think\nI owe you now? Is that why\nyou sent me a gift? You're\nso transparent. Well, here!\nNow you owe me!\n",
+      "new": "Thanks for the letter, but\nwhat's the deal? You think\nI owe you now? Is that why\nyou sent me a gift? You're\nso transparent. Well, here!\nNow you owe me!\n"
+    },
+    {
+      "group": "mail",
+      "index": 164,
+      "label": "",
+      "original": "You've gotten so good at\npleasing me. Assaulting me\nwith presents is the only\nway. It's a great strategy.\nKeep it up! Who knows\nwhere it could lead....\n",
+      "new": "You've gotten so good at\npleasing me. Assaulting me\nwith presents is the only\nway. It's a great strategy.\nKeep it up! Who knows\nwhere it could lead....\n"
+    },
+    {
+      "group": "mail",
+      "index": 165,
+      "label": "",
+      "original": "Thanks for writing me a\nletter like I asked. I didn't\nexpect to get a gift, too!\nYou can write me anytime.\n\n\n",
+      "new": "Thanks for writing me a\nletter like I asked. I didn't\nexpect to get a gift, too!\nYou can write me anytime.\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 166,
+      "label": "",
+      "original": "Hi! How are you? I'm great!\nReally great! And it's all\nbecause I got a great gift.\nHere! You can have these\nclothes. They're hard to find\naround here.\n",
+      "new": "Hi! How are you? I'm great!\nReally great! And it's all\nbecause I got a great gift.\nHere! You can have these\nclothes. They're hard to find\naround here.\n"
+    },
+    {
+      "group": "mail",
+      "index": 167,
+      "label": "",
+      "original": "Thanks! I liked the letter.\nOh, and thanks for the\npresent, too! Here are some\nclothes. They're too small\nfor me anyway.\n\n",
+      "new": "Thanks! I liked the letter.\nOh, and thanks for the\npresent, too! Here are some\nclothes. They're too small\nfor me anyway.\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 168,
+      "label": "",
+      "original": "You totally rock! Letters!\nPresents! I never had such a\ngenerous friend! I feel bad\ngetting all this stuff, so\nhere are some old clothes I\nhad lying around!\n",
+      "new": "You totally rock! Letters!\nPresents! I never had such a\ngenerous friend! I feel bad\ngetting all this stuff, so\nhere are some old clothes I\nhad lying around!\n"
+    },
+    {
+      "group": "mail",
+      "index": 169,
+      "label": "",
+      "original": "Thanks for that letter. And\nthe gift. There. I said it.\nIt's not even like it was a\ngood letter or anything. Here\nare some clothes I had lying\naround. They're all yours.\n",
+      "new": "Thanks for that letter. And\nthe gift. There. I said it.\nIt's not even like it was a\ngood letter or anything. Here\nare some clothes I had lying\naround. They're all yours.\n"
+    },
+    {
+      "group": "mail",
+      "index": 170,
+      "label": "",
+      "original": "Thanks for that letter. Could\nyou MAKE it any longer? The\npresent was great, but the\nletter just dragged on!\nStill, I have a gift for you.\nI hope you'll take it.\n",
+      "new": "Thanks for that letter. Could\nyou MAKE it any longer? The\npresent was great, but the\nletter just dragged on!\nStill, I have a gift for you.\nI hope you'll take it.\n"
+    },
+    {
+      "group": "mail",
+      "index": 171,
+      "label": "",
+      "original": "Thanks for your letter.\nThat gift was wonderful!\nI managed to get my hands\non some fruit that we don't\nusually see around here.\nI'll share it with you!\n",
+      "new": "Thanks for your letter.\nThat gift was wonderful!\nI managed to get my hands\non some fruit that we don't\nusually see around here.\nI'll share it with you!\n"
+    },
+    {
+      "group": "mail",
+      "index": 172,
+      "label": "",
+      "original": "I can't believe you wrote!\nAnd a present, too? I'm so\nflattered! And you're so\nsweet! So, I'm sending you\nsome of the sweetest fruit\nyou'll ever find! Enjoy!\n",
+      "new": "I can't believe you wrote!\nAnd a present, too? I'm so\nflattered! And you're so\nsweet! So, I'm sending you\nsome of the sweetest fruit\nyou'll ever find! Enjoy!\n"
+    },
+    {
+      "group": "mail",
+      "index": 173,
+      "label": "",
+      "original": "Thanks for the note and the\npackage. It put me in such a\ngood mood, I went out and\ngot you a gift. Here's hoping\nyou like fruit.\n\n",
+      "new": "Thanks for the note and the\npackage. It put me in such a\ngood mood, I went out and\ngot you a gift. Here's hoping\nyou like fruit.\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 174,
+      "label": "",
+      "original": "Thank you so much for the\nletter! You're awesome. Hey,\na friend of mine just sent\nme some fruit. You want\nsome? Maybe you can grow\nan orchard or something!\n",
+      "new": "Thank you so much for the\nletter! You're awesome. Hey,\na friend of mine just sent\nme some fruit. You want\nsome? Maybe you can grow\nan orchard or something!\n"
+    },
+    {
+      "group": "mail",
+      "index": 175,
+      "label": "",
+      "original": "Wow! A present? What did I\ndo to deserve that? Don't I\nfeel special! Well, here's\na present for you. See? I'm\nnot such a bad guy.\n\n",
+      "new": "Wow! A present? What did I\ndo to deserve that? Don't I\nfeel special! Well, here's\na present for you. See? I'm\nnot such a bad guy.\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 176,
+      "label": "",
+      "original": "Thank you for the package.\nIt was very nice of you.\nThat's the way to make\nfriendsーlots of gifts.\nHere's a little something\nfor you. I hope you enjoy it!\n",
+      "new": "Thank you for the package.\nIt was very nice of you.\nThat's the way to make\nfriendsーlots of gifts.\nHere's a little something\nfor you. I hope you enjoy it!\n"
+    },
+    {
+      "group": "mail",
+      "index": 177,
+      "label": "",
+      "original": "Thank you so much for that\ndelightful present. You don't\nhave to go to all that\ntrouble, though. I'm happy\nenough just to get a letter!\nStill, it was very nice.\n",
+      "new": "Thank you so much for that\ndelightful present. You don't\nhave to go to all that\ntrouble, though. I'm happy\nenough just to get a letter!\nStill, it was very nice.\n"
+    },
+    {
+      "group": "mail",
+      "index": 178,
+      "label": "",
+      "original": "Hi there! How are you? I\ncouldn't be better! You know\nwhy? Because of that present\nyou sent me, silly! Thanks\nso much! Here's a little\nsurprise for you!\n",
+      "new": "Hi there! How are you? I\ncouldn't be better! You know\nwhy? Because of that present\nyou sent me, silly! Thanks\nso much! Here's a little\nsurprise for you!\n"
+    },
+    {
+      "group": "mail",
+      "index": 179,
+      "label": "",
+      "original": "Thank you for the letter...\nand for the present. It was\njust what I needed. In case\nyou couldn't tell, it put me\nin a great mood. Here's\n<<STR_FREE0>> for you.\n",
+      "new": "Thank you for the letter...\nand for the present. It was\njust what I needed. In case\nyou couldn't tell, it put me\nin a great mood. Here's\n<<STR_FREE0>> for you.\n"
+    },
+    {
+      "group": "mail",
+      "index": 180,
+      "label": "",
+      "original": "Yo! Your letters are so wild!\nI need more! Especially the\nones with gifts. Those are\nthe best, and so are you!\n\nI'm serious!\n",
+      "new": "Yo! Your letters are so wild!\nI need more! Especially the\nones with gifts. Those are\nthe best, and so are you!\n\nI'm serious!\n"
+    },
+    {
+      "group": "mail",
+      "index": 181,
+      "label": "",
+      "original": "That package you sent me\nwas cool. Thanks! You're not\nso bad after all. I can't\nwait get your next package!\n\nIt better be good!\n",
+      "new": "That package you sent me\nwas cool. Thanks! You're not\nso bad after all. I can't\nwait get your next package!\n\nIt better be good!\n"
+    },
+    {
+      "group": "mail",
+      "index": 182,
+      "label": "",
+      "original": "Thank you so much for that\nletter. Are you even reading\nthis, or did you just go\nstraight to the gift I sent\nyou? You're so impatient!\nHere's <<STR_FREE0>>.\n",
+      "new": "Thank you so much for that\nletter. Are you even reading\nthis, or did you just go\nstraight to the gift I sent\nyou? You're so impatient!\nHere's <<STR_FREE0>>.\n"
+    },
+    {
+      "group": "mail",
+      "index": 183,
+      "label": "",
+      "original": "I'm amazed! I was only\nexpecting to get a letter,\nbut you sent a present,\ntoo? I hope you'll always\nbe this nice to me!\n\n",
+      "new": "I'm amazed! I was only\nexpecting to get a letter,\nbut you sent a present,\ntoo? I hope you'll always\nbe this nice to me!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 184,
+      "label": "",
+      "original": "Hello! Hi! Yoo-hoo! It's me!\nI can't thank you enough for\nthat letter. I hope you'll\nsend me more soon.\nI promise to write back. \nWait...I just did!\n",
+      "new": "Hello! Hi! Yoo-hoo! It's me!\nI can't thank you enough for\nthat letter. I hope you'll\nsend me more soon.\nI promise to write back. \nWait...I just did!\n"
+    },
+    {
+      "group": "mail",
+      "index": 185,
+      "label": "",
+      "original": "That letter you sent me was\nthe most uplifting thing I've\never received. Please send\nmore. I'm waiting. I'll be\ncrashed in bed until then.\n\n",
+      "new": "That letter you sent me was\nthe most uplifting thing I've\never received. Please send\nmore. I'm waiting. I'll be\ncrashed in bed until then.\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 186,
+      "label": "",
+      "original": "I got a letter! That rocks!\nDude, you're so cool. And\nseriously, I loved the gift!\nNot that I'm asking for more\npresents...but hey! I'm not\nstopping you! Right on.\n",
+      "new": "I got a letter! That rocks!\nDude, you're so cool. And\nseriously, I loved the gift!\nNot that I'm asking for more\npresents...but hey! I'm not\nstopping you! Right on.\n"
+    },
+    {
+      "group": "mail",
+      "index": 187,
+      "label": "",
+      "original": "Hey! You! Yeah you!!!\nThanks for the letter.\nAnd send me more soon!\nGot that?\n\n\n",
+      "new": "Hey! You! Yeah you!!!\nThanks for the letter.\nAnd send me more soon!\nGot that?\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 188,
+      "label": "",
+      "original": "How've you been? I've been\nfabulous, but then, I always\nam! Especially since I got\nthat splendid note from you.\nIt was a pleasant surprise.\nI love surprises. Tee hee!\n",
+      "new": "How've you been? I've been\nfabulous, but then, I always\nam! Especially since I got\nthat splendid note from you.\nIt was a pleasant surprise.\nI love surprises. Tee hee!\n"
+    },
+    {
+      "group": "mail",
+      "index": 189,
+      "label": "",
+      "original": "The Farway Museum cordially\ninvites you to take part in\nits free fossil identification\nprogram. Send us any fossil\nyou find, and we'll identify\nit and return it promptly.\n",
+      "new": "The Farway Museum cordially\ninvites you to take part in\nits free fossil identification\nprogram. Send us any fossil\nyou find, and we'll identify\nit and return it promptly.\n"
+    },
+    {
+      "group": "mail",
+      "index": 190,
+      "label": "",
+      "original": "Thank you very much for\nyour recent donation to the\nmuseum. Your generosity has\nprovided a much-needed\nboost to our research.\nThanks for your support! \n",
+      "new": "Thank you very much for\nyour recent donation to the\nmuseum. Your generosity has\nprovided a much-needed\nboost to our research.\nThanks for your support! \n"
+    },
+    {
+      "group": "mail",
+      "index": 191,
+      "label": "",
+      "original": "We are pleased to inform you\nthat we have identified the\nfossil you recently sent us.\nIt is <<STR_FREE0>>.\nExcellent find!\n\n",
+      "new": "We are pleased to inform you\nthat we have identified the\nfossil you recently sent us.\nIt is <<STR_FREE0>>.\nExcellent find!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 192,
+      "label": "",
+      "original": "ç÷\n\n\n\n\n\n",
+      "new": "ç÷\n\n\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 193,
+      "label": "",
+      "original": "ç÷\n\n\n\n\n\n",
+      "new": "ç÷\n\n\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 194,
+      "label": "",
+      "original": "ç÷\n\n\n\n\n\n",
+      "new": "ç÷\n\n\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 195,
+      "label": "",
+      "original": "ç÷\n\n\n\n\n\n",
+      "new": "ç÷\n\n\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 196,
+      "label": "",
+      "original": "ç÷\n\n\n\n\n\n",
+      "new": "ç÷\n\n\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 197,
+      "label": "",
+      "original": "You call that a letter?\nI have absolutely no idea\nwhat you were trying to say.\nI like getting mail as much\nas the next girl, but not if\nI can't understand it!\n",
+      "new": "You call that a letter?\nI have absolutely no idea\nwhat you were trying to say.\nI like getting mail as much\nas the next girl, but not if\nI can't understand it!\n"
+    },
+    {
+      "group": "mail",
+      "index": 198,
+      "label": "",
+      "original": "I guess I should thank you\nfor your letter, but to be\nhonest, I had no idea what\nyou were trying to say.\nIt just made me feel like\nI'm not smart enough.\n",
+      "new": "I guess I should thank you\nfor your letter, but to be\nhonest, I had no idea what\nyou were trying to say.\nIt just made me feel like\nI'm not smart enough.\n"
+    },
+    {
+      "group": "mail",
+      "index": 199,
+      "label": "",
+      "original": "Are you trying to play a\njoke on me? Is that your\nidea of fun, writing letters\nthat no one can understand?\nWell, I had no idea what\nall that stuff meant.\n",
+      "new": "Are you trying to play a\njoke on me? Is that your\nidea of fun, writing letters\nthat no one can understand?\nWell, I had no idea what\nall that stuff meant.\n"
+    },
+    {
+      "group": "mail",
+      "index": 200,
+      "label": "",
+      "original": "Hey! Seriously, don't send me\nweird letters, OK? I mean,\nwhat in the world were you\ntalking about? And what's\nwith all those big words,\nprofessor? You lost me!\n",
+      "new": "Hey! Seriously, don't send me\nweird letters, OK? I mean,\nwhat in the world were you\ntalking about? And what's\nwith all those big words,\nprofessor? You lost me!\n"
+    },
+    {
+      "group": "mail",
+      "index": 201,
+      "label": "",
+      "original": "Hi there! I totally tried to\nread your letter and all, but\nI just couldn't get it! Was\nit, like, some sort of code\nor something? Or do you\nnot know how to write?\n",
+      "new": "Hi there! I totally tried to\nread your letter and all, but\nI just couldn't get it! Was\nit, like, some sort of code\nor something? Or do you\nnot know how to write?\n"
+    },
+    {
+      "group": "mail",
+      "index": 202,
+      "label": "",
+      "original": "Hey, listen! I think you're\nnice and all, but don't keep\nsending me these creepy\nletters! I mean, the last one\nmade NO sense, and it really\nfreaked me out! Seriously!\n",
+      "new": "Hey, listen! I think you're\nnice and all, but don't keep\nsending me these creepy\nletters! I mean, the last one\nmade NO sense, and it really\nfreaked me out! Seriously!\n"
+    },
+    {
+      "group": "mail",
+      "index": 203,
+      "label": "",
+      "original": "Well...uh...thanks for the\nnote, I guess. But here's the\nthing: I didn't have a clue\nwhat you were trying to say.\nNext time, try to make some\nsense. Simplify, dude!\n",
+      "new": "Well...uh...thanks for the\nnote, I guess. But here's the\nthing: I didn't have a clue\nwhat you were trying to say.\nNext time, try to make some\nsense. Simplify, dude!\n"
+    },
+    {
+      "group": "mail",
+      "index": 204,
+      "label": "",
+      "original": "Hey, thanks for the letter.\nIt was sort of a bummer\nthat I didn't understand it,\nthough. How about next time\nyou make it a little simpler,\nhuh? That'd be real cool.\n",
+      "new": "Hey, thanks for the letter.\nIt was sort of a bummer\nthat I didn't understand it,\nthough. How about next time\nyou make it a little simpler,\nhuh? That'd be real cool.\n"
+    },
+    {
+      "group": "mail",
+      "index": 205,
+      "label": "",
+      "original": "What was the deal with your\nletter? Man, if I had a Bell\nfor every note I didn't 'get,'\nI'd have...well, I'd have some\nBells, that's for sure! Could\nyou be a little more clear?\n",
+      "new": "What was the deal with your\nletter? Man, if I had a Bell\nfor every note I didn't 'get,'\nI'd have...well, I'd have some\nBells, that's for sure! Could\nyou be a little more clear?\n"
+    },
+    {
+      "group": "mail",
+      "index": 206,
+      "label": "",
+      "original": "Hold up, neighbor! Just what\nthe hey was up with that\nwacked-out letter? Don't go\ncutting corners when you\nwrite me! You were making\nno sense! Write a REAL note!\n",
+      "new": "Hold up, neighbor! Just what\nthe hey was up with that\nwacked-out letter? Don't go\ncutting corners when you\nwrite me! You were making\nno sense! Write a REAL note!\n"
+    },
+    {
+      "group": "mail",
+      "index": 207,
+      "label": "",
+      "original": "What in the world are you\ntalking about? That letter\nboggled my mind, big time!\nNext time, if you get it into\nyour head to write me, send\nsomething easier to read!\n",
+      "new": "What in the world are you\ntalking about? That letter\nboggled my mind, big time!\nNext time, if you get it into\nyour head to write me, send\nsomething easier to read!\n"
+    },
+    {
+      "group": "mail",
+      "index": 208,
+      "label": "",
+      "original": "Huh, <<STR_FREE0>>?\nAre you nuts? That letter\nmade absolutely no sense!\nI opened it up, all pumped,\nand it was a huge letdown!\nI got psyched for nothing!\n",
+      "new": "Huh, <<STR_FREE0>>?\nAre you nuts? That letter\nmade absolutely no sense!\nI opened it up, all pumped,\nand it was a huge letdown!\nI got psyched for nothing!\n"
+    },
+    {
+      "group": "mail",
+      "index": 209,
+      "label": "",
+      "original": "Yeah, you! When you send a\nletter to somebody, it really\nhelps if the letter makes\njust a tiny bit of SENSE! Do\nwe understand each other?\n\n",
+      "new": "Yeah, you! When you send a\nletter to somebody, it really\nhelps if the letter makes\njust a tiny bit of SENSE! Do\nwe understand each other?\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 210,
+      "label": "",
+      "original": "Hey, <<STR_FREE0>>! I know\nI may not be the smartest\nguy in the world, but you\ndon't have to draw attention\nto it! Next time you write,\ntry making some sense!\n",
+      "new": "Hey, <<STR_FREE0>>! I know\nI may not be the smartest\nguy in the world, but you\ndon't have to draw attention\nto it! Next time you write,\ntry making some sense!\n"
+    },
+    {
+      "group": "mail",
+      "index": 211,
+      "label": "",
+      "original": "Stop it, already! I give up!\nYour letters are too\nconfusing! They're giving me\na migraine! Have mercy! \nPlease, I'm begging you!\n\n",
+      "new": "Stop it, already! I give up!\nYour letters are too\nconfusing! They're giving me\na migraine! Have mercy! \nPlease, I'm begging you!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 212,
+      "label": "",
+      "original": "I simply wasn't able to\ncomprehend the meaning of\nyour bizarre letter. It might\nhelp to use easier words.\nI can't be bothered to look\nup every word you write.\n",
+      "new": "I simply wasn't able to\ncomprehend the meaning of\nyour bizarre letter. It might\nhelp to use easier words.\nI can't be bothered to look\nup every word you write.\n"
+    },
+    {
+      "group": "mail",
+      "index": 213,
+      "label": "",
+      "original": "Is this your idea of fun?\nSending letters to me you\nknow I won't understand?\nWell, I'll have you know\nthat I think you're terribly\nmean! Mean mean MEAN!\n",
+      "new": "Is this your idea of fun?\nSending letters to me you\nknow I won't understand?\nWell, I'll have you know\nthat I think you're terribly\nmean! Mean mean MEAN!\n"
+    },
+    {
+      "group": "mail",
+      "index": 214,
+      "label": "",
+      "original": "Look, I give up. I tried my\nbest to understand your note,\nbut I just couldn't do it.\nCouldn't you try to write in\nplain English next time?\nIt would make things easier.\n",
+      "new": "Look, I give up. I tried my\nbest to understand your note,\nbut I just couldn't do it.\nCouldn't you try to write in\nplain English next time?\nIt would make things easier.\n"
+    },
+    {
+      "group": "mail",
+      "index": 215,
+      "label": "",
+      "original": "Happy Holidays!!!\n\nHere's your present, straight\nfrom Jingle's workshop!\n\n\n",
+      "new": "Happy Holidays!!!\n\nHere's your present, straight\nfrom Jingle's workshop!\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 216,
+      "label": "",
+      "original": "You came an awfully long\nway just to send me a note...\nand I couldn't even read it!\nIf you're going to go to all\nthat trouble, you ought\nto at least make sense!\n",
+      "new": "You came an awfully long\nway just to send me a note...\nand I couldn't even read it!\nIf you're going to go to all\nthat trouble, you ought\nto at least make sense!\n"
+    },
+    {
+      "group": "mail",
+      "index": 217,
+      "label": "",
+      "original": "It was so sweet of you to\ncome visit! And thanks so\nmuch for that letter...even\nthough it WAS kind of hard\nto read. I guess I just need\nto study a bit more! Bye!\n",
+      "new": "It was so sweet of you to\ncome visit! And thanks so\nmuch for that letter...even\nthough it WAS kind of hard\nto read. I guess I just need\nto study a bit more! Bye!\n"
+    },
+    {
+      "group": "mail",
+      "index": 218,
+      "label": "",
+      "original": "I'm sorry, but that letter of\nyours was too hard to read!\nI feel bad, too, because\nI know you came a long way\nto send it. You should write\na simpler one next time.\n",
+      "new": "I'm sorry, but that letter of\nyours was too hard to read!\nI feel bad, too, because\nI know you came a long way\nto send it. You should write\na simpler one next time.\n"
+    },
+    {
+      "group": "mail",
+      "index": 219,
+      "label": "",
+      "original": "You silly goose! Don't send\nme a copy of your thesis!\nI want letters I can read,\nnot these totally weird,\ncomplicated messes! Or was\nthat your idea of a joke?\n",
+      "new": "You silly goose! Don't send\nme a copy of your thesis!\nI want letters I can read,\nnot these totally weird,\ncomplicated messes! Or was\nthat your idea of a joke?\n"
+    },
+    {
+      "group": "mail",
+      "index": 220,
+      "label": "",
+      "original": "OK, maybe I've been, like,\nliving in a cave for a while,\nbut I just don't understand\nwhy someone would travel so\nfar just to send a letter\nthat makes so little sense...\n",
+      "new": "OK, maybe I've been, like,\nliving in a cave for a while,\nbut I just don't understand\nwhy someone would travel so\nfar just to send a letter\nthat makes so little sense...\n"
+    },
+    {
+      "group": "mail",
+      "index": 221,
+      "label": "",
+      "original": "Time out, super-freak! Who\nwrites letters like that?\nIt went right over my head!\nNext time you bother to\nsend me a letter, try sending\none I'll understand! Jeepers!\n",
+      "new": "Time out, super-freak! Who\nwrites letters like that?\nIt went right over my head!\nNext time you bother to\nsend me a letter, try sending\none I'll understand! Jeepers!\n"
+    },
+    {
+      "group": "mail",
+      "index": 222,
+      "label": "",
+      "original": "What a stupendous letdown.\nI was wicked stoked about\ngetting your letter, but when\nI read it, it gave me a\nheadache. Help me out here,\n<<STR_FREE0>>! Cripes!\n",
+      "new": "What a stupendous letdown.\nI was wicked stoked about\ngetting your letter, but when\nI read it, it gave me a\nheadache. Help me out here,\n<<STR_FREE0>>! Cripes!\n"
+    },
+    {
+      "group": "mail",
+      "index": 223,
+      "label": "",
+      "original": "I got your letter, but either\nI'm really spaced out or you\ncan't write so good. I just\ndidn't get it! You'd better\nstart writing more clearly,\nknow what I'm saying?\n",
+      "new": "I got your letter, but either\nI'm really spaced out or you\ncan't write so good. I just\ndidn't get it! You'd better\nstart writing more clearly,\nknow what I'm saying?\n"
+    },
+    {
+      "group": "mail",
+      "index": 224,
+      "label": "",
+      "original": "What's the story with that\nweird letter you sent me?\nMaybe it's just me, but if I\nwent that far just to send\na letter, I'd want the person\nwho got it to get it. Got it?\n",
+      "new": "What's the story with that\nweird letter you sent me?\nMaybe it's just me, but if I\nwent that far just to send\na letter, I'd want the person\nwho got it to get it. Got it?\n"
+    },
+    {
+      "group": "mail",
+      "index": 225,
+      "label": "",
+      "original": "Hey, Einstein, what was up\nwith that letter? You think\nI'm some kind of brainiac or\nsomething? I couldn't\nunderstand a word of it!\nDumb it down, will ya?\n",
+      "new": "Hey, Einstein, what was up\nwith that letter? You think\nI'm some kind of brainiac or\nsomething? I couldn't\nunderstand a word of it!\nDumb it down, will ya?\n"
+    },
+    {
+      "group": "mail",
+      "index": 226,
+      "label": "",
+      "original": "Listen, seriously, if you're\ngoing to send me a letter,\nsend me one I want to read,\n<<STR_FREE0>>! That last\none gave me the old\nbrain-pain something fierce!\n",
+      "new": "Listen, seriously, if you're\ngoing to send me a letter,\nsend me one I want to read,\n<<STR_FREE0>>! That last\none gave me the old\nbrain-pain something fierce!\n"
+    },
+    {
+      "group": "mail",
+      "index": 227,
+      "label": "",
+      "original": "Whoa! You are seriously out\nthere! You came all the way\nhere to send me a note that\nread like it was written by a\nchimp! You are W-E-I-R-D!\nGet it together!\n ",
+      "new": "Whoa! You are seriously out\nthere! You came all the way\nhere to send me a note that\nread like it was written by a\nchimp! You are W-E-I-R-D!\nGet it together!\n "
+    },
+    {
+      "group": "mail",
+      "index": 228,
+      "label": "",
+      "original": "To be frank, I have much\nbetter things to do with my\ntime than to read your epic,\nbabbling nonsense. Whatever\nit meant, I didn't get it.\nNor do I wish to.\n",
+      "new": "To be frank, I have much\nbetter things to do with my\ntime than to read your epic,\nbabbling nonsense. Whatever\nit meant, I didn't get it.\nNor do I wish to.\n"
+    },
+    {
+      "group": "mail",
+      "index": 229,
+      "label": "",
+      "original": "All right, you comedian!\nYou think you're funny, huh?\nSure, travel way out here to\nsend me a letter you knew I\nwouldn't understand. Ha ha.\nFunny. I won't forget this!\n",
+      "new": "All right, you comedian!\nYou think you're funny, huh?\nSure, travel way out here to\nsend me a letter you knew I\nwouldn't understand. Ha ha.\nFunny. I won't forget this!\n"
+    },
+    {
+      "group": "mail",
+      "index": 230,
+      "label": "",
+      "original": "What theー? Look, if you\nwant to write a letter, write\na short note, not a master's\nthesis! I didn't understand\nword one. You'd do well to\nremember I like easy reads!\n",
+      "new": "What theー? Look, if you\nwant to write a letter, write\na short note, not a master's\nthesis! I didn't understand\nword one. You'd do well to\nremember I like easy reads!\n"
+    },
+    {
+      "group": "mail",
+      "index": 231,
+      "label": "",
+      "original": "I'm flattered that you think\nso highly of my intellect,\nbut sadly, I must admit that\nI didn't understand a word\nof your note. Be a bit more\ncommon next time, hmmm?\n",
+      "new": "I'm flattered that you think\nso highly of my intellect,\nbut sadly, I must admit that\nI didn't understand a word\nof your note. Be a bit more\ncommon next time, hmmm?\n"
+    },
+    {
+      "group": "mail",
+      "index": 232,
+      "label": "",
+      "original": "Do you ENJOY teasing me\nwith odd, unreadable letters?\nIs it fun for you? I know\nsome folks think I'm snooty,\nbut I have feelings, same as\nanybody, so don't be mean!\n",
+      "new": "Do you ENJOY teasing me\nwith odd, unreadable letters?\nIs it fun for you? I know\nsome folks think I'm snooty,\nbut I have feelings, same as\nanybody, so don't be mean!\n"
+    },
+    {
+      "group": "mail",
+      "index": 233,
+      "label": "",
+      "original": "I put quite a bit of effort\ninto understanding your\nletter, but I'm afraid it was\nall for naught. You simply\nmust simplify your letters!\nPerhaps next time?\n",
+      "new": "I put quite a bit of effort\ninto understanding your\nletter, but I'm afraid it was\nall for naught. You simply\nmust simplify your letters!\nPerhaps next time?\n"
+    },
+    {
+      "group": "mail",
+      "index": 234,
+      "label": "",
+      "original": "Happy birthday!\n\nNever lose that cheery\noutlook on life!\n\n\n",
+      "new": "Happy birthday!\n\nNever lose that cheery\noutlook on life!\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 235,
+      "label": "",
+      "original": "Happy birthday, \n<<STR_FREE0>>!!\n\nNo matter how many years\nmay pass, I hope you'll \nalways remain my friend.\n",
+      "new": "Happy birthday, \n<<STR_FREE0>>!!\n\nNo matter how many years\nmay pass, I hope you'll \nalways remain my friend.\n"
+    },
+    {
+      "group": "mail",
+      "index": 236,
+      "label": "",
+      "original": "Congratulations, <<STR_FREE0>>!\nYou're one year older!\n\nThis is sort of a silly\npresent, but it's the best\nI could find. Enjoy!\n",
+      "new": "Congratulations, <<STR_FREE0>>!\nYou're one year older!\n\nThis is sort of a silly\npresent, but it's the best\nI could find. Enjoy!\n"
+    },
+    {
+      "group": "mail",
+      "index": 237,
+      "label": "",
+      "original": "Happy birthday to you♪\n\nI hope you won't think\nyou're too old to hang out\nwith me anymore!\nHa ha! Just kidding!\n",
+      "new": "Happy birthday to you♪\n\nI hope you won't think\nyou're too old to hang out\nwith me anymore!\nHa ha! Just kidding!\n"
+    },
+    {
+      "group": "mail",
+      "index": 238,
+      "label": "",
+      "original": "Hey there! A very happy\nbirthday to you!\n\nI had absolutely no idea\nwhat to get you! Oh, well.\nThe thought counts, right?\n",
+      "new": "Hey there! A very happy\nbirthday to you!\n\nI had absolutely no idea\nwhat to get you! Oh, well.\nThe thought counts, right?\n"
+    },
+    {
+      "group": "mail",
+      "index": 239,
+      "label": "",
+      "original": "Happy birthday!\n\nI got you this great\n<<CUTARTICLE>><<STR_FREE2>>! Hope\nyou like it!\n\n",
+      "new": "Happy birthday!\n\nI got you this great\n<<CUTARTICLE>><<STR_FREE2>>! Hope\nyou like it!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 240,
+      "label": "",
+      "original": "Well, you did it. You're a\nyear older! Congratulations!\n\nHere's hoping you'll never\nget too old to be my pal!\n\n",
+      "new": "Well, you did it. You're a\nyear older! Congratulations!\n\nHere's hoping you'll never\nget too old to be my pal!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 241,
+      "label": "",
+      "original": "♪Happy birthday, dear\n<<STR_FREE0>>♪\nYou're my best friend in the\nwhole village! Seriously!\nI hope you like this\n<<CUTARTICLE>><<STR_FREE2>>.\n",
+      "new": "♪Happy birthday, dear\n<<STR_FREE0>>♪\nYou're my best friend in the\nwhole village! Seriously!\nI hope you like this\n<<CUTARTICLE>><<STR_FREE2>>.\n"
+    },
+    {
+      "group": "mail",
+      "index": 242,
+      "label": "",
+      "original": "Happy B-day!\n\nIt always brings a smile to\nmy face when one of my best\nfriends has a birthday!\n\n",
+      "new": "Happy B-day!\n\nIt always brings a smile to\nmy face when one of my best\nfriends has a birthday!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 243,
+      "label": "",
+      "original": "Happy birthday,\n<<STR_FREE0>>! Remember,\nbirthdays only come once\na year, so be sure to enjoy\nthis one to the fullest.\nSpoil yourself!\n",
+      "new": "Happy birthday,\n<<STR_FREE0>>! Remember,\nbirthdays only come once\na year, so be sure to enjoy\nthis one to the fullest.\nSpoil yourself!\n"
+    },
+    {
+      "group": "mail",
+      "index": 244,
+      "label": "",
+      "original": "Have the happiest of\nbirthdays, <<STR_FREE0>>!\n\nI decided to get you\n<<STR_FREE2>>. I hope you\nlike it!\n",
+      "new": "Have the happiest of\nbirthdays, <<STR_FREE0>>!\n\nI decided to get you\n<<STR_FREE2>>. I hope you\nlike it!\n"
+    },
+    {
+      "group": "mail",
+      "index": 245,
+      "label": "",
+      "original": "Happy birthday, \n<<STR_FREE0>>! You're one\nof my best friends, and\nI put a lot of work into \nfinding you a gift, so you'd\nbetter like it!\n",
+      "new": "Happy birthday, \n<<STR_FREE0>>! You're one\nof my best friends, and\nI put a lot of work into \nfinding you a gift, so you'd\nbetter like it!\n"
+    },
+    {
+      "group": "mail",
+      "index": 246,
+      "label": "",
+      "original": "Hey, <<STR_FREE0>>!\nHappy birthday!\n\nWe all know you're older;\nlet's hope you're wiser, too!\nAah ha ha har!\n",
+      "new": "Hey, <<STR_FREE0>>!\nHappy birthday!\n\nWe all know you're older;\nlet's hope you're wiser, too!\nAah ha ha har!\n"
+    },
+    {
+      "group": "mail",
+      "index": 247,
+      "label": "",
+      "original": "You're one year older\nnow, <<STR_FREE0>>.\n\nThe you of today is more \nyou than the you of\nyesterday. You get me?\n",
+      "new": "You're one year older\nnow, <<STR_FREE0>>.\n\nThe you of today is more \nyou than the you of\nyesterday. You get me?\n"
+    },
+    {
+      "group": "mail",
+      "index": 248,
+      "label": "",
+      "original": "Well, don't that beat all!\nYou got yourself a birthday!\nYou know, you're always\nhooking me up with favors,\nso I went and hooked you up\nwith a nice present. Enjoy!\n",
+      "new": "Well, don't that beat all!\nYou got yourself a birthday!\nYou know, you're always\nhooking me up with favors,\nso I went and hooked you up\nwith a nice present. Enjoy!\n"
+    },
+    {
+      "group": "mail",
+      "index": 249,
+      "label": "",
+      "original": "Happy birthday to you!\n\nNo matter how many years\nsettle on your shoulders, I\nhope you stay just the same.\n\n",
+      "new": "Happy birthday to you!\n\nNo matter how many years\nsettle on your shoulders, I\nhope you stay just the same.\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 250,
+      "label": "",
+      "original": "HAPPY BIRTHDAY,\n<<STR_FREE0>>! You're\nalways doing such nice\nthings for me, so I've taken\nthe time to send this\nbirthday gift for you.\n",
+      "new": "HAPPY BIRTHDAY,\n<<STR_FREE0>>! You're\nalways doing such nice\nthings for me, so I've taken\nthe time to send this\nbirthday gift for you.\n"
+    },
+    {
+      "group": "mail",
+      "index": 251,
+      "label": "",
+      "original": "Word on the street is you're\na year older now, so happy\nbirthday! Or is it? Is any\nbirthday truly happy?\nAnyway, please accept this\n<<CUTARTICLE>><<STR_FREE2>>. Bye!\n",
+      "new": "Word on the street is you're\na year older now, so happy\nbirthday! Or is it? Is any\nbirthday truly happy?\nAnyway, please accept this\n<<CUTARTICLE>><<STR_FREE2>>. Bye!\n"
+    },
+    {
+      "group": "mail",
+      "index": 252,
+      "label": "",
+      "original": "Hi, <<STR_FREE0>>! I was just\nwriting to let you know I've\nmoved to <<STR_FREE2>>! I\nhope you'll come visit me\nsomeday soon. I'll keep an\neye out for you!\n",
+      "new": "Hi, <<STR_FREE0>>! I was just\nwriting to let you know I've\nmoved to <<STR_FREE2>>! I\nhope you'll come visit me\nsomeday soon. I'll keep an\neye out for you!\n"
+    },
+    {
+      "group": "mail",
+      "index": 253,
+      "label": "",
+      "original": "Hi there! I decided to move,\nand I just wanted to thank\nyou for everything you did\nfor me in <<STR_FREE3>>. I \nreally appreciate it, and I\nhope you'll come visit me.\n",
+      "new": "Hi there! I decided to move,\nand I just wanted to thank\nyou for everything you did\nfor me in <<STR_FREE3>>. I \nreally appreciate it, and I\nhope you'll come visit me.\n"
+    },
+    {
+      "group": "mail",
+      "index": 254,
+      "label": "",
+      "original": "I've just gotten settled after\nmy move to <<STR_FREE2>>.\nI certainly hope you'll come\nvisit me in my new house at\nleast onceーif you don't,\nI'll be mad!\n",
+      "new": "I've just gotten settled after\nmy move to <<STR_FREE2>>.\nI certainly hope you'll come\nvisit me in my new house at\nleast onceーif you don't,\nI'll be mad!\n"
+    },
+    {
+      "group": "mail",
+      "index": 255,
+      "label": "",
+      "original": "Hi there, <<STR_FREE0>>!\nI figured I'd drop you a\nquick note to say that I've\nmoved to <<STR_FREE2>>...but\nyou knew that already, didn't\nyou! Be sure to come visit!\n",
+      "new": "Hi there, <<STR_FREE0>>!\nI figured I'd drop you a\nquick note to say that I've\nmoved to <<STR_FREE2>>...but\nyou knew that already, didn't\nyou! Be sure to come visit!\n"
+    },
+    {
+      "group": "mail",
+      "index": 256,
+      "label": "",
+      "original": "I know it's spontaneous, but\nI decided I HAD to move!\nI just couldn't help myself!\nI had fun in <<STR_FREE3>>.\nI won't forget you!\n\n",
+      "new": "I know it's spontaneous, but\nI decided I HAD to move!\nI just couldn't help myself!\nI had fun in <<STR_FREE3>>.\nI won't forget you!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 257,
+      "label": "",
+      "original": "Hi, <<STR_FREE0>>! You're\ngonna flip when you hear\nthis, but I just moved to\n<<STR_FREE2>>! I know it's\nkind of far, but I hope\nyou'll come visit! Toodles!\n",
+      "new": "Hi, <<STR_FREE0>>! You're\ngonna flip when you hear\nthis, but I just moved to\n<<STR_FREE2>>! I know it's\nkind of far, but I hope\nyou'll come visit! Toodles!\n"
+    },
+    {
+      "group": "mail",
+      "index": 258,
+      "label": "",
+      "original": "Hey, <<STR_FREE0>>. Of course,\nleaving <<STR_FREE3>> means\nI won't be seeing you much,\nbut I'll never forget you,\nand...there was something\nelse...but I forget. Oh well.\n",
+      "new": "Hey, <<STR_FREE0>>. Of course,\nleaving <<STR_FREE3>> means\nI won't be seeing you much,\nbut I'll never forget you,\nand...there was something\nelse...but I forget. Oh well.\n"
+    },
+    {
+      "group": "mail",
+      "index": 259,
+      "label": "",
+      "original": "I managed to motivate myself\nto move to <<STR_FREE2>>.\nCrazy, huh? Anyhoo, there\nare tons of cool dudes here.\nYou oughta visit. Who knows\nwhen I'll be out your way?\n",
+      "new": "I managed to motivate myself\nto move to <<STR_FREE2>>.\nCrazy, huh? Anyhoo, there\nare tons of cool dudes here.\nYou oughta visit. Who knows\nwhen I'll be out your way?\n"
+    },
+    {
+      "group": "mail",
+      "index": 260,
+      "label": "",
+      "original": "So I up and moved the other\nday. Out of the blue, I know.\nWhat can I say? I live in\nlovely <<STR_FREE2>> now. You\nshould buy a house-warming\npresent and pop by sometime.\n",
+      "new": "So I up and moved the other\nday. Out of the blue, I know.\nWhat can I say? I live in\nlovely <<STR_FREE2>> now. You\nshould buy a house-warming\npresent and pop by sometime.\n"
+    },
+    {
+      "group": "mail",
+      "index": 261,
+      "label": "",
+      "original": "Yo! <<STR_FREE0>>! How goes\nit? You know I moved to\n<<STR_FREE2>>, right?\nI wish we could still hang,\nbut I guess I'll manage out\nhere until you come visit.\n",
+      "new": "Yo! <<STR_FREE0>>! How goes\nit? You know I moved to\n<<STR_FREE2>>, right?\nI wish we could still hang,\nbut I guess I'll manage out\nhere until you come visit.\n"
+    },
+    {
+      "group": "mail",
+      "index": 262,
+      "label": "",
+      "original": "Hey, I left for <<STR_FREE2>>.\nYeah, I know we had a lot\nof fun together living in old\n<<STR_FREE3>>, but the fun\ndoesn't have to end now that\nI live here! Visit, will ya?\n",
+      "new": "Hey, I left for <<STR_FREE2>>.\nYeah, I know we had a lot\nof fun together living in old\n<<STR_FREE3>>, but the fun\ndoesn't have to end now that\nI live here! Visit, will ya?\n"
+    },
+    {
+      "group": "mail",
+      "index": 263,
+      "label": "",
+      "original": "Don't take this wrong, but I\njust moved to scenic\n<<STR_FREE2>>. I know it's\nsudden, but you can drop me\na line if you're ever in the\nneighborhood, right?\n",
+      "new": "Don't take this wrong, but I\njust moved to scenic\n<<STR_FREE2>>. I know it's\nsudden, but you can drop me\na line if you're ever in the\nneighborhood, right?\n"
+    },
+    {
+      "group": "mail",
+      "index": 264,
+      "label": "",
+      "original": "This doesn't have anything\nto do with you, but I moved.\nThat's right: I'm living in\n<<STR_FREE2>>. We may still\nbump into each other, so\ndon't cry or anything, OK?\n",
+      "new": "This doesn't have anything\nto do with you, but I moved.\nThat's right: I'm living in\n<<STR_FREE2>>. We may still\nbump into each other, so\ndon't cry or anything, OK?\n"
+    },
+    {
+      "group": "mail",
+      "index": 265,
+      "label": "",
+      "original": "I'm moving to <<STR_FREE2>>.\nUs being acquaintances and\nall, I thought I should tell\nyou. So...I guess, thanks for\neverything, and drop by if\nyou're ever in town. Bye.\n",
+      "new": "I'm moving to <<STR_FREE2>>.\nUs being acquaintances and\nall, I thought I should tell\nyou. So...I guess, thanks for\neverything, and drop by if\nyou're ever in town. Bye.\n"
+    },
+    {
+      "group": "mail",
+      "index": 266,
+      "label": "",
+      "original": "Hello, <<STR_FREE0>>. It was\nnice knowing you, I suppose,\nbut, tragically, this is\ngoodbye. I'm moving to\n<<STR_FREE2>>. Have a\nnice life, if you must.\n",
+      "new": "Hello, <<STR_FREE0>>. It was\nnice knowing you, I suppose,\nbut, tragically, this is\ngoodbye. I'm moving to\n<<STR_FREE2>>. Have a\nnice life, if you must.\n"
+    },
+    {
+      "group": "mail",
+      "index": 267,
+      "label": "",
+      "original": "Hello, <<STR_FREE0>>! Guess\nwhat! I'm in <<STR_FREE2>>,\nand I'm not coming back! \nI'm sure the village won't be\nthe same without me, but\nsuch is life.\n",
+      "new": "Hello, <<STR_FREE0>>! Guess\nwhat! I'm in <<STR_FREE2>>,\nand I'm not coming back! \nI'm sure the village won't be\nthe same without me, but\nsuch is life.\n"
+    },
+    {
+      "group": "mail",
+      "index": 268,
+      "label": "",
+      "original": "Hi there! You're doing well,\nI hope. I've moved! I live\nin <<STR_FREE2>> now, so\nmake sure you come see me\nonce in a while. And you'd\nbetter visit, or I'll pout!\n",
+      "new": "Hi there! You're doing well,\nI hope. I've moved! I live\nin <<STR_FREE2>> now, so\nmake sure you come see me\nonce in a while. And you'd\nbetter visit, or I'll pout!\n"
+    },
+    {
+      "group": "mail",
+      "index": 269,
+      "label": "",
+      "original": "You've been a good friend,\n<<STR_FREE0>>, but I can't\nspend my whole life in\n<<STR_FREE3>>. I have to\nget out and see the world. I\nhope our paths cross again!\n",
+      "new": "You've been a good friend,\n<<STR_FREE0>>, but I can't\nspend my whole life in\n<<STR_FREE3>>. I have to\nget out and see the world. I\nhope our paths cross again!\n"
+    },
+    {
+      "group": "mail",
+      "index": 270,
+      "label": "",
+      "original": "The fossil you recently sent\nus is a valuable triceratops\nskullーand in excellent\nshape! We return this fine\nspecimen to you and eagerly\nawait any future submissions.\n",
+      "new": "The fossil you recently sent\nus is a valuable triceratops\nskullーand in excellent\nshape! We return this fine\nspecimen to you and eagerly\nawait any future submissions.\n"
+    },
+    {
+      "group": "mail",
+      "index": 271,
+      "label": "",
+      "original": "The fossil you recently sent\nus is a fantastic triceratops\ntorsoーquite an amazing find!\nWe now return the specimen\nto you, and we look forward\nto your future submissions.\n",
+      "new": "The fossil you recently sent\nus is a fantastic triceratops\ntorsoーquite an amazing find!\nWe now return the specimen\nto you, and we look forward\nto your future submissions.\n"
+    },
+    {
+      "group": "mail",
+      "index": 272,
+      "label": "",
+      "original": "The fossil you recently sent\nus is a valuable triceratops\ntailーand in remarkable\ncondition! We have enclosed\nthe specimen, and we eagerly\nawait any future submissions.\n",
+      "new": "The fossil you recently sent\nus is a valuable triceratops\ntailーand in remarkable\ncondition! We have enclosed\nthe specimen, and we eagerly\nawait any future submissions.\n"
+    },
+    {
+      "group": "mail",
+      "index": 273,
+      "label": "",
+      "original": "The fossil you recently sent\nus is the skull of a vicious\nT-rexーand the teeth are still\nsharp! We return this fine\nspecimen to you and eagerly\nawait future submissions.\n",
+      "new": "The fossil you recently sent\nus is the skull of a vicious\nT-rexーand the teeth are still\nsharp! We return this fine\nspecimen to you and eagerly\nawait future submissions.\n"
+    },
+    {
+      "group": "mail",
+      "index": 274,
+      "label": "",
+      "original": "The fossil you recently sent\nus is the torso of a T-rex,\nsavage predator of the\nCretaceous! We return this\nspecimen to you and eagerly\nawait future submissions.\n",
+      "new": "The fossil you recently sent\nus is the torso of a T-rex,\nsavage predator of the\nCretaceous! We return this\nspecimen to you and eagerly\nawait future submissions.\n"
+    },
+    {
+      "group": "mail",
+      "index": 275,
+      "label": "",
+      "original": "The fossil you submitted to\nus is the tail of the vicious\nT-rex, the scourge of the\nCretaceous! We return this\nspecimen to you and eagerly\nawait any future submissions.\n",
+      "new": "The fossil you submitted to\nus is the tail of the vicious\nT-rex, the scourge of the\nCretaceous! We return this\nspecimen to you and eagerly\nawait any future submissions.\n"
+    },
+    {
+      "group": "mail",
+      "index": 276,
+      "label": "",
+      "original": "The fossil you sent us is the\nskull of an apatosaurus.\nA small head for such a big\ncreature! We return this fine\nspecimen to you and eagerly\nawait future submissions.\n",
+      "new": "The fossil you sent us is the\nskull of an apatosaurus.\nA small head for such a big\ncreature! We return this fine\nspecimen to you and eagerly\nawait future submissions.\n"
+    },
+    {
+      "group": "mail",
+      "index": 277,
+      "label": "",
+      "original": "The fossil you recently sent\nus is an apatosaurus torso.\nThese massive creatures\nweighed around 35 tons!\nWe now return the torso and\nawait future submissions.\n",
+      "new": "The fossil you recently sent\nus is an apatosaurus torso.\nThese massive creatures\nweighed around 35 tons!\nWe now return the torso and\nawait future submissions.\n"
+    },
+    {
+      "group": "mail",
+      "index": 278,
+      "label": "",
+      "original": "The fossil you recently sent\nus is an apatosaurus tail.\nWe hereby return this fine\nspecimen to you, and look\nforward to your future\nsubmissions. Happy hunting!\n",
+      "new": "The fossil you recently sent\nus is an apatosaurus tail.\nWe hereby return this fine\nspecimen to you, and look\nforward to your future\nsubmissions. Happy hunting!\n"
+    },
+    {
+      "group": "mail",
+      "index": 279,
+      "label": "",
+      "original": "The fossil you sent us is a\nskull of a stegosaurus, a\ncreature that thrived during\nthe late Jurassic. We return\nthis specimen to you and\nawait future submissions.\n",
+      "new": "The fossil you sent us is a\nskull of a stegosaurus, a\ncreature that thrived during\nthe late Jurassic. We return\nthis specimen to you and\nawait future submissions.\n"
+    },
+    {
+      "group": "mail",
+      "index": 280,
+      "label": "",
+      "original": "The fossil you recently sent\nis a rare stegosaurus torsoー\nnote the impressive plates on\nits spine! We return this\nspecimen to you and eagerly\nawait any future submissions.\n",
+      "new": "The fossil you recently sent\nis a rare stegosaurus torsoー\nnote the impressive plates on\nits spine! We return this\nspecimen to you and eagerly\nawait any future submissions.\n"
+    },
+    {
+      "group": "mail",
+      "index": 281,
+      "label": "",
+      "original": "The fossil you submitted is\nan extremely rare stegosaurus\ntailーtake a gander at those\nspikes! We return your\nspecimen to you and eagerly\nawait future submissions.\n",
+      "new": "The fossil you submitted is\nan extremely rare stegosaurus\ntailーtake a gander at those\nspikes! We return your\nspecimen to you and eagerly\nawait future submissions.\n"
+    },
+    {
+      "group": "mail",
+      "index": 282,
+      "label": "",
+      "original": "The fossil you sent is the\nskull of a flying pteranodon,\nan aviator of the Cretaceous\nperiod. We return your fine\nspecimen and await any\nfuture submissions.\n",
+      "new": "The fossil you sent is the\nskull of a flying pteranodon,\nan aviator of the Cretaceous\nperiod. We return your fine\nspecimen and await any\nfuture submissions.\n"
+    },
+    {
+      "group": "mail",
+      "index": 283,
+      "label": "",
+      "original": "The fossil you sent is the\nright wing of a pteranodon,\nscourge of the Cretaceous\nskies! We return your\nspecimen and eagerly await\nfuture submissions.\n",
+      "new": "The fossil you sent is the\nright wing of a pteranodon,\nscourge of the Cretaceous\nskies! We return your\nspecimen and eagerly await\nfuture submissions.\n"
+    },
+    {
+      "group": "mail",
+      "index": 284,
+      "label": "",
+      "original": "The fossil you sent is the\nleft wing of a pteranodon,\nan airborne menace of the\nCretaceous period! We\nreturn your specimen and\nawait future submissions.\n",
+      "new": "The fossil you sent is the\nleft wing of a pteranodon,\nan airborne menace of the\nCretaceous period! We\nreturn your specimen and\nawait future submissions.\n"
+    },
+    {
+      "group": "mail",
+      "index": 285,
+      "label": "",
+      "original": "The fossil you recently sent\nus is the skull of an ocean-\ndwelling plesiosaur. We now\nreturn this fine specimen to\nyou and eagerly await future\nsubmissions. Happy hunting!\n",
+      "new": "The fossil you recently sent\nus is the skull of an ocean-\ndwelling plesiosaur. We now\nreturn this fine specimen to\nyou and eagerly await future\nsubmissions. Happy hunting!\n"
+    },
+    {
+      "group": "mail",
+      "index": 286,
+      "label": "",
+      "original": "The fossil you sent is the\nneck of an ocean-dwelling\nplesiosaur, terror of the\ndeep. We return this fine\nspecimen to you, and eagerly\nawait any future submissions.\n",
+      "new": "The fossil you sent is the\nneck of an ocean-dwelling\nplesiosaur, terror of the\ndeep. We return this fine\nspecimen to you, and eagerly\nawait any future submissions.\n"
+    },
+    {
+      "group": "mail",
+      "index": 287,
+      "label": "",
+      "original": "The fossil you recently sent\nus is the torso of an ocean-\ndwelling plesiosaur. We are\nreturning the specimen to\nyou, and we eagerly await\nfuture submissions.\n",
+      "new": "The fossil you recently sent\nus is the torso of an ocean-\ndwelling plesiosaur. We are\nreturning the specimen to\nyou, and we eagerly await\nfuture submissions.\n"
+    },
+    {
+      "group": "mail",
+      "index": 288,
+      "label": "",
+      "original": "The fossil you submitted is a\nmammoth skull. These fine\nbeasts went extinct a\nrelatively short while ago.\nWe are returning your fossil.\nWe await future submissions.\n",
+      "new": "The fossil you submitted is a\nmammoth skull. These fine\nbeasts went extinct a\nrelatively short while ago.\nWe are returning your fossil.\nWe await future submissions.\n"
+    },
+    {
+      "group": "mail",
+      "index": 289,
+      "label": "",
+      "original": "The fossil you recently sent\nis the torso of a mammoth\nthat went extinct a relatively\nshort time ago. We return\nthis specimen to you and\nawait future submissions.\n",
+      "new": "The fossil you recently sent\nis the torso of a mammoth\nthat went extinct a relatively\nshort time ago. We return\nthis specimen to you and\nawait future submissions.\n"
+    },
+    {
+      "group": "mail",
+      "index": 290,
+      "label": "",
+      "original": "The fossil you recently sent\nus is a trilobite, an ancient\nlife-form. We hereby return\nthis fine specimen to you\nand eagerly await future\nsubmissions. Happy hunting!\n",
+      "new": "The fossil you recently sent\nus is a trilobite, an ancient\nlife-form. We hereby return\nthis fine specimen to you\nand eagerly await future\nsubmissions. Happy hunting!\n"
+    },
+    {
+      "group": "mail",
+      "index": 291,
+      "label": "",
+      "original": "The fossil you recently sent\nus is an ammoniteーan\nancient ocean dweller. We\nhereby return this specimen\nto you and eagerly await\nfuture submissions.\n",
+      "new": "The fossil you recently sent\nus is an ammoniteーan\nancient ocean dweller. We\nhereby return this specimen\nto you and eagerly await\nfuture submissions.\n"
+    },
+    {
+      "group": "mail",
+      "index": 292,
+      "label": "",
+      "original": "The fossil you recently sent\nus is a dinosaur eggーif only\nit could hatch! We hereby\nreturn this fine specimen to\nyou, and eagerly await future\nsubmissions. Happy hunting!\n",
+      "new": "The fossil you recently sent\nus is a dinosaur eggーif only\nit could hatch! We hereby\nreturn this fine specimen to\nyou, and eagerly await future\nsubmissions. Happy hunting!\n"
+    },
+    {
+      "group": "mail",
+      "index": 293,
+      "label": "",
+      "original": "The fossil you recently sent\nus is a dinosaur track,\npreserved in mud ages ago.\nWe hereby return this fine\nspecimen to you and eagerly\nawait future submissions.\n",
+      "new": "The fossil you recently sent\nus is a dinosaur track,\npreserved in mud ages ago.\nWe hereby return this fine\nspecimen to you and eagerly\nawait future submissions.\n"
+    },
+    {
+      "group": "mail",
+      "index": 294,
+      "label": "",
+      "original": "The fossil you recently sent\nus is amber, a durable resin\nin which many fossils are\npreserved. We hereby return\nthis specimen to you and\nawait future submissions.\n",
+      "new": "The fossil you recently sent\nus is amber, a durable resin\nin which many fossils are\npreserved. We hereby return\nthis specimen to you and\nawait future submissions.\n"
+    },
+    {
+      "group": "mail",
+      "index": 295,
+      "label": "",
+      "original": "\n\n\n\n\n\n",
+      "new": "\n\n\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 296,
+      "label": "",
+      "original": "\n\n\n\n\n\n",
+      "new": "\n\n\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 297,
+      "label": "",
+      "original": "\n\n\n\n\n\n",
+      "new": "\n\n\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 298,
+      "label": "",
+      "original": "\n\n\n\n\n\n",
+      "new": "\n\n\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 299,
+      "label": "",
+      "original": "\n\n\n\n\n\n",
+      "new": "\n\n\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 300,
+      "label": "",
+      "original": "I was thinking of you the \nother day as I made some\ncoffee. And when I went to\ntake a sip of it, it was the\nworst pot of coffee I've ever\nmade! Why would that be?\n",
+      "new": "I was thinking of you the \nother day as I made some\ncoffee. And when I went to\ntake a sip of it, it was the\nworst pot of coffee I've ever\nmade! Why would that be?\n"
+    },
+    {
+      "group": "mail",
+      "index": 301,
+      "label": "",
+      "original": "I got this on saleーyou know\nhow your mom loves to hunt\nthe wild bargain!\nAnyway, it didn't look good\non me when I got home, so\nI'll give it to you. Enjoy it!\n",
+      "new": "I got this on saleーyou know\nhow your mom loves to hunt\nthe wild bargain!\nAnyway, it didn't look good\non me when I got home, so\nI'll give it to you. Enjoy it!\n"
+    },
+    {
+      "group": "mail",
+      "index": 302,
+      "label": "",
+      "original": "Well, I just got back from a\nshort trip. I love traveling\nby train! Around every bend\nof the track there are new\nadventures, new people, and\nnew memories to be made...\n",
+      "new": "Well, I just got back from a\nshort trip. I love traveling\nby train! Around every bend\nof the track there are new\nadventures, new people, and\nnew memories to be made...\n"
+    },
+    {
+      "group": "mail",
+      "index": 303,
+      "label": "",
+      "original": "Our neighbor had a bunch\nof these. I'm already way\ntoo fullーI really overdid it! \nWhy don't you have some?\nThe way you eat, I'm sure\nyou're just skin and bones!\n",
+      "new": "Our neighbor had a bunch\nof these. I'm already way\ntoo fullーI really overdid it! \nWhy don't you have some?\nThe way you eat, I'm sure\nyou're just skin and bones!\n"
+    },
+    {
+      "group": "mail",
+      "index": 304,
+      "label": "",
+      "original": "What shows up even if you\nlock all your doors? Your\nbirthday! HAHAHA! Ohhh,\nmercy! You should be happy\nyour mother has such a\ngood sense of humor!\n",
+      "new": "What shows up even if you\nlock all your doors? Your\nbirthday! HAHAHA! Ohhh,\nmercy! You should be happy\nyour mother has such a\ngood sense of humor!\n"
+    },
+    {
+      "group": "mail",
+      "index": 305,
+      "label": "",
+      "original": "Horror of horrors! I found a\nwrinkle today! Am I getting\nold? Say...you don't get\nuncomfortable hearing about\nthis sort of thing, do you?\n\n",
+      "new": "Horror of horrors! I found a\nwrinkle today! Am I getting\nold? Say...you don't get\nuncomfortable hearing about\nthis sort of thing, do you?\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 306,
+      "label": "",
+      "original": "Would it kill you to visit\nyour folks once in a while?\nWe miss you! I think about\nyou often, and your dad...\nWell, he misses you, too,\nbut you know how he is.\n",
+      "new": "Would it kill you to visit\nyour folks once in a while?\nWe miss you! I think about\nyou often, and your dad...\nWell, he misses you, too,\nbut you know how he is.\n"
+    },
+    {
+      "group": "mail",
+      "index": 307,
+      "label": "",
+      "original": "Try not to take this the\nwrong way, hon, but...you've\nalways been a bit slow.\nWhich is fine! But that's\nwhy you should always take\nthings at your own pace.\n",
+      "new": "Try not to take this the\nwrong way, hon, but...you've\nalways been a bit slow.\nWhich is fine! But that's\nwhy you should always take\nthings at your own pace.\n"
+    },
+    {
+      "group": "mail",
+      "index": 308,
+      "label": "",
+      "original": "I saw this woman at the\nstore letting her horrid kids\nrun amok! One of the little\nbrats kicked me in the shin,\nand before I knew it, I stuck\nmy tongue out at him!\n",
+      "new": "I saw this woman at the\nstore letting her horrid kids\nrun amok! One of the little\nbrats kicked me in the shin,\nand before I knew it, I stuck\nmy tongue out at him!\n"
+    },
+    {
+      "group": "mail",
+      "index": 309,
+      "label": "",
+      "original": "I found an old love letter\naddressed to you while I\nwas cleaning out the attic.\nI didn't READ it...but I may\nhave PEEKED. You know, to\nmake sure it wasn't a bill.\n",
+      "new": "I found an old love letter\naddressed to you while I\nwas cleaning out the attic.\nI didn't READ it...but I may\nhave PEEKED. You know, to\nmake sure it wasn't a bill.\n"
+    },
+    {
+      "group": "mail",
+      "index": 310,
+      "label": "",
+      "original": "Being filled with doubt and\nuncertainty is just part of\nbeing young. Don't worry so\nmuch, my dear! Even adults\nlive with doubt and regret;\nall you can do is just live!\n",
+      "new": "Being filled with doubt and\nuncertainty is just part of\nbeing young. Don't worry so\nmuch, my dear! Even adults\nlive with doubt and regret;\nall you can do is just live!\n"
+    },
+    {
+      "group": "mail",
+      "index": 311,
+      "label": "",
+      "original": "Well, just got back! We had\nsuch a great time on our\nfirst trip abroad. There was\none small hitch, though: I\nwoke up really late, and I\nhad to travel in my P.J.s!\n",
+      "new": "Well, just got back! We had\nsuch a great time on our\nfirst trip abroad. There was\none small hitch, though: I\nwoke up really late, and I\nhad to travel in my P.J.s!\n"
+    },
+    {
+      "group": "mail",
+      "index": 312,
+      "label": "",
+      "original": "I found 10,000 Bells while\n\"cleaning\" your dad's desk.\nLooks like I've a date with\nsome fancy new shoes!\nP.S. Here's your share.\nThis is our little secret!\n",
+      "new": "I found 10,000 Bells while\n\"cleaning\" your dad's desk.\nLooks like I've a date with\nsome fancy new shoes!\nP.S. Here's your share.\nThis is our little secret!\n"
+    },
+    {
+      "group": "mail",
+      "index": 313,
+      "label": "",
+      "original": "I was so excited to start\nmy new jazz dancing class...\nuntil some big-haired ditz\nin an ugly leotard told me\nit looked like I was\nsquare-dancing! The nerve!\n",
+      "new": "I was so excited to start\nmy new jazz dancing class...\nuntil some big-haired ditz\nin an ugly leotard told me\nit looked like I was\nsquare-dancing! The nerve!\n"
+    },
+    {
+      "group": "mail",
+      "index": 314,
+      "label": "",
+      "original": "You've been through a lot,\nand had a hard go of it\nsometimes, but you've always\ndone your best. It's all you\nCAN do! ...Just once, I wish\nsomeone would tell me that.\n",
+      "new": "You've been through a lot,\nand had a hard go of it\nsometimes, but you've always\ndone your best. It's all you\nCAN do! ...Just once, I wish\nsomeone would tell me that.\n"
+    },
+    {
+      "group": "mail",
+      "index": 315,
+      "label": "",
+      "original": "I hate to say it, but your\nmom's been going a little\ngrey lately. There's a little\nsnow on the mountains! I'm\nyoung at heart, though, so\nI'm dying my hair purple!\n",
+      "new": "I hate to say it, but your\nmom's been going a little\ngrey lately. There's a little\nsnow on the mountains! I'm\nyoung at heart, though, so\nI'm dying my hair purple!\n"
+    },
+    {
+      "group": "mail",
+      "index": 316,
+      "label": "",
+      "original": "I found where your father\nhides the credit cards, so I\ndid some shopping on one of\nthose 800 numbers. I went a\nbit overboard: you can have\nthis, but promise to wear it!\n",
+      "new": "I found where your father\nhides the credit cards, so I\ndid some shopping on one of\nthose 800 numbers. I went a\nbit overboard: you can have\nthis, but promise to wear it!\n"
+    },
+    {
+      "group": "mail",
+      "index": 317,
+      "label": "",
+      "original": "Ooh, is your mother a\nfinancial whiz or what?\nI made an absolute killing \non the turnip market a\nwhile ago, so I...well, I\nturned your room into a spa!\n",
+      "new": "Ooh, is your mother a\nfinancial whiz or what?\nI made an absolute killing \non the turnip market a\nwhile ago, so I...well, I\nturned your room into a spa!\n"
+    },
+    {
+      "group": "mail",
+      "index": 318,
+      "label": "",
+      "original": "I found an old picture of\nyou and me the other day.\nOh, I looked so young!\nYou looked OKーyou were\nsmiling, I think, but WOW!\nYour mom sure was a looker!\n",
+      "new": "I found an old picture of\nyou and me the other day.\nOh, I looked so young!\nYou looked OKーyou were\nsmiling, I think, but WOW!\nYour mom sure was a looker!\n"
+    },
+    {
+      "group": "mail",
+      "index": 319,
+      "label": "",
+      "original": "I found some of your old\ncomics and a box marked\n\"Precious Collectibles\" when\nI was tidying the house the\nother day. I tossed them\nout. You don't mind, do you?\n",
+      "new": "I found some of your old\ncomics and a box marked\n\"Precious Collectibles\" when\nI was tidying the house the\nother day. I tossed them\nout. You don't mind, do you?\n"
+    },
+    {
+      "group": "mail",
+      "index": 320,
+      "label": "",
+      "original": "I decided I could stand to\nlose a few pounds, so I\nstarted doing aerobics. What\na fiasco... It's a long story,\nbut your dad ended up\ncalling the fire department.\n",
+      "new": "I decided I could stand to\nlose a few pounds, so I\nstarted doing aerobics. What\na fiasco... It's a long story,\nbut your dad ended up\ncalling the fire department.\n"
+    },
+    {
+      "group": "mail",
+      "index": 321,
+      "label": "",
+      "original": "Remember the year you\nfell out of the tree and\nbroke your poor arm? Mercy,\nthat tree produced so much\nfruit that year! Doesn't\nthat strike you as odd?\n",
+      "new": "Remember the year you\nfell out of the tree and\nbroke your poor arm? Mercy,\nthat tree produced so much\nfruit that year! Doesn't\nthat strike you as odd?\n"
+    },
+    {
+      "group": "mail",
+      "index": 322,
+      "label": "",
+      "original": "I was feeling bored, so I\nstarted up a little kitchen\ngarden. Who knew I had\na green thumb? I grew more\nfruit than I could eat!\n\n",
+      "new": "I was feeling bored, so I\nstarted up a little kitchen\ngarden. Who knew I had\na green thumb? I grew more\nfruit than I could eat!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 323,
+      "label": "",
+      "original": "Your dad finally noticed the\nexotic travel pamphlet I\n\"accidentally\" left on the\ntable. Looks like it's time\nfor a little vacation! He's\nconvinced it was his idea.\n",
+      "new": "Your dad finally noticed the\nexotic travel pamphlet I\n\"accidentally\" left on the\ntable. Looks like it's time\nfor a little vacation! He's\nconvinced it was his idea.\n"
+    },
+    {
+      "group": "mail",
+      "index": 324,
+      "label": "",
+      "original": "I recently decided to take up\ngardening as a hobby, except\nI couldn't grow anything but\nbrussels sprouts! I hate\nthose things! They're like\nevil little cabbages. Bleah!\n",
+      "new": "I recently decided to take up\ngardening as a hobby, except\nI couldn't grow anything but\nbrussels sprouts! I hate\nthose things! They're like\nevil little cabbages. Bleah!\n"
+    },
+    {
+      "group": "mail",
+      "index": 325,
+      "label": "",
+      "original": "I was watching a scary\nmovie the other nightーyour\nfather was fast asleep, of\ncourseーand I yelled at the\ntop of my lungs! Every light\non our street went on!\n",
+      "new": "I was watching a scary\nmovie the other nightーyour\nfather was fast asleep, of\ncourseーand I yelled at the\ntop of my lungs! Every light\non our street went on!\n"
+    },
+    {
+      "group": "mail",
+      "index": 326,
+      "label": "",
+      "original": "I tried to move this\npainting yesterday, but,\ninstead, it moved me!\nTrue story!\n\n\n",
+      "new": "I tried to move this\npainting yesterday, but,\ninstead, it moved me!\nTrue story!\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 327,
+      "label": "",
+      "original": "My secret recipe for double\nchoco-caramel cake is\ngetting rave reviews all\nover the neighborhood.\nI should start a business!\nI'd make a fortune!\n",
+      "new": "My secret recipe for double\nchoco-caramel cake is\ngetting rave reviews all\nover the neighborhood.\nI should start a business!\nI'd make a fortune!\n"
+    },
+    {
+      "group": "mail",
+      "index": 328,
+      "label": "",
+      "original": "Being popular is no great\nfeat. Anyone can do it! The\nkey is to be a personally\npersonable person. Nobody\nlikes a Gloomy Gus or a\nSalty Sally!\n",
+      "new": "Being popular is no great\nfeat. Anyone can do it! The\nkey is to be a personally\npersonable person. Nobody\nlikes a Gloomy Gus or a\nSalty Sally!\n"
+    },
+    {
+      "group": "mail",
+      "index": 329,
+      "label": "",
+      "original": "We just got a new\nconvenience store in town.\nStrangely, our village doesn't\nFEEL any more convenient...\n\n\n",
+      "new": "We just got a new\nconvenience store in town.\nStrangely, our village doesn't\nFEEL any more convenient...\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 330,
+      "label": "",
+      "original": "It's the weirdest thing...\nI found this spoiled carton\nof milk in the fridge...and\nfor some reason I thought\nof you. Anyway, when did\nyou last do your laundry?\n",
+      "new": "It's the weirdest thing...\nI found this spoiled carton\nof milk in the fridge...and\nfor some reason I thought\nof you. Anyway, when did\nyou last do your laundry?\n"
+    },
+    {
+      "group": "mail",
+      "index": 331,
+      "label": "",
+      "original": "Guess what! I've started\nmaking homemade spaghetti\nfrom scratch! I'll send you\nsome when I improve at itー\nyour poor father couldn't eat\nsolids for a week last time!\n",
+      "new": "Guess what! I've started\nmaking homemade spaghetti\nfrom scratch! I'll send you\nsome when I improve at itー\nyour poor father couldn't eat\nsolids for a week last time!\n"
+    },
+    {
+      "group": "mail",
+      "index": 332,
+      "label": "",
+      "original": "Your dad complimented my\ncurry, so as a surprise, I\nmade it every night for the\nrest of the week! Instead of\nbeing excited, he got really\ngrouchy. Men!\n",
+      "new": "Your dad complimented my\ncurry, so as a surprise, I\nmade it every night for the\nrest of the week! Instead of\nbeing excited, he got really\ngrouchy. Men!\n"
+    },
+    {
+      "group": "mail",
+      "index": 333,
+      "label": "",
+      "original": "If there's one meal your dad\nloves, it's pork chops. Of\ncourse, I only buy them on\nsale, as they're pricey!\nWhen shopping, use your\nbrains, not your belly.\n",
+      "new": "If there's one meal your dad\nloves, it's pork chops. Of\ncourse, I only buy them on\nsale, as they're pricey!\nWhen shopping, use your\nbrains, not your belly.\n"
+    },
+    {
+      "group": "mail",
+      "index": 334,
+      "label": "",
+      "original": "My dear, I miss you terribly\nand sometimes wish you'd\nmove back home, but I know\nit would be a bad idea...\nFor one thing, do you even\nremember where we live?\n",
+      "new": "My dear, I miss you terribly\nand sometimes wish you'd\nmove back home, but I know\nit would be a bad idea...\nFor one thing, do you even\nremember where we live?\n"
+    },
+    {
+      "group": "mail",
+      "index": 335,
+      "label": "",
+      "original": "So, hon, you must be pretty\nwell settled over there by\nnow. I hope you're making a\npoint of being nice to your\nneighbors! Nobody likes a\ncreepy next-door recluse!\n",
+      "new": "So, hon, you must be pretty\nwell settled over there by\nnow. I hope you're making a\npoint of being nice to your\nneighbors! Nobody likes a\ncreepy next-door recluse!\n"
+    },
+    {
+      "group": "mail",
+      "index": 336,
+      "label": "",
+      "original": "Your father and I made a\npleasant day of shopping\nyesterday in the next town\nover. I picked up your\nfavorite treat: Caramel-\nCovered Goo Nummies!\n",
+      "new": "Your father and I made a\npleasant day of shopping\nyesterday in the next town\nover. I picked up your\nfavorite treat: Caramel-\nCovered Goo Nummies!\n"
+    },
+    {
+      "group": "mail",
+      "index": 337,
+      "label": "",
+      "original": "I chanced upon this in the\nnext town over and simply\ncouldn't resist buying it\nfor you. Just look at it!\nIt's perfect for you!\n\n",
+      "new": "I chanced upon this in the\nnext town over and simply\ncouldn't resist buying it\nfor you. Just look at it!\nIt's perfect for you!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 338,
+      "label": "",
+      "original": "Take good care of this\nsapling I grew for you, and\nit will bring you fortune! I\ndon't know what'll happen if\nyou treat it like that tree\nyou didn't water. Misfortune?\n",
+      "new": "Take good care of this\nsapling I grew for you, and\nit will bring you fortune! I\ndon't know what'll happen if\nyou treat it like that tree\nyou didn't water. Misfortune?\n"
+    },
+    {
+      "group": "mail",
+      "index": 339,
+      "label": "",
+      "original": "You're old enough now to\nknow this... When you were\na kid, I almost lost my cool\na number of times. Do you\nrecall \"sledding\" down the\nstairs on the couch? I do...\n",
+      "new": "You're old enough now to\nknow this... When you were\na kid, I almost lost my cool\na number of times. Do you\nrecall \"sledding\" down the\nstairs on the couch? I do...\n"
+    },
+    {
+      "group": "mail",
+      "index": 340,
+      "label": "",
+      "original": "There was a darling bazaar\nin the town square the other\nday, and I happened upon\nthis adorable umbrella. Do\nyou want it? Don't stay out\nin the rain too long!\n",
+      "new": "There was a darling bazaar\nin the town square the other\nday, and I happened upon\nthis adorable umbrella. Do\nyou want it? Don't stay out\nin the rain too long!\n"
+    },
+    {
+      "group": "mail",
+      "index": 341,
+      "label": "",
+      "original": "I found a muddy old pair\nof your shoes and recalled\nyou when you were little,\nstomping in mud puddles... \nI was so overcome by the\nmemory, I couldn't wash 'em.\n",
+      "new": "I found a muddy old pair\nof your shoes and recalled\nyou when you were little,\nstomping in mud puddles... \nI was so overcome by the\nmemory, I couldn't wash 'em.\n"
+    },
+    {
+      "group": "mail",
+      "index": 342,
+      "label": "",
+      "original": "I asked your father, very\nsweetly, \"What would you\nlike for dinner, dear?\"\nNo answer.\nWell! It looks like someone's\ngetting meatloaf AGAIN!\n",
+      "new": "I asked your father, very\nsweetly, \"What would you\nlike for dinner, dear?\"\nNo answer.\nWell! It looks like someone's\ngetting meatloaf AGAIN!\n"
+    },
+    {
+      "group": "mail",
+      "index": 343,
+      "label": "",
+      "original": "I was sort of dozing in\nfront of the TV, and someone\non the soap opera cried out,\n\"Mommm!\" And I leaped up,\nyelling, \"What's wrong?\"\nI thought it was you! Ha!\n",
+      "new": "I was sort of dozing in\nfront of the TV, and someone\non the soap opera cried out,\n\"Mommm!\" And I leaped up,\nyelling, \"What's wrong?\"\nI thought it was you! Ha!\n"
+    },
+    {
+      "group": "mail",
+      "index": 344,
+      "label": "",
+      "original": "I don't really know why\nI'm bothering to tell you\nthis, but we've been having\nstrictly leftovers for lunch\nlately. Hope all's well!\n\n",
+      "new": "I don't really know why\nI'm bothering to tell you\nthis, but we've been having\nstrictly leftovers for lunch\nlately. Hope all's well!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 345,
+      "label": "",
+      "original": "I heard a rumor about you\nthe other day. Is it true?\nWith the rubber cement,\nand the spatula, and those\npoor ants from little Timmy's\nant farm? My word!\n",
+      "new": "I heard a rumor about you\nthe other day. Is it true?\nWith the rubber cement,\nand the spatula, and those\npoor ants from little Timmy's\nant farm? My word!\n"
+    },
+    {
+      "group": "mail",
+      "index": 346,
+      "label": "",
+      "original": "So, have you made any new\nfriends? I'd love to meet\nthem. What are they like?\nWould I approve of them?\nAre any of them hooligans? \nWas there anyone SPECIAL?\n",
+      "new": "So, have you made any new\nfriends? I'd love to meet\nthem. What are they like?\nWould I approve of them?\nAre any of them hooligans? \nWas there anyone SPECIAL?\n"
+    },
+    {
+      "group": "mail",
+      "index": 347,
+      "label": "",
+      "original": "I tell you, sometimes, when\nyour father and I get too\nstressed out, we just head\nto a hot spring for some\ntime by ourselves. We come\nback feeling like newlyweds!\n",
+      "new": "I tell you, sometimes, when\nyour father and I get too\nstressed out, we just head\nto a hot spring for some\ntime by ourselves. We come\nback feeling like newlyweds!\n"
+    },
+    {
+      "group": "mail",
+      "index": 348,
+      "label": "",
+      "original": "So, how do you like my\nletters? They're funny, aren't\nthey? Especially for an old\nbird like me! Whoo-HOOOO!\nI am the wittiest mom\nIN THE WORLD!!!\n",
+      "new": "So, how do you like my\nletters? They're funny, aren't\nthey? Especially for an old\nbird like me! Whoo-HOOOO!\nI am the wittiest mom\nIN THE WORLD!!!\n"
+    },
+    {
+      "group": "mail",
+      "index": 349,
+      "label": "",
+      "original": "Strange... I've had a poor\nappetite lately. How about\nyou? Have you been healthy?\nAre you having melted cheese\nsandwiches for dinner?\nAre you washing your knees?\n",
+      "new": "Strange... I've had a poor\nappetite lately. How about\nyou? Have you been healthy?\nAre you having melted cheese\nsandwiches for dinner?\nAre you washing your knees?\n"
+    },
+    {
+      "group": "mail",
+      "index": 350,
+      "label": "",
+      "original": "I went outside the other day\nafter a hard rain and guess\nwhat I found buried?\nA Gyroid! How weird\nis that? Ah, the wonders\nof nature!\n",
+      "new": "I went outside the other day\nafter a hard rain and guess\nwhat I found buried?\nA Gyroid! How weird\nis that? Ah, the wonders\nof nature!\n"
+    },
+    {
+      "group": "mail",
+      "index": 351,
+      "label": "",
+      "original": "Always remember to use the\nbathroom before you go to\nsleep! Otherwise, you may\nsuffer a horrible fate, like\nyour poor Uncle Dweezil...\n\n",
+      "new": "Always remember to use the\nbathroom before you go to\nsleep! Otherwise, you may\nsuffer a horrible fate, like\nyour poor Uncle Dweezil...\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 352,
+      "label": "",
+      "original": "I certainly hope you're\nremembering to brush your\nteeth at night. I can't keep\nyou from living with beasts,\nbut I can at least remind\nyou to save your gums!\n",
+      "new": "I certainly hope you're\nremembering to brush your\nteeth at night. I can't keep\nyou from living with beasts,\nbut I can at least remind\nyou to save your gums!\n"
+    },
+    {
+      "group": "mail",
+      "index": 353,
+      "label": "",
+      "original": "There's an old saying that\nyou can save three Bells by\nwaking up early, but me, I'd\npay ten just to be able to\nsleep late... I do love my\nbeauty rest!\n",
+      "new": "There's an old saying that\nyou can save three Bells by\nwaking up early, but me, I'd\npay ten just to be able to\nsleep late... I do love my\nbeauty rest!\n"
+    },
+    {
+      "group": "mail",
+      "index": 354,
+      "label": "",
+      "original": "I hope you don't mind all\nthese strange letters, but\nI just want to share my life\nwith you. Even if you have\nchosen to live with animals,\nwhich I'll never understand.\n",
+      "new": "I hope you don't mind all\nthese strange letters, but\nI just want to share my life\nwith you. Even if you have\nchosen to live with animals,\nwhich I'll never understand.\n"
+    },
+    {
+      "group": "mail",
+      "index": 355,
+      "label": "",
+      "original": "Stressful moments pass \nquickly from day to day,\nbut the combined weight of\nall of them can crush your\nyouth... Never let your cares\nweigh you down for long!\n",
+      "new": "Stressful moments pass \nquickly from day to day,\nbut the combined weight of\nall of them can crush your\nyouth... Never let your cares\nweigh you down for long!\n"
+    },
+    {
+      "group": "mail",
+      "index": 356,
+      "label": "",
+      "original": "My New Year's resolution is\nto help you be healthier and\nhappier. I'm still not sure\nof the best way to go about\nit, but I hope this helps!\n\n",
+      "new": "My New Year's resolution is\nto help you be healthier and\nhappier. I'm still not sure\nof the best way to go about\nit, but I hope this helps!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 357,
+      "label": "",
+      "original": "Happy New Year! Everyone\nalways shouts \"Happy New\nYear!\" Not to be a \"bum-\nout,\" or whatever you kids\nsay, but what's so happy\nabout another year passing?\n",
+      "new": "Happy New Year! Everyone\nalways shouts \"Happy New\nYear!\" Not to be a \"bum-\nout,\" or whatever you kids\nsay, but what's so happy\nabout another year passing?\n"
+    },
+    {
+      "group": "mail",
+      "index": 358,
+      "label": "",
+      "original": "So did the groundhog see\nits shadow today? Or not?\nI saw your father's shadow.\nIt seems to grow wider\nevery year.\n\n",
+      "new": "So did the groundhog see\nits shadow today? Or not?\nI saw your father's shadow.\nIt seems to grow wider\nevery year.\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 359,
+      "label": "",
+      "original": "I say spring is coming,\nregardless of what that\ngroundhog says. Just you\nwait and see.\n\n\n",
+      "new": "I say spring is coming,\nregardless of what that\ngroundhog says. Just you\nwait and see.\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 360,
+      "label": "",
+      "original": "Down by the river's edge,\nI sat on the ground and let\nmy cares flow away with the\ncool water. And perhaps,\njust perhaps, I heard the\nsoft footsteps of spring...\n",
+      "new": "Down by the river's edge,\nI sat on the ground and let\nmy cares flow away with the\ncool water. And perhaps,\njust perhaps, I heard the\nsoft footsteps of spring...\n"
+    },
+    {
+      "group": "mail",
+      "index": 361,
+      "label": "",
+      "original": "The early signs of spring\nare all around. That means\nits time to come out of\nhibernation and get active\nagain. It's the season for\ngetting in shape.\n",
+      "new": "The early signs of spring\nare all around. That means\nits time to come out of\nhibernation and get active\nagain. It's the season for\ngetting in shape.\n"
+    },
+    {
+      "group": "mail",
+      "index": 362,
+      "label": "",
+      "original": "The cherry trees in the back\nyard have positively exploded\ninto bloom recently! How do\nthey look in your neck of\nthe woods, my darling dear?\n\n",
+      "new": "The cherry trees in the back\nyard have positively exploded\ninto bloom recently! How do\nthey look in your neck of\nthe woods, my darling dear?\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 363,
+      "label": "",
+      "original": "Looking at the cherry\nblossoms, I remembered\nthe time you tried to climb\nup to the highest branch!\nOh, how you tried! But you\nnever quite made it...\n",
+      "new": "Looking at the cherry\nblossoms, I remembered\nthe time you tried to climb\nup to the highest branch!\nOh, how you tried! But you\nnever quite made it...\n"
+    },
+    {
+      "group": "mail",
+      "index": 364,
+      "label": "",
+      "original": "It's the darnedest thing!\nI just noticed the marks we\ndrew on the wall to measure\nyour height as you grew up!\nOh, what memories! How tall\nare you now?\n",
+      "new": "It's the darnedest thing!\nI just noticed the marks we\ndrew on the wall to measure\nyour height as you grew up!\nOh, what memories! How tall\nare you now?\n"
+    },
+    {
+      "group": "mail",
+      "index": 365,
+      "label": "",
+      "original": "Spring is such a lovely\nseason. It makes me want\nto go outside and fly a\nkite. You should do the\nsame.\n\n",
+      "new": "Spring is such a lovely\nseason. It makes me want\nto go outside and fly a\nkite. You should do the\nsame.\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 366,
+      "label": "",
+      "original": "Ick. Another gray and cloudy\nday... How depressing...\nWith my luck, the laundry\nwon't even dry on the \nclothesline. Well, hope your\nday is nicer than mine...\n",
+      "new": "Ick. Another gray and cloudy\nday... How depressing...\nWith my luck, the laundry\nwon't even dry on the \nclothesline. Well, hope your\nday is nicer than mine...\n"
+    },
+    {
+      "group": "mail",
+      "index": 367,
+      "label": "",
+      "original": "Oh, the heat last night was\nunbearable! In the deep\ndarkness, I wandered down\nto the river, enjoying the\nnight breezes... I must have\ncounted a thousand fireflies!\n",
+      "new": "Oh, the heat last night was\nunbearable! In the deep\ndarkness, I wandered down\nto the river, enjoying the\nnight breezes... I must have\ncounted a thousand fireflies!\n"
+    },
+    {
+      "group": "mail",
+      "index": 368,
+      "label": "",
+      "original": "While out on a romantic\nnighttime stroll, your father\nand I walked through a huge\nswarm of fireflies. I swear,\nit was as if we were walking\nthrough the Milky Way!\n",
+      "new": "While out on a romantic\nnighttime stroll, your father\nand I walked through a huge\nswarm of fireflies. I swear,\nit was as if we were walking\nthrough the Milky Way!\n"
+    },
+    {
+      "group": "mail",
+      "index": 369,
+      "label": "",
+      "original": "Nothing says summer like a\nfireworks show. I took your\nmother to the amusement\npark a few days ago.\nThey had the best rockets\nI've ever seen.\n",
+      "new": "Nothing says summer like a\nfireworks show. I took your\nmother to the amusement\npark a few days ago.\nThey had the best rockets\nI've ever seen.\n"
+    },
+    {
+      "group": "mail",
+      "index": 370,
+      "label": "",
+      "original": "Dawn breaks... Slowly,\nfigures appear and gather\ntogether...and then...\nONE! TWO! THREE! HUP!\nUgh.\nI hate morning exercises...\n",
+      "new": "Dawn breaks... Slowly,\nfigures appear and gather\ntogether...and then...\nONE! TWO! THREE! HUP!\nUgh.\nI hate morning exercises...\n"
+    },
+    {
+      "group": "mail",
+      "index": 371,
+      "label": "",
+      "original": "There's a big meteor shower\nthis weekーanyone who's\nanyone will be there! You'll\nbe pleased to know that your\nmother will be looking smart\nin her red dress this year...\n",
+      "new": "There's a big meteor shower\nthis weekーanyone who's\nanyone will be there! You'll\nbe pleased to know that your\nmother will be looking smart\nin her red dress this year...\n"
+    },
+    {
+      "group": "mail",
+      "index": 372,
+      "label": "",
+      "original": "I know it's September, but\nit's still rather hot out,\ndon't you think? So take\ncare not to overheat!\nAnd don't wear dirty socks!\nYou mind your mother, now!\n",
+      "new": "I know it's September, but\nit's still rather hot out,\ndon't you think? So take\ncare not to overheat!\nAnd don't wear dirty socks!\nYou mind your mother, now!\n"
+    },
+    {
+      "group": "mail",
+      "index": 373,
+      "label": "",
+      "original": "It's strange... I heard this\nnoise for the longest time\nbefore I realized it was\na bell cricket chirping! \nBoy, autumn sure snuck\nup on me this year!\n",
+      "new": "It's strange... I heard this\nnoise for the longest time\nbefore I realized it was\na bell cricket chirping! \nBoy, autumn sure snuck\nup on me this year!\n"
+    },
+    {
+      "group": "mail",
+      "index": 374,
+      "label": "",
+      "original": "Your father and I hiked up\nthe mountain to admire the\npretty fall leaves, but I\nfound myself enticed by\nan aroma. Pretty soon, I was\nhunting mushrooms like mad!\n",
+      "new": "Your father and I hiked up\nthe mountain to admire the\npretty fall leaves, but I\nfound myself enticed by\nan aroma. Pretty soon, I was\nhunting mushrooms like mad!\n"
+    },
+    {
+      "group": "mail",
+      "index": 375,
+      "label": "",
+      "original": "Your mother and I just\njoined the local mycological\nsociety. We're learning all\nabout identifying and\npicking mushrooms. It's\nquite interesting.\n",
+      "new": "Your mother and I just\njoined the local mycological\nsociety. We're learning all\nabout identifying and\npicking mushrooms. It's\nquite interesting.\n"
+    },
+    {
+      "group": "mail",
+      "index": 376,
+      "label": "",
+      "original": "Your father and I did some\nyard work yesterday. He\nraked up all the leaves, and\nI set them on fireーyes, we\nhad a permit! It reminded\nme of roasting chestnuts.\n",
+      "new": "Your father and I did some\nyard work yesterday. He\nraked up all the leaves, and\nI set them on fireーyes, we\nhad a permit! It reminded\nme of roasting chestnuts.\n"
+    },
+    {
+      "group": "mail",
+      "index": 377,
+      "label": "",
+      "original": "Yesterday I was listening\nto dead leaves rustle, and\nall of a sudden a wave of\nnostalgia crashed over me.\nFall is such a lovely time!\nLovely, yet sad...\n",
+      "new": "Yesterday I was listening\nto dead leaves rustle, and\nall of a sudden a wave of\nnostalgia crashed over me.\nFall is such a lovely time!\nLovely, yet sad...\n"
+    },
+    {
+      "group": "mail",
+      "index": 378,
+      "label": "",
+      "original": "I got so tired of writing\nholiday cards that I must\nhave completely zoned out.\nI wrote some upside down,\nfilled one with nonsense, and\naddressed one to the cat.\n",
+      "new": "I got so tired of writing\nholiday cards that I must\nhave completely zoned out.\nI wrote some upside down,\nfilled one with nonsense, and\naddressed one to the cat.\n"
+    },
+    {
+      "group": "mail",
+      "index": 379,
+      "label": "",
+      "original": "The other day, I finally got\naround to covering that fine\ndrawing you did on the\nwallpaper during your 'young\nartist' phase. Odd...I thought\nyour dad had the moustache.\n",
+      "new": "The other day, I finally got\naround to covering that fine\ndrawing you did on the\nwallpaper during your 'young\nartist' phase. Odd...I thought\nyour dad had the moustache.\n"
+    },
+    {
+      "group": "mail",
+      "index": 380,
+      "label": "",
+      "original": "I'm always joyous on\nMother's Day, regardless\nof whether you give me\nflowers or worms!\n\nJust so you remember.\n",
+      "new": "I'm always joyous on\nMother's Day, regardless\nof whether you give me\nflowers or worms!\n\nJust so you remember.\n"
+    },
+    {
+      "group": "mail",
+      "index": 381,
+      "label": "",
+      "original": "You know, as a mother, I'll\nnever let go of my precious\nmemories of you. Like those\nfabulous, fun-filled 46\nhours I spent in labor... You\nwere worth every minute!\n",
+      "new": "You know, as a mother, I'll\nnever let go of my precious\nmemories of you. Like those\nfabulous, fun-filled 46\nhours I spent in labor... You\nwere worth every minute!\n"
+    },
+    {
+      "group": "mail",
+      "index": 382,
+      "label": "",
+      "original": "Hey, child of mine! Isn't\nthis a wild foofaraw! Your\nold dad's trying his hand at\nthis letter-writing thing!\nWill wonders never cease?!\nSo, you know what today is?\n",
+      "new": "Hey, child of mine! Isn't\nthis a wild foofaraw! Your\nold dad's trying his hand at\nthis letter-writing thing!\nWill wonders never cease?!\nSo, you know what today is?\n"
+    },
+    {
+      "group": "mail",
+      "index": 383,
+      "label": "",
+      "original": "Well, now, you'd have to\nagree, I've been your dad for\nquite a while, right? So I\nwas wondering... You don't\nhappen to remember exactly\nwhen that began, do you? \n",
+      "new": "Well, now, you'd have to\nagree, I've been your dad for\nquite a while, right? So I\nwas wondering... You don't\nhappen to remember exactly\nwhen that began, do you? \n"
+    },
+    {
+      "group": "mail",
+      "index": 384,
+      "label": "",
+      "original": "Guess what!? I have great\nnews! We've decided to give\nyou your inheritance early!\nYou're rich!!!!\nHA! April Fool's Day, dear!\nNo Bells for you!\n",
+      "new": "Guess what!? I have great\nnews! We've decided to give\nyou your inheritance early!\nYou're rich!!!!\nHA! April Fool's Day, dear!\nNo Bells for you!\n"
+    },
+    {
+      "group": "mail",
+      "index": 385,
+      "label": "",
+      "original": "Ugh... No...more...letters...\nI'm awfully sorry, dear, but\nI've been writing letters all\nday, and I am just bushed!\nI promise to write a more\ninteresting one next time!\n",
+      "new": "Ugh... No...more...letters...\nI'm awfully sorry, dear, but\nI've been writing letters all\nday, and I am just bushed!\nI promise to write a more\ninteresting one next time!\n"
+    },
+    {
+      "group": "mail",
+      "index": 386,
+      "label": "",
+      "original": "Is there any more magical\ntime than the holidays?\nI think not! Flurries drifting\nthrough the frosty night air,\nfootsteps crunching through\nsnow, family gatherings...\n",
+      "new": "Is there any more magical\ntime than the holidays?\nI think not! Flurries drifting\nthrough the frosty night air,\nfootsteps crunching through\nsnow, family gatherings...\n"
+    },
+    {
+      "group": "mail",
+      "index": 387,
+      "label": "",
+      "original": "I hope we make it through\nthe holidays without any of\nlast year's hoopla. That foul\neggnog still won't come out\nof the drapes, and we never\ndid find Cindy's hamster...\n",
+      "new": "I hope we make it through\nthe holidays without any of\nlast year's hoopla. That foul\neggnog still won't come out\nof the drapes, and we never\ndid find Cindy's hamster...\n"
+    },
+    {
+      "group": "mail",
+      "index": 388,
+      "label": "",
+      "original": "Dearest child of mine!\nOn this day, the day of your\nbirth, your parents wish you\nnothing but happiness!\nWish you were here!\n\n",
+      "new": "Dearest child of mine!\nOn this day, the day of your\nbirth, your parents wish you\nnothing but happiness!\nWish you were here!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 389,
+      "label": "",
+      "original": "Today is a special day,\nthe anniversary of the\nday you came into our\nlives! I tell you, that was\nthe happiest day in all\nmy days! Happy birthday!\n",
+      "new": "Today is a special day,\nthe anniversary of the\nday you came into our\nlives! I tell you, that was\nthe happiest day in all\nmy days! Happy birthday!\n"
+    },
+    {
+      "group": "mail",
+      "index": 390,
+      "label": "",
+      "original": "My! The moon looks simply\nbeautiful in the autumn sky.\nSometimes I feel like I could\nspend the rest of my life\ngazing at the moon...\n\n",
+      "new": "My! The moon looks simply\nbeautiful in the autumn sky.\nSometimes I feel like I could\nspend the rest of my life\ngazing at the moon...\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 391,
+      "label": "",
+      "original": "I get so worked up worrying\nabout huge storms coming\nthat when they don't arrive,\nI feel kind of disappointed.\nIs that wrong?\n\n",
+      "new": "I get so worked up worrying\nabout huge storms coming\nthat when they don't arrive,\nI feel kind of disappointed.\nIs that wrong?\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 392,
+      "label": "",
+      "original": "I sure do love sauteed\nmushrooms. But not as much\nas your father! He ate so\nmany helpings last night,\nI swear he started to look\nlike a mushroom himself!\n",
+      "new": "I sure do love sauteed\nmushrooms. But not as much\nas your father! He ate so\nmany helpings last night,\nI swear he started to look\nlike a mushroom himself!\n"
+    },
+    {
+      "group": "mail",
+      "index": 393,
+      "label": "",
+      "original": "You know when you eat\nall the mushrooms out of\nyour mushroom pilaf, and all\nthat's left is brown rice? I\nhate that! I need to improve\nmy mushroom-to-rice ratio! \n",
+      "new": "You know when you eat\nall the mushrooms out of\nyour mushroom pilaf, and all\nthat's left is brown rice? I\nhate that! I need to improve\nmy mushroom-to-rice ratio! \n"
+    },
+    {
+      "group": "mail",
+      "index": 394,
+      "label": "",
+      "original": "Your father doesn't seem\nto like having sardines for\ndinner every night, but what\ncan I do?\n\n\n",
+      "new": "Your father doesn't seem\nto like having sardines for\ndinner every night, but what\ncan I do?\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 395,
+      "label": "",
+      "original": "I walked hand-in-hand with\nyour father down a gorgeous,\ntree-lined street the other\nday. The colors were lovely,\nand he was just as handsome\nas the day we met.\n",
+      "new": "I walked hand-in-hand with\nyour father down a gorgeous,\ntree-lined street the other\nday. The colors were lovely,\nand he was just as handsome\nas the day we met.\n"
+    },
+    {
+      "group": "mail",
+      "index": 396,
+      "label": "",
+      "original": "Now that the snows have\nmelted, I can go for long\nwalks outdoors. It feels good\nto stretch my legs after\nbeing cooped up for so long!\n\n",
+      "new": "Now that the snows have\nmelted, I can go for long\nwalks outdoors. It feels good\nto stretch my legs after\nbeing cooped up for so long!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 397,
+      "label": "",
+      "original": "I'm sure you'll face hardship\nout thereーafter all, you're\nout on your own with those\nanimalsーbut stick it out, no\nmatter what! You'll be fine,\nI know it!\n",
+      "new": "I'm sure you'll face hardship\nout thereーafter all, you're\nout on your own with those\nanimalsーbut stick it out, no\nmatter what! You'll be fine,\nI know it!\n"
+    },
+    {
+      "group": "mail",
+      "index": 398,
+      "label": "",
+      "original": "The other day, I was rooting\naround in a cupboard, and a\npair of cockroaches popped\nout and skittered into a hole\nin the wall! Ick!! I nearly\nswallowed my cough drop!!\n",
+      "new": "The other day, I was rooting\naround in a cupboard, and a\npair of cockroaches popped\nout and skittered into a hole\nin the wall! Ick!! I nearly\nswallowed my cough drop!!\n"
+    },
+    {
+      "group": "mail",
+      "index": 399,
+      "label": "",
+      "original": "I saw a swallowtail butterfly\nbasking in the sun yesterday.\nMy, it was gorgeous! It was\nalmost as if it was a gift to\nme from Spring herself!\n\n",
+      "new": "I saw a swallowtail butterfly\nbasking in the sun yesterday.\nMy, it was gorgeous! It was\nalmost as if it was a gift to\nme from Spring herself!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 400,
+      "label": "",
+      "original": "When Old Man Winter relaxes\nhis icy grip and Dame\nSpring blows warm breath\nacross my face, I sometimes\nfeel like a child being led\nfrom one delight to another.\n",
+      "new": "When Old Man Winter relaxes\nhis icy grip and Dame\nSpring blows warm breath\nacross my face, I sometimes\nfeel like a child being led\nfrom one delight to another.\n"
+    },
+    {
+      "group": "mail",
+      "index": 401,
+      "label": "",
+      "original": "The May weather must have\nmoved me to finish knitting\nthis sky-blue shirt for you!\nLike the clear sky of spring,\nlet it breathe hope and \nfresh life into your soul!\n",
+      "new": "The May weather must have\nmoved me to finish knitting\nthis sky-blue shirt for you!\nLike the clear sky of spring,\nlet it breathe hope and \nfresh life into your soul!\n"
+    },
+    {
+      "group": "mail",
+      "index": 402,
+      "label": "",
+      "original": "I've started taking swimming\nclasses to get ready for the\nsummer heat. Apparently,\nmy best stroke is \"the\nflounder.\" They tell me I\ninvented it! Isn't that cool!\n",
+      "new": "I've started taking swimming\nclasses to get ready for the\nsummer heat. Apparently,\nmy best stroke is \"the\nflounder.\" They tell me I\ninvented it! Isn't that cool!\n"
+    },
+    {
+      "group": "mail",
+      "index": 403,
+      "label": "",
+      "original": "I woke up in a great mood\ntoday. Then, as I hung the\nlaundry on the line, the sky\nclouded up, and it rained all\nover my parade. Now I just\nwant to watch TV and sulk.\n",
+      "new": "I woke up in a great mood\ntoday. Then, as I hung the\nlaundry on the line, the sky\nclouded up, and it rained all\nover my parade. Now I just\nwant to watch TV and sulk.\n"
+    },
+    {
+      "group": "mail",
+      "index": 404,
+      "label": "",
+      "original": "I went to sleep with the AC\nset to \"Glacial,\" but I\ndidn't even have a cold in\nthe morning! I did have to\nwait for my eyelids to thaw,\nbut that wasn't a big deal.\n",
+      "new": "I went to sleep with the AC\nset to \"Glacial,\" but I\ndidn't even have a cold in\nthe morning! I did have to\nwait for my eyelids to thaw,\nbut that wasn't a big deal.\n"
+    },
+    {
+      "group": "mail",
+      "index": 405,
+      "label": "",
+      "original": "Do you remember when we\nplanted the morning glories\nin the front of the garden?\nWell, one of them just\nopened up and said \"hello.\"\n...Not literally, of course!\n",
+      "new": "Do you remember when we\nplanted the morning glories\nin the front of the garden?\nWell, one of them just\nopened up and said \"hello.\"\n...Not literally, of course!\n"
+    },
+    {
+      "group": "mail",
+      "index": 406,
+      "label": "",
+      "original": "Your father paid me the\nnicest compliment today!\nHe said, \"You look so fine\nin your bathing suit that I\ncan't bear to look at you!\"\n...Wait a minute.\n",
+      "new": "Your father paid me the\nnicest compliment today!\nHe said, \"You look so fine\nin your bathing suit that I\ncan't bear to look at you!\"\n...Wait a minute.\n"
+    },
+    {
+      "group": "mail",
+      "index": 407,
+      "label": "",
+      "original": "It...is...so...hot...\nMust...eat...ice...cream...\nby...the...gallon...\n\n\n\n",
+      "new": "It...is...so...hot...\nMust...eat...ice...cream...\nby...the...gallon...\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 408,
+      "label": "",
+      "original": "Ahh, summer! All I want to\ndo is eat watermelon, watch\nfireworks, and collect\nfascinating insects under\nclear summer skies. And\na nap! On a picnic blanket!\n",
+      "new": "Ahh, summer! All I want to\ndo is eat watermelon, watch\nfireworks, and collect\nfascinating insects under\nclear summer skies. And\na nap! On a picnic blanket!\n"
+    },
+    {
+      "group": "mail",
+      "index": 409,
+      "label": "",
+      "original": "It's so hard to sleep in this\nheat! But just when I think\nI can't take it, I remember\nthe time you fell asleep on\nthe air conditioner and got\nstuck. That was a hoot! \n",
+      "new": "It's so hard to sleep in this\nheat! But just when I think\nI can't take it, I remember\nthe time you fell asleep on\nthe air conditioner and got\nstuck. That was a hoot! \n"
+    },
+    {
+      "group": "mail",
+      "index": 410,
+      "label": "",
+      "original": "A poem for my dear child:\nRoused from sleep\nby chimes of wind,\nI close the window\nand climb back in.\n...I love sleeping in.\n",
+      "new": "A poem for my dear child:\nRoused from sleep\nby chimes of wind,\nI close the window\nand climb back in.\n...I love sleeping in.\n"
+    },
+    {
+      "group": "mail",
+      "index": 411,
+      "label": "",
+      "original": "I love visiting the blue,\nblue sea, and lying by\nthe surf, and falling asleep,\nand waking up utterly burnt\nto a crispー\nWait, no...I hate that part.\n",
+      "new": "I love visiting the blue,\nblue sea, and lying by\nthe surf, and falling asleep,\nand waking up utterly burnt\nto a crispー\nWait, no...I hate that part.\n"
+    },
+    {
+      "group": "mail",
+      "index": 412,
+      "label": "",
+      "original": "Can you hear that?\nOff in the distance...\nThe siren song of a wild\ninsect! Listen to its\nbarbaric yawp!\nLet's go BUG HUNTING!\n",
+      "new": "Can you hear that?\nOff in the distance...\nThe siren song of a wild\ninsect! Listen to its\nbarbaric yawp!\nLet's go BUG HUNTING!\n"
+    },
+    {
+      "group": "mail",
+      "index": 413,
+      "label": "",
+      "original": "Blue Sea\nBlue Sky\n...Red nose!?\nSure enough, your mom\ncaught a cold this summer.\n\n",
+      "new": "Blue Sea\nBlue Sky\n...Red nose!?\nSure enough, your mom\ncaught a cold this summer.\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 414,
+      "label": "",
+      "original": "My! I just saw a weather\nreport for your area, and it\nlooks cold over there! You\nremember to bundle up and\nwatch your health, OK?\nRemember! An apple a day...\n",
+      "new": "My! I just saw a weather\nreport for your area, and it\nlooks cold over there! You\nremember to bundle up and\nwatch your health, OK?\nRemember! An apple a day...\n"
+    },
+    {
+      "group": "mail",
+      "index": 415,
+      "label": "",
+      "original": "I was up all night knitting\na pair of gloves for you, but\nit's the strangest thing...\nI must have been 'in the\nzone,' because before I knew\nit, I'd made a sweater!\n",
+      "new": "I was up all night knitting\na pair of gloves for you, but\nit's the strangest thing...\nI must have been 'in the\nzone,' because before I knew\nit, I'd made a sweater!\n"
+    },
+    {
+      "group": "mail",
+      "index": 416,
+      "label": "",
+      "original": "If you get a cold, wrap your\nthroat in onion slices. And\nif you have a fever, stick a\ncompress of minced garlic\nunder your armpits for an\nhour. You mind your mother!\n",
+      "new": "If you get a cold, wrap your\nthroat in onion slices. And\nif you have a fever, stick a\ncompress of minced garlic\nunder your armpits for an\nhour. You mind your mother!\n"
+    },
+    {
+      "group": "mail",
+      "index": 417,
+      "label": "",
+      "original": "I made a snowman with your\ndad for the first time in a\nlong while yesterday. It was\nso much fun! When we were\ndone, it looked kind of like\nyou! Isn't that a hoot?\n",
+      "new": "I made a snowman with your\ndad for the first time in a\nlong while yesterday. It was\nso much fun! When we were\ndone, it looked kind of like\nyou! Isn't that a hoot?\n"
+    },
+    {
+      "group": "mail",
+      "index": 418,
+      "label": "",
+      "original": "You know, your dad used to\ncall me his hot potato.\nIsn't that cute? But I swear,\non cold days, I'm no hot\npotato! Instead, I magically\nturn into a couch potato!\n",
+      "new": "You know, your dad used to\ncall me his hot potato.\nIsn't that cute? But I swear,\non cold days, I'm no hot\npotato! Instead, I magically\nturn into a couch potato!\n"
+    },
+    {
+      "group": "mail",
+      "index": 419,
+      "label": "",
+      "original": "I woke up this morning, \nstarted cooking breakfast,\nand I made you a huge meal\nbefore I remembered that you\nmoved out! It's OK, though.\nYour father ate it all.\n",
+      "new": "I woke up this morning, \nstarted cooking breakfast,\nand I made you a huge meal\nbefore I remembered that you\nmoved out! It's OK, though.\nYour father ate it all.\n"
+    },
+    {
+      "group": "mail",
+      "index": 420,
+      "label": "",
+      "original": "HAPPY NEW YEAR! It's been\nmy honor to provide you all\nwith the finest goods this\npast year. I look forward to\nseeing you all at my store!\n                  Tom Nook\n",
+      "new": "HAPPY NEW YEAR! It's been\nmy honor to provide you all\nwith the finest goods this\npast year. I look forward to\nseeing you all at my store!\n                  Tom Nook\n"
+    },
+    {
+      "group": "mail",
+      "index": 421,
+      "label": "",
+      "original": "   ーWeather Reportー\nExpect normal snowfall and\nideal conditions for snowmen\nand igloos this year. Mild\ntemperatures mean the lakes\nshouldn't freeze this winter.\n",
+      "new": "   ーWeather Reportー\nExpect normal snowfall and\nideal conditions for snowmen\nand igloos this year. Mild\ntemperatures mean the lakes\nshouldn't freeze this winter.\n"
+    },
+    {
+      "group": "mail",
+      "index": 422,
+      "label": "",
+      "original": "For those who can't wait\nfor spring to arrive, we're\nabout to find out when it\nwill! Drop by the wishing\nwell at 7:00 a.m. on\nFebruary 2nd for the news!\n",
+      "new": "For those who can't wait\nfor spring to arrive, we're\nabout to find out when it\nwill! Drop by the wishing\nwell at 7:00 a.m. on\nFebruary 2nd for the news!\n"
+    },
+    {
+      "group": "mail",
+      "index": 423,
+      "label": "",
+      "original": "It's almost Valentine's Day!\nDon't forget to clean out\nyour mailbox so there's lots\nof room for cards from your\nspecial sweetie or sweeties!\n              Postman Pete\n",
+      "new": "It's almost Valentine's Day!\nDon't forget to clean out\nyour mailbox so there's lots\nof room for cards from your\nspecial sweetie or sweeties!\n              Postman Pete\n"
+    },
+    {
+      "group": "mail",
+      "index": 424,
+      "label": "",
+      "original": "Well, I finished DELIVERING\nvalentines to all of you...\nBut when will I start\nRECEIVING some?\n\n\n",
+      "new": "Well, I finished DELIVERING\nvalentines to all of you...\nBut when will I start\nRECEIVING some?\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 425,
+      "label": "",
+      "original": "~Cherry Blossom Festival~\nSpring is upon us, and the\nflowers will soon be\nblooming! Join us April 5th-\n7th for the annual Cherry\nBlossom Festival!\n",
+      "new": "~Cherry Blossom Festival~\nSpring is upon us, and the\nflowers will soon be\nblooming! Join us April 5th-\n7th for the annual Cherry\nBlossom Festival!\n"
+    },
+    {
+      "group": "mail",
+      "index": 426,
+      "label": "",
+      "original": "Attention, residents of\n<<STR_FREE0>>! The spring\nsport season is upon us!\nStretch those winter-weary\nlimbs and take part in the\nannual Spring Sports Fair!\n",
+      "new": "Attention, residents of\n<<STR_FREE0>>! The spring\nsport season is upon us!\nStretch those winter-weary\nlimbs and take part in the\nannual Spring Sports Fair!\n"
+    },
+    {
+      "group": "mail",
+      "index": 427,
+      "label": "",
+      "original": "      ~Notice~\nThe Spring Sports Fair\nwill be held on the vernal\nequinox. Stop by the wishing\nwell to watch the day's\nexciting athletic events!\n",
+      "new": "      ~Notice~\nThe Spring Sports Fair\nwill be held on the vernal\nequinox. Stop by the wishing\nwell to watch the day's\nexciting athletic events!\n"
+    },
+    {
+      "group": "mail",
+      "index": 428,
+      "label": "",
+      "original": " ~Spring Sports Fair~\n      Schedule of Events\n   9:00 a.m. - Aerobics\n  11:00 a.m. - Footrace\n   1:00 p.m. - Ball-Toss\n   3:00 p.m. - Tug-o'-War\n",
+      "new": " ~Spring Sports Fair~\n      Schedule of Events\n   9:00 a.m. - Aerobics\n  11:00 a.m. - Footrace\n   1:00 p.m. - Ball-Toss\n   3:00 p.m. - Tug-o'-War\n"
+    },
+    {
+      "group": "mail",
+      "index": 429,
+      "label": "",
+      "original": "~Come See the Blossoms!~\nJoin us April 5th-7th in the\nwishing well plaza for the\nCherry Blossom Festival!\nCome join us for this lovely\ncelebration of spring!\n",
+      "new": "~Come See the Blossoms!~\nJoin us April 5th-7th in the\nwishing well plaza for the\nCherry Blossom Festival!\nCome join us for this lovely\ncelebration of spring!\n"
+    },
+    {
+      "group": "mail",
+      "index": 430,
+      "label": "",
+      "original": "Spring is upon us! Flowers\nand warmer temperatures\nare a prelude to summer\nfun! It makes me want to\nfly a kite. Or a windsock.\nBe on the lookout for one!\n              <<STR_FREE1>>",
+      "new": "Spring is upon us! Flowers\nand warmer temperatures\nare a prelude to summer\nfun! It makes me want to\nfly a kite. Or a windsock.\nBe on the lookout for one!\n              <<STR_FREE1>>"
+    },
+    {
+      "group": "mail",
+      "index": 431,
+      "label": "",
+      "original": "~Seasonal Weather Report~\n<<STR_FREE0>> can expect\na period of beautiful sunny\nweather, with seasonal rains\ndue to set in by late June.\nEnjoy the sunshine!\n",
+      "new": "~Seasonal Weather Report~\n<<STR_FREE0>> can expect\na period of beautiful sunny\nweather, with seasonal rains\ndue to set in by late June.\nEnjoy the sunshine!\n"
+    },
+    {
+      "group": "mail",
+      "index": 432,
+      "label": "",
+      "original": "         ~Notice~\nFishing season is here!\nJoin us every Sunday in\nJune for our Summer Fishing\nTourneys! Can you catch a\nprize-winning fish?\n",
+      "new": "         ~Notice~\nFishing season is here!\nJoin us every Sunday in\nJune for our Summer Fishing\nTourneys! Can you catch a\nprize-winning fish?\n"
+    },
+    {
+      "group": "mail",
+      "index": 433,
+      "label": "",
+      "original": "So, how'd you make out in\nthe first week of the Fishing\nTourney? Good? Bad? Catch\na lunker? Catch a boot?\nCatch a cold? See you next\nSunday!              Chip\n",
+      "new": "So, how'd you make out in\nthe first week of the Fishing\nTourney? Good? Bad? Catch\na lunker? Catch a boot?\nCatch a cold? See you next\nSunday!              Chip\n"
+    },
+    {
+      "group": "mail",
+      "index": 434,
+      "label": "",
+      "original": "Well, thanks to everyone who\nparticipated in the Fishing\nTourney! I hope I get to eat\nall the tasty bass that you\nall caught! Nyuk nyuk nyuk!\n                      Chip\n",
+      "new": "Well, thanks to everyone who\nparticipated in the Fishing\nTourney! I hope I get to eat\nall the tasty bass that you\nall caught! Nyuk nyuk nyuk!\n                      Chip\n"
+    },
+    {
+      "group": "mail",
+      "index": 435,
+      "label": "",
+      "original": " ~Fireworks Festival~\nJoin us at 7:00 p.m. on July\n4th to commemorate the\nanniversary of the opening\nof the train station, with\nfood, fun, and fireworks!\n",
+      "new": " ~Fireworks Festival~\nJoin us at 7:00 p.m. on July\n4th to commemorate the\nanniversary of the opening\nof the train station, with\nfood, fun, and fireworks!\n"
+    },
+    {
+      "group": "mail",
+      "index": 436,
+      "label": "",
+      "original": "~Seasonal Weather Report~\n<<STR_FREE0>> can expect the\nsummer rains to end on or\naround July 16th. Expect a\nlong stretch of hot summer\ndays after that!\n",
+      "new": "~Seasonal Weather Report~\n<<STR_FREE0>> can expect the\nsummer rains to end on or\naround July 16th. Expect a\nlong stretch of hot summer\ndays after that!\n"
+    },
+    {
+      "group": "mail",
+      "index": 437,
+      "label": "",
+      "original": "It's not fair! Everyone else\ngot to see the fireworks,\nbut NO, not me! I had to\nWORK! Why? It's not like\nanyone came in anyway!\nThe place was deserted!\n",
+      "new": "It's not fair! Everyone else\ngot to see the fireworks,\nbut NO, not me! I had to\nWORK! Why? It's not like\nanyone came in anyway!\nThe place was deserted!\n"
+    },
+    {
+      "group": "mail",
+      "index": 438,
+      "label": "",
+      "original": "      ~Notice~\nAerobics for Early Risers!\nJoin us every morning at\n6:00 at the wishing well,\n7/25 through 8/31, for\nmorning aerobics!\n",
+      "new": "      ~Notice~\nAerobics for Early Risers!\nJoin us every morning at\n6:00 at the wishing well,\n7/25 through 8/31, for\nmorning aerobics!\n"
+    },
+    {
+      "group": "mail",
+      "index": 439,
+      "label": "",
+      "original": "Starting today, I want to see\neveryone at the wishing well\nat oh-six-hundred hours!\nYour friendly neighborhood\npolice dog will whip you into\nshape for swimsuit season!!!\n",
+      "new": "Starting today, I want to see\neveryone at the wishing well\nat oh-six-hundred hours!\nYour friendly neighborhood\npolice dog will whip you into\nshape for swimsuit season!!!\n"
+    },
+    {
+      "group": "mail",
+      "index": 440,
+      "label": "",
+      "original": " ~Meteor Shower~\n6:00 p.m., August 12th\nJoin us by the lake to see\nthis year's meteor shower\nat its awe-inspiring peak!\nYou'll see stars!\n",
+      "new": " ~Meteor Shower~\n6:00 p.m., August 12th\nJoin us by the lake to see\nthis year's meteor shower\nat its awe-inspiring peak!\nYou'll see stars!\n"
+    },
+    {
+      "group": "mail",
+      "index": 441,
+      "label": "",
+      "original": "Attention, citizens! Tomorrow\nis the final day for morning\naerobics! Congrats to those\nof you who joined. To the\nrest: too bad you frittered\nyour summer away, lazybones!\n",
+      "new": "Attention, citizens! Tomorrow\nis the final day for morning\naerobics! Congrats to those\nof you who joined. To the\nrest: too bad you frittered\nyour summer away, lazybones!\n"
+    },
+    {
+      "group": "mail",
+      "index": 442,
+      "label": "",
+      "original": "     ~Moon Viewing~\n\nJoin us <<STR_FREE2>>\nat 6:00 p.m. as we view the\ntranquil autumn beauty of\nthe harvest moon.\n",
+      "new": "     ~Moon Viewing~\n\nJoin us <<STR_FREE2>>\nat 6:00 p.m. as we view the\ntranquil autumn beauty of\nthe harvest moon.\n"
+    },
+    {
+      "group": "mail",
+      "index": 443,
+      "label": "",
+      "original": "~Seasonal Weather Report~\nForecasts show heavy rains\nexpected through September.\nBut a pleasant stretch of\nIndian summer in October\nshould cheer you all up!\n",
+      "new": "~Seasonal Weather Report~\nForecasts show heavy rains\nexpected through September.\nBut a pleasant stretch of\nIndian summer in October\nshould cheer you all up!\n"
+    },
+    {
+      "group": "mail",
+      "index": 444,
+      "label": "",
+      "original": "The fall sports season is\nalmost here! Since my\nschedule doesn't allow me to\nparticipate, I expect all of\nyou to pick up my slack!\n                      Pete\n",
+      "new": "The fall sports season is\nalmost here! Since my\nschedule doesn't allow me to\nparticipate, I expect all of\nyou to pick up my slack!\n                      Pete\n"
+    },
+    {
+      "group": "mail",
+      "index": 445,
+      "label": "",
+      "original": "~Fall Sports Fair~\n\nCome to the wishing well\nplaza on <<STR_FREE4>> to\nwatch the events! It'll be\na wild time, guaranteed!\n",
+      "new": "~Fall Sports Fair~\n\nCome to the wishing well\nplaza on <<STR_FREE4>> to\nwatch the events! It'll be\na wild time, guaranteed!\n"
+    },
+    {
+      "group": "mail",
+      "index": 446,
+      "label": "",
+      "original": "   ~Fall Sports Fair~\n      Schedule of Events\n  9:00 a.m. - Aerobics\n 11:00 a.m. - Footrace\n  1:00 p.m. - Ball-Toss\n  3:00 p.m. - Tug-o'-War\n",
+      "new": "   ~Fall Sports Fair~\n      Schedule of Events\n  9:00 a.m. - Aerobics\n 11:00 a.m. - Footrace\n  1:00 p.m. - Ball-Toss\n  3:00 p.m. - Tug-o'-War\n"
+    },
+    {
+      "group": "mail",
+      "index": 447,
+      "label": "",
+      "original": "~Attention Mycologists!~\nAt long last, mushrooming\nseason is upon us! Yes, in\njust four or five more days,\ndon your 'shrooming shoes\nand hunt those mushrooms!\n",
+      "new": "~Attention Mycologists!~\nAt long last, mushrooming\nseason is upon us! Yes, in\njust four or five more days,\ndon your 'shrooming shoes\nand hunt those mushrooms!\n"
+    },
+    {
+      "group": "mail",
+      "index": 448,
+      "label": "",
+      "original": "We have the best (and only)\nselection of Halloween candy\nin town! Treat your trick-\nor-treaters to the best! Be\nsure to stock up before the\n31st!        <<STR_FREE1>>\n",
+      "new": "We have the best (and only)\nselection of Halloween candy\nin town! Treat your trick-\nor-treaters to the best! Be\nsure to stock up before the\n31st!        <<STR_FREE1>>\n"
+    },
+    {
+      "group": "mail",
+      "index": 449,
+      "label": "",
+      "original": "     ~Halloween Fun!~\n       October 31st\n Don't be caught out after\n  dark! There's no telling\n    what kind of trouble\n       you'll run into!\n",
+      "new": "     ~Halloween Fun!~\n       October 31st\n Don't be caught out after\n  dark! There's no telling\n    what kind of trouble\n       you'll run into!\n"
+    },
+    {
+      "group": "mail",
+      "index": 450,
+      "label": "",
+      "original": "  ~Fall Fishing Tourney~\nThe fall fishing season is\nhere! If you're hooked on\nfishing, join us every Sunday\nin November to see if you've\ngot skills with the gills!\n",
+      "new": "  ~Fall Fishing Tourney~\nThe fall fishing season is\nhere! If you're hooked on\nfishing, join us every Sunday\nin November to see if you've\ngot skills with the gills!\n"
+    },
+    {
+      "group": "mail",
+      "index": 451,
+      "label": "",
+      "original": "So how'd you do in the first\nweek of the tournament?\nFloating to the top? Feeding\non the bottom? I'll have\nmany prizes next Sunday, too.\n                      Chip\n",
+      "new": "So how'd you do in the first\nweek of the tournament?\nFloating to the top? Feeding\non the bottom? I'll have\nmany prizes next Sunday, too.\n                      Chip\n"
+    },
+    {
+      "group": "mail",
+      "index": 452,
+      "label": "",
+      "original": "The season of plenty is upon\nus! Join us to celebrate our\nbounty at the annual Harvest\nFestival on the 4th Thursday\nin November!\n\n",
+      "new": "The season of plenty is upon\nus! Join us to celebrate our\nbounty at the annual Harvest\nFestival on the 4th Thursday\nin November!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 453,
+      "label": "",
+      "original": "~Seasonal Weather Report~\nNovember will see a stretch\nof snow flurries, with\ncolder temperatures at dawn\nand dusk. Take care not to\ncatch an early winter cold!\n",
+      "new": "~Seasonal Weather Report~\nNovember will see a stretch\nof snow flurries, with\ncolder temperatures at dawn\nand dusk. Take care not to\ncatch an early winter cold!\n"
+    },
+    {
+      "group": "mail",
+      "index": 454,
+      "label": "",
+      "original": "This Sunday is the final day\nof the Fall Fishing Tourney!\nDon't miss this opportunity\nto catch some tasty, tasty\nbass for me! Nyuk nyuk nyuk!\n             Chip\n",
+      "new": "This Sunday is the final day\nof the Fall Fishing Tourney!\nDon't miss this opportunity\nto catch some tasty, tasty\nbass for me! Nyuk nyuk nyuk!\n             Chip\n"
+    },
+    {
+      "group": "mail",
+      "index": 455,
+      "label": "",
+      "original": "  ! Winter Storm Warning !\nA fierce cold front is fast\napproaching <<STR_FREE0>>,\nwith heavy snows forecast\nfor all neighboring regions.\nWatch out for snow drifts!\n",
+      "new": "  ! Winter Storm Warning !\nA fierce cold front is fast\napproaching <<STR_FREE0>>,\nwith heavy snows forecast\nfor all neighboring regions.\nWatch out for snow drifts!\n"
+    },
+    {
+      "group": "mail",
+      "index": 456,
+      "label": "",
+      "original": "Happy holidays, everybody!\nJingle here! I'll be making\nmy rounds on the 24th again\nthis year to give gifts to\neveryone on my list! I'll be\nbusy, so don't distract me!\n",
+      "new": "Happy holidays, everybody!\nJingle here! I'll be making\nmy rounds on the 24th again\nthis year to give gifts to\neveryone on my list! I'll be\nbusy, so don't distract me!\n"
+    },
+    {
+      "group": "mail",
+      "index": 457,
+      "label": "",
+      "original": "New Year's Eve Countdown!\nJoin us December 31st at\n11:00 p.m. for our annual\ncountdown celebration\nby the lake! Let's ring in\nthe new year together!\n",
+      "new": "New Year's Eve Countdown!\nJoin us December 31st at\n11:00 p.m. for our annual\ncountdown celebration\nby the lake! Let's ring in\nthe new year together!\n"
+    },
+    {
+      "group": "mail",
+      "index": 458,
+      "label": "",
+      "original": "~New Year Wishes~\nJoin us at the wishing well\nplaza for our annual New\nYear's Day festivities! Make\nyour New Year's wish and\nget your fortune read!\n",
+      "new": "~New Year Wishes~\nJoin us at the wishing well\nplaza for our annual New\nYear's Day festivities! Make\nyour New Year's wish and\nget your fortune read!\n"
+    },
+    {
+      "group": "mail",
+      "index": 459,
+      "label": "",
+      "original": "Check your mailbox daily!\nIf your mailbox is filled up,\nI can't deliver the mail!\nPlease, folks, it's my job, so\nkeep the mailboxes in order!\n                      Pete\n",
+      "new": "Check your mailbox daily!\nIf your mailbox is filled up,\nI can't deliver the mail!\nPlease, folks, it's my job, so\nkeep the mailboxes in order!\n                      Pete\n"
+    },
+    {
+      "group": "mail",
+      "index": 460,
+      "label": "",
+      "original": "       ! Don't Litter !\nDo you want to live in a\nnasty filth-hole? Of course\nnot. So dump your garbage\nin the dump! Trash days are\nevery Monday and Thursday.\n",
+      "new": "       ! Don't Litter !\nDo you want to live in a\nnasty filth-hole? Of course\nnot. So dump your garbage\nin the dump! Trash days are\nevery Monday and Thursday.\n"
+    },
+    {
+      "group": "mail",
+      "index": 461,
+      "label": "",
+      "original": "Ready to Spring Forward?\nIf you live in an area that\nobserves daylight saving\ntime, be sure to set your\nclock ahead one hour at\nat 2:00 a.m. next Sunday!\n",
+      "new": "Ready to Spring Forward?\nIf you live in an area that\nobserves daylight saving\ntime, be sure to set your\nclock ahead one hour at\nat 2:00 a.m. next Sunday!\n"
+    },
+    {
+      "group": "mail",
+      "index": 462,
+      "label": "",
+      "original": "It's time to fall back!\nIf you live in an area that\nobserves daylight saving\ntime, be sure to set your\nclock back one hour at\n2:00 a.m. next Sunday.\n",
+      "new": "It's time to fall back!\nIf you live in an area that\nobserves daylight saving\ntime, be sure to set your\nclock back one hour at\n2:00 a.m. next Sunday.\n"
+    },
+    {
+      "group": "mail",
+      "index": 463,
+      "label": "",
+      "original": "\n\n\n\n\n\n",
+      "new": "\n\n\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 464,
+      "label": "",
+      "original": "\n\n\n\n\n\n",
+      "new": "\n\n\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 465,
+      "label": "",
+      "original": "\n\n\n\n\n\n",
+      "new": "\n\n\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 466,
+      "label": "",
+      "original": "\n\n\n\n\n\n",
+      "new": "\n\n\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 467,
+      "label": "",
+      "original": "\n\n\n\n\n\n",
+      "new": "\n\n\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 468,
+      "label": "",
+      "original": "\n\n\n\n\n\n",
+      "new": "\n\n\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 469,
+      "label": "",
+      "original": "\n\n\n\n\n\n",
+      "new": "\n\n\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 470,
+      "label": "",
+      "original": "\n\n\n\n\n\n",
+      "new": "\n\n\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 471,
+      "label": "",
+      "original": "\n\n\n\n\n\n",
+      "new": "\n\n\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 472,
+      "label": "",
+      "original": "\n\n\n\n\n\n",
+      "new": "\n\n\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 473,
+      "label": "",
+      "original": "\n\n\n\n\n\n",
+      "new": "\n\n\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 474,
+      "label": "",
+      "original": "\n\n\n\n\n\n",
+      "new": "\n\n\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 475,
+      "label": "",
+      "original": "\n\n\n\n\n\n",
+      "new": "\n\n\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 476,
+      "label": "",
+      "original": "Here's a great tip! If your\nroom needs an exotic flair,\nthen get yourself a complete\nset of exotic wares: table,\nchair, bed, bureau, wardrobe,\nbench, and lamp!\n",
+      "new": "Here's a great tip! If your\nroom needs an exotic flair,\nthen get yourself a complete\nset of exotic wares: table,\nchair, bed, bureau, wardrobe,\nbench, and lamp!\n"
+    },
+    {
+      "group": "mail",
+      "index": 477,
+      "label": "",
+      "original": "Need some love in your life?\nWhy not start by making\nyour house look lovely with\na lovely end table, chair,\nbed, armchair, dresser, lamp,\nand more? Isn't life lovely?\n",
+      "new": "Need some love in your life?\nWhy not start by making\nyour house look lovely with\na lovely end table, chair,\nbed, armchair, dresser, lamp,\nand more? Isn't life lovely?\n"
+    },
+    {
+      "group": "mail",
+      "index": 478,
+      "label": "",
+      "original": "You're classy, and you know\nit! Now you can show it\nwith the classic table,\nchair, bed, sofa, cabinet,\nclock, hutch, wardrobe,\ncarpet, and wallpaper!\n",
+      "new": "You're classy, and you know\nit! Now you can show it\nwith the classic table,\nchair, bed, sofa, cabinet,\nclock, hutch, wardrobe,\ncarpet, and wallpaper!\n"
+    },
+    {
+      "group": "mail",
+      "index": 479,
+      "label": "",
+      "original": "For that perfect \"Home On\nthe Range,\" try the ranch\nset: the ranch wallpaper and\ncarpet perfectly complement\nyour table, bed, armchair,\nchair, dresser, and couch!\n",
+      "new": "For that perfect \"Home On\nthe Range,\" try the ranch\nset: the ranch wallpaper and\ncarpet perfectly complement\nyour table, bed, armchair,\nchair, dresser, and couch!\n"
+    },
+    {
+      "group": "mail",
+      "index": 480,
+      "label": "",
+      "original": "Need a vacation? Well, who\ndoesn't? Transform your\nhome into a luxurious beach\nresort with the cabana\narmchair, table, bed, chair,\nlamp, vanity, and wardrobe!\n",
+      "new": "Need a vacation? Well, who\ndoesn't? Transform your\nhome into a luxurious beach\nresort with the cabana\narmchair, table, bed, chair,\nlamp, vanity, and wardrobe!\n"
+    },
+    {
+      "group": "mail",
+      "index": 481,
+      "label": "",
+      "original": "Now your home can be your\ncastle! Enhance the beauty\nof the regal bed, dresser,\nwardrobe, vanity, sofa, table,\nand cupboard with the regal\ncarpet and wallpaper.\n",
+      "new": "Now your home can be your\ncastle! Enhance the beauty\nof the regal bed, dresser,\nwardrobe, vanity, sofa, table,\nand cupboard with the regal\ncarpet and wallpaper.\n"
+    },
+    {
+      "group": "mail",
+      "index": 482,
+      "label": "",
+      "original": "Bring the soothing beauty of\nthe sea into your home with\na blue dresser, bookcase,\nbed, chair, table, bench,\nwardrobe, bureau, carpet,\nand wallpaper!\n",
+      "new": "Bring the soothing beauty of\nthe sea into your home with\na blue dresser, bookcase,\nbed, chair, table, bench,\nwardrobe, bureau, carpet,\nand wallpaper!\n"
+    },
+    {
+      "group": "mail",
+      "index": 483,
+      "label": "",
+      "original": "Flaunt your hip sensibilities\nwith a complete set of\nmodern gear: modern carpet\nand wallpaper, and a modern\nchair, dresser, wardrobe,\nbed, cabinet, and end table!\n",
+      "new": "Flaunt your hip sensibilities\nwith a complete set of\nmodern gear: modern carpet\nand wallpaper, and a modern\nchair, dresser, wardrobe,\nbed, cabinet, and end table!\n"
+    },
+    {
+      "group": "mail",
+      "index": 484,
+      "label": "",
+      "original": "Make your pals green with\nenvy with the green set!\nJust imagine it: your bed,\ndresser, pantry, counter, and\neverything you own in\nglorious green!\n",
+      "new": "Make your pals green with\nenvy with the green set!\nJust imagine it: your bed,\ndresser, pantry, counter, and\neverything you own in\nglorious green!\n"
+    },
+    {
+      "group": "mail",
+      "index": 485,
+      "label": "",
+      "original": "Do you pine for the rural\nsimplicity of a remote\ncabin? With the cabin table,\ncouch, bed, chair, wardrobe,\nclock, and bookcase, you'll\nbe living the rustic life!\n",
+      "new": "Do you pine for the rural\nsimplicity of a remote\ncabin? With the cabin table,\ncouch, bed, chair, wardrobe,\nclock, and bookcase, you'll\nbe living the rustic life!\n"
+    },
+    {
+      "group": "mail",
+      "index": 486,
+      "label": "",
+      "original": "Are you young at heart?\nThen you'll LOVE the kiddie\nset! The kiddie dresser, bed,\ncouch, wardrobe, bookcase,\nchair, and clock will bring\nout the kid in you!\n",
+      "new": "Are you young at heart?\nThen you'll LOVE the kiddie\nset! The kiddie dresser, bed,\ncouch, wardrobe, bookcase,\nchair, and clock will bring\nout the kid in you!\n"
+    },
+    {
+      "group": "mail",
+      "index": 487,
+      "label": "",
+      "original": "A quick household tip:\nSome furniture sets aren't\navailable in any store!\nSadly, we at the Happy Room\nAcademy can't offer any\nadvice regarding these sets.\n",
+      "new": "A quick household tip:\nSome furniture sets aren't\navailable in any store!\nSadly, we at the Happy Room\nAcademy can't offer any\nadvice regarding these sets.\n"
+    },
+    {
+      "group": "mail",
+      "index": 488,
+      "label": "",
+      "original": "If you like a nice, orderly\nhouseーand we at the Happy\nRoom Academy doーthen we\nsuggest you purchase all the\npieces in a furniture set!\nPay attention to set names!\n",
+      "new": "If you like a nice, orderly\nhouseーand we at the Happy\nRoom Academy doーthen we\nsuggest you purchase all the\npieces in a furniture set!\nPay attention to set names!\n"
+    },
+    {
+      "group": "mail",
+      "index": 489,
+      "label": "",
+      "original": "Putting everything you own\nin your room won't earn\nyou high marks for interior\ndesign. Quite the opposite!\nThink about what you need,\nand plan accordingly!\n",
+      "new": "Putting everything you own\nin your room won't earn\nyou high marks for interior\ndesign. Quite the opposite!\nThink about what you need,\nand plan accordingly!\n"
+    },
+    {
+      "group": "mail",
+      "index": 490,
+      "label": "",
+      "original": "A practical design is always\nnice, but you may find that\nimpressing visitors with a\nstrange, yet artistic, layout\ncan also be satisfying. Let\ncreativity be your guide!\n",
+      "new": "A practical design is always\nnice, but you may find that\nimpressing visitors with a\nstrange, yet artistic, layout\ncan also be satisfying. Let\ncreativity be your guide!\n"
+    },
+    {
+      "group": "mail",
+      "index": 491,
+      "label": "",
+      "original": "Decorating your home is \nimportant, but that doesn't\nmake it easy! Instead of\ntrying to mix and match, it\nmay be easier just to collect\npieces from one set you like.\n",
+      "new": "Decorating your home is \nimportant, but that doesn't\nmake it easy! Instead of\ntrying to mix and match, it\nmay be easier just to collect\npieces from one set you like.\n"
+    },
+    {
+      "group": "mail",
+      "index": 492,
+      "label": "",
+      "original": "Rare furniture and items you\ncan only get at annual\nevents or with raffle tickets\nwill boost your Happy Room\npoint total! Get these itemsー\nyou'll be glad you did. \n",
+      "new": "Rare furniture and items you\ncan only get at annual\nevents or with raffle tickets\nwill boost your Happy Room\npoint total! Get these itemsー\nyou'll be glad you did. \n"
+    },
+    {
+      "group": "mail",
+      "index": 493,
+      "label": "",
+      "original": "Helpful hints for happy\nhomemakers! Every piece\nof furniture has a function.\nFor example, if your dresser\nfaces a wall, it's useless!\nLet the function guide you!\n",
+      "new": "Helpful hints for happy\nhomemakers! Every piece\nof furniture has a function.\nFor example, if your dresser\nfaces a wall, it's useless!\nLet the function guide you!\n"
+    },
+    {
+      "group": "mail",
+      "index": 494,
+      "label": "",
+      "original": "It can take a long time to\ncomplete a furniture set\non your own. Why not enlist\nthe help of your neighbors?\nBuy, sell, and trade your\nway to a happy home!\n",
+      "new": "It can take a long time to\ncomplete a furniture set\non your own. Why not enlist\nthe help of your neighbors?\nBuy, sell, and trade your\nway to a happy home!\n"
+    },
+    {
+      "group": "mail",
+      "index": 495,
+      "label": "",
+      "original": "Thank you for joining the\nHappy Room Academy! We'll\nbe monitoring your progress\nas you try to turn your home\ninto a masterpiece of style.\nHappy decorating!\n",
+      "new": "Thank you for joining the\nHappy Room Academy! We'll\nbe monitoring your progress\nas you try to turn your home\ninto a masterpiece of style.\nHappy decorating!\n"
+    },
+    {
+      "group": "mail",
+      "index": 496,
+      "label": "",
+      "original": "Wouldn't you like to get\n<<STR_FREE2>>? One lucky\nindividual will! I planted\none somewhere in Acre\n<<STR_FREE3>>-<<STR_FREE4>>! Good luck!\n           <<STR_FREE1>>\n",
+      "new": "Wouldn't you like to get\n<<STR_FREE2>>? One lucky\nindividual will! I planted\none somewhere in Acre\n<<STR_FREE3>>-<<STR_FREE4>>! Good luck!\n           <<STR_FREE1>>\n"
+    },
+    {
+      "group": "mail",
+      "index": 497,
+      "label": "",
+      "original": "♪Treasure Hunt Time!♪\nCan you find my buried\ntreasure? It's somewhere in\nAcre <<STR_FREE3>>-<<STR_FREE4>>. If you want\nto know what it is, find it!\n           <<STR_FREE1>>\n",
+      "new": "♪Treasure Hunt Time!♪\nCan you find my buried\ntreasure? It's somewhere in\nAcre <<STR_FREE3>>-<<STR_FREE4>>. If you want\nto know what it is, find it!\n           <<STR_FREE1>>\n"
+    },
+    {
+      "group": "mail",
+      "index": 498,
+      "label": "",
+      "original": "Free <<CUTARTICLE>><<STR_FREE2>>\nfor whoever finds it!\nIt's buried somewhere in\nthe <<STR_FREE3>> acres. Hurry up!\nIt may already be gone!😃\n\n",
+      "new": "Free <<CUTARTICLE>><<STR_FREE2>>\nfor whoever finds it!\nIt's buried somewhere in\nthe <<STR_FREE3>> acres. Hurry up!\nIt may already be gone!😃\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 499,
+      "label": "",
+      "original": "One lucky ducky just might\nfind some super surprise\nburied in Acre <<STR_FREE3>>-<<STR_FREE4>>!\nI won't tell you what it is,\nthough! Can you find it?\n    ♥<<STR_FREE1>>♥\n",
+      "new": "One lucky ducky just might\nfind some super surprise\nburied in Acre <<STR_FREE3>>-<<STR_FREE4>>!\nI won't tell you what it is,\nthough! Can you find it?\n    ♥<<STR_FREE1>>♥\n"
+    },
+    {
+      "group": "mail",
+      "index": 500,
+      "label": "",
+      "original": "Free <<CUTARTICLE>><<STR_FREE2>>\nfor whoever finds it! Woo!\n\nGo dig in the <<STR_FREE3>> acres!\nYou snooze, you lose!\n      ♥<<STR_FREE1>>♥\n",
+      "new": "Free <<CUTARTICLE>><<STR_FREE2>>\nfor whoever finds it! Woo!\n\nGo dig in the <<STR_FREE3>> acres!\nYou snooze, you lose!\n      ♥<<STR_FREE1>>♥\n"
+    },
+    {
+      "group": "mail",
+      "index": 501,
+      "label": "",
+      "original": "Anyone who wants\n<<STR_FREE2>>, start\ndigging in Acre <<STR_FREE3>>-<<STR_FREE4>>!\n(It's not my fault if it's\nalready gone by the time\nyou get there♪!)\n",
+      "new": "Anyone who wants\n<<STR_FREE2>>, start\ndigging in Acre <<STR_FREE3>>-<<STR_FREE4>>!\n(It's not my fault if it's\nalready gone by the time\nyou get there♪!)\n"
+    },
+    {
+      "group": "mail",
+      "index": 502,
+      "label": "",
+      "original": "I buried my most prized\nbelonging in one of the\n<<STR_FREE3>> acres. I know it's\na waste, but I guess I just\ndon't care. Finders keepers!\n    from <<STR_FREE1>>\n",
+      "new": "I buried my most prized\nbelonging in one of the\n<<STR_FREE3>> acres. I know it's\na waste, but I guess I just\ndon't care. Finders keepers!\n    from <<STR_FREE1>>\n"
+    },
+    {
+      "group": "mail",
+      "index": 503,
+      "label": "",
+      "original": "To the folks of <<STR_FREE5>>.\nI buried valuable treasure\nsomewhere in Acre <<STR_FREE3>>-<<STR_FREE4>>!😃\nTake a peek out thereーmaybe\nyou'll find it...\n      from <<STR_FREE1>>\n",
+      "new": "To the folks of <<STR_FREE5>>.\nI buried valuable treasure\nsomewhere in Acre <<STR_FREE3>>-<<STR_FREE4>>!😃\nTake a peek out thereーmaybe\nyou'll find it...\n      from <<STR_FREE1>>\n"
+    },
+    {
+      "group": "mail",
+      "index": 504,
+      "label": "",
+      "original": "I buried my <<CUTARTICLE>><<STR_FREE2>>\nin one of the <<STR_FREE4>> acres.\nI don't know why I did it;\nI was sleepwalking at the\ntime. Finders keepers!\n      from <<STR_FREE1>>\n",
+      "new": "I buried my <<CUTARTICLE>><<STR_FREE2>>\nin one of the <<STR_FREE4>> acres.\nI don't know why I did it;\nI was sleepwalking at the\ntime. Finders keepers!\n      from <<STR_FREE1>>\n"
+    },
+    {
+      "group": "mail",
+      "index": 505,
+      "label": "",
+      "original": "Hey, my peeps! <<STR_FREE1>>\nhere reporting for\n<<STR_FREE5>> News!\nI've buried the greatest\ntreasure ever in one of the\n<<STR_FREE3>> acres. Go find it!\n",
+      "new": "Hey, my peeps! <<STR_FREE1>>\nhere reporting for\n<<STR_FREE5>> News!\nI've buried the greatest\ntreasure ever in one of the\n<<STR_FREE3>> acres. Go find it!\n"
+    },
+    {
+      "group": "mail",
+      "index": 506,
+      "label": "",
+      "original": "<<STR_FREE1>> here! I've\nburied something that\neveryone'll love somewhere\nin one of <<STR_FREE5>>'s\n<<STR_FREE3>> acres. Start digging!\n\n",
+      "new": "<<STR_FREE1>> here! I've\nburied something that\neveryone'll love somewhere\nin one of <<STR_FREE5>>'s\n<<STR_FREE3>> acres. Start digging!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 507,
+      "label": "",
+      "original": "What up! It's <<STR_FREE1>>!\nI've buried my favorite\nthing in the world in Acre\n<<STR_FREE3>>-<<STR_FREE4>>! Be good sports\nand see who can find it\nfirst! Dig it!\n",
+      "new": "What up! It's <<STR_FREE1>>!\nI've buried my favorite\nthing in the world in Acre\n<<STR_FREE3>>-<<STR_FREE4>>! Be good sports\nand see who can find it\nfirst! Dig it!\n"
+    },
+    {
+      "group": "mail",
+      "index": 508,
+      "label": "",
+      "original": "Hey! It's <<STR_FREE1>>! 💢\nI buried\n<<STR_FREE2>>\nsomewhere in Acre <<STR_FREE3>>-<<STR_FREE4>>.\nWhoever finds it, keeps it!\nBut you'll owe me big time!\n",
+      "new": "Hey! It's <<STR_FREE1>>! 💢\nI buried\n<<STR_FREE2>>\nsomewhere in Acre <<STR_FREE3>>-<<STR_FREE4>>.\nWhoever finds it, keeps it!\nBut you'll owe me big time!\n"
+    },
+    {
+      "group": "mail",
+      "index": 509,
+      "label": "",
+      "original": "Get in gear! It's time for a\ntreasure hunt! I buried\n<<STR_FREE2>>. It's\nsomewhere in one of the\n<<STR_FREE3>> acres. I ain't saying no\nmore. Find it for yourself!\n",
+      "new": "Get in gear! It's time for a\ntreasure hunt! I buried\n<<STR_FREE2>>. It's\nsomewhere in one of the\n<<STR_FREE3>> acres. I ain't saying no\nmore. Find it for yourself!\n"
+    },
+    {
+      "group": "mail",
+      "index": 510,
+      "label": "",
+      "original": "I have one great present for\nwhoever finds it! 😃\nIt's <<STR_FREE2>>.\nIt's somewhere in one of the\n<<STR_FREE4>> acres, so if you find it,\nit's yours!\n",
+      "new": "I have one great present for\nwhoever finds it! 😃\nIt's <<STR_FREE2>>.\nIt's somewhere in one of the\n<<STR_FREE4>> acres, so if you find it,\nit's yours!\n"
+    },
+    {
+      "group": "mail",
+      "index": 511,
+      "label": "",
+      "original": "I've buried some treasure!\nIsn't that generous of me?\nLook for <<STR_FREE2>>\nburied somewhere in\nAcre <<STR_FREE3>>-<<STR_FREE4>>. You'd better\nstep on it if you want it!\n",
+      "new": "I've buried some treasure!\nIsn't that generous of me?\nLook for <<STR_FREE2>>\nburied somewhere in\nAcre <<STR_FREE3>>-<<STR_FREE4>>. You'd better\nstep on it if you want it!\n"
+    },
+    {
+      "group": "mail",
+      "index": 512,
+      "label": "",
+      "original": "😃 Who wants to play my\nlittle game? 😃 If you can\nfind the <<CUTARTICLE>><<STR_FREE2>>\nI buried in one of the <<STR_FREE4>>\nacres, it's yours! ♥ But...\nIt may already be gone! 🌢\n",
+      "new": "😃 Who wants to play my\nlittle game? 😃 If you can\nfind the <<CUTARTICLE>><<STR_FREE2>>\nI buried in one of the <<STR_FREE4>>\nacres, it's yours! ♥ But...\nIt may already be gone! 🌢\n"
+    },
+    {
+      "group": "mail",
+      "index": 513,
+      "label": "",
+      "original": "♥♥Yours for the taking!♥♥\nI buried <<STR_FREE2>>\nin one of the <<STR_FREE4>> acres.\nCan you find it? If you can,\nit's all yours! ♥♥♥\n\n",
+      "new": "♥♥Yours for the taking!♥♥\nI buried <<STR_FREE2>>\nin one of the <<STR_FREE4>> acres.\nCan you find it? If you can,\nit's all yours! ♥♥♥\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 514,
+      "label": "",
+      "original": "Snow there! I do believe a\ngift is in orderーI surely\nappreciate you building me!\nThis little <<CUTARTICLE>><<STR_FREE0>>\nwill keep anything as cool\nas you. Take it, it's yours!\n",
+      "new": "Snow there! I do believe a\ngift is in orderーI surely\nappreciate you building me!\nThis little <<CUTARTICLE>><<STR_FREE0>>\nwill keep anything as cool\nas you. Take it, it's yours!\n"
+    },
+    {
+      "group": "mail",
+      "index": 515,
+      "label": "",
+      "original": "Snow nelly! Now THAT was\nsome snowman-building! I've\nnever been so well-crafted!\nTake this <<CUTARTICLE>><<STR_FREE0>>\nas my thanks! It's a real\npiece of workーlike you! 😃\n",
+      "new": "Snow nelly! Now THAT was\nsome snowman-building! I've\nnever been so well-crafted!\nTake this <<CUTARTICLE>><<STR_FREE0>>\nas my thanks! It's a real\npiece of workーlike you! 😃\n"
+    },
+    {
+      "group": "mail",
+      "index": 516,
+      "label": "",
+      "original": "Here's something for making\nme such a noble snowman!\nThis <<CUTARTICLE>><<STR_FREE0>> will\nmake sure you stay cool...\nAh, just pulling your icicle!\nIt'll keep you warm! 😃\n",
+      "new": "Here's something for making\nme such a noble snowman!\nThis <<CUTARTICLE>><<STR_FREE0>> will\nmake sure you stay cool...\nAh, just pulling your icicle!\nIt'll keep you warm! 😃\n"
+    },
+    {
+      "group": "mail",
+      "index": 517,
+      "label": "",
+      "original": "Here's a fine <<CUTARTICLE>><<STR_FREE0>>\nas a token of my thanks.\nIt's good, solid snowman\ncraftsmanship, so don't be\nafraid to relax and chill\nto your heart's content! 😃\n",
+      "new": "Here's a fine <<CUTARTICLE>><<STR_FREE0>>\nas a token of my thanks.\nIt's good, solid snowman\ncraftsmanship, so don't be\nafraid to relax and chill\nto your heart's content! 😃\n"
+    },
+    {
+      "group": "mail",
+      "index": 518,
+      "label": "",
+      "original": "This <<CUTARTICLE>><<STR_FREE0>>\nis my way of saying thanks\nfor molding me into what I\nam today! May this light\nwarm your home on even\nthe coldest day! 😃\n",
+      "new": "This <<CUTARTICLE>><<STR_FREE0>>\nis my way of saying thanks\nfor molding me into what I\nam today! May this light\nwarm your home on even\nthe coldest day! 😃\n"
+    },
+    {
+      "group": "mail",
+      "index": 519,
+      "label": "",
+      "original": "How can I repay you for\nmaking me into such a fine,\nupstanding snowman? Aha!\nTake this <<CUTARTICLE>><<STR_FREE0>>!\nCareful not to hurt yourself\nif you sit in the middle! 😃\n",
+      "new": "How can I repay you for\nmaking me into such a fine,\nupstanding snowman? Aha!\nTake this <<CUTARTICLE>><<STR_FREE0>>!\nCareful not to hurt yourself\nif you sit in the middle! 😃\n"
+    },
+    {
+      "group": "mail",
+      "index": 520,
+      "label": "",
+      "original": "This <<CUTARTICLE>><<STR_FREE0>>\nis just a little token of my\nthanks. After all the hassle\nyou went to building me, it's\nthe least I could do. Sorry\nfor the snowy reception! 😃\n",
+      "new": "This <<CUTARTICLE>><<STR_FREE0>>\nis just a little token of my\nthanks. After all the hassle\nyou went to building me, it's\nthe least I could do. Sorry\nfor the snowy reception! 😃\n"
+    },
+    {
+      "group": "mail",
+      "index": 521,
+      "label": "",
+      "original": "This <<CUTARTICLE>><<STR_FREE0>> is\nby far the coolest way ever\nto store your things. I beg\nyou, please accept it as my\nway of saying thanks for\ncreating me! 😃\n",
+      "new": "This <<CUTARTICLE>><<STR_FREE0>> is\nby far the coolest way ever\nto store your things. I beg\nyou, please accept it as my\nway of saying thanks for\ncreating me! 😃\n"
+    },
+    {
+      "group": "mail",
+      "index": 522,
+      "label": "",
+      "original": "You could have flaked, but\ninstead you took the time to\nmold me into a fine figure!\nI insist that you accept this\n<<CUTARTICLE>><<STR_FREE0>> as a\nthank-you. Enjoy! 😃\n",
+      "new": "You could have flaked, but\ninstead you took the time to\nmold me into a fine figure!\nI insist that you accept this\n<<CUTARTICLE>><<STR_FREE0>> as a\nthank-you. Enjoy! 😃\n"
+    },
+    {
+      "group": "mail",
+      "index": 523,
+      "label": "",
+      "original": "You wasted no time getting\nme on my...uh...torso, \nso this <<CUTARTICLE>><<STR_FREE0>>\nis for you! I made sure to\nsynchronize it with the\nstation clock! 😃\n",
+      "new": "You wasted no time getting\nme on my...uh...torso, \nso this <<CUTARTICLE>><<STR_FREE0>>\nis for you! I made sure to\nsynchronize it with the\nstation clock! 😃\n"
+    },
+    {
+      "group": "mail",
+      "index": 524,
+      "label": "",
+      "original": "I put my all into weaving\nthis <<CUTARTICLE>><<STR_FREE0>>\nfor you. ♪ Thanks for making\nme so handsome! You're the\n\"icest\" person I know, and\nthat's \"snow\" joke! Ha!\n",
+      "new": "I put my all into weaving\nthis <<CUTARTICLE>><<STR_FREE0>>\nfor you. ♪ Thanks for making\nme so handsome! You're the\n\"icest\" person I know, and\nthat's \"snow\" joke! Ha!\n"
+    },
+    {
+      "group": "mail",
+      "index": 525,
+      "label": "",
+      "original": "This <<CUTARTICLE>><<STR_FREE0>>\nis as cool as the other side\nof the pillow! Feel free to\nput it up or just sell it to\nhelp you get byーit's yours to\ndo with as you please! ♪ \n",
+      "new": "This <<CUTARTICLE>><<STR_FREE0>>\nis as cool as the other side\nof the pillow! Feel free to\nput it up or just sell it to\nhelp you get byーit's yours to\ndo with as you please! ♪ \n"
+    },
+    {
+      "group": "mail",
+      "index": 526,
+      "label": "",
+      "original": "I recently decided to move\nfor reasons I prefer not to\ngo into. I can't tell you\nwhere I'm going, but I will\nsay this: I won't forget you!\nBest of luckーto both of us.\n",
+      "new": "I recently decided to move\nfor reasons I prefer not to\ngo into. I can't tell you\nwhere I'm going, but I will\nsay this: I won't forget you!\nBest of luckーto both of us.\n"
+    },
+    {
+      "group": "mail",
+      "index": 527,
+      "label": "",
+      "original": "I know this is sudden, but...\nI had to leave the village.\nI don't know where I'm\nheaded, but don't worryーI'll\nget by somehow. Thanks for\nall you've done for me!\n",
+      "new": "I know this is sudden, but...\nI had to leave the village.\nI don't know where I'm\nheaded, but don't worryーI'll\nget by somehow. Thanks for\nall you've done for me!\n"
+    },
+    {
+      "group": "mail",
+      "index": 528,
+      "label": "",
+      "original": "I'm moving. There, I said it.\nI'd tell you where I'm going,\nbut if you were to come to\nvisit, I...just know I'd cry.\nPlease forgive me for going.\nThis is how things must be.\n",
+      "new": "I'm moving. There, I said it.\nI'd tell you where I'm going,\nbut if you were to come to\nvisit, I...just know I'd cry.\nPlease forgive me for going.\nThis is how things must be.\n"
+    },
+    {
+      "group": "mail",
+      "index": 529,
+      "label": "",
+      "original": "I'm leaving town, and I'm\nnot telling anyone where I'm\ngoing, but don't you worry!\nI'm off on a grand adventure\nthat's totally going to rule!\nWish me luck in my new life.\n",
+      "new": "I'm leaving town, and I'm\nnot telling anyone where I'm\ngoing, but don't you worry!\nI'm off on a grand adventure\nthat's totally going to rule!\nWish me luck in my new life.\n"
+    },
+    {
+      "group": "mail",
+      "index": 530,
+      "label": "",
+      "original": "I awoke the other day with\nthe wanderlust, so I just up\nand left. Wild, huh? On the\nroad, destination unknown!\nAnyway, thanks for dealing\nwith my craziness!\n",
+      "new": "I awoke the other day with\nthe wanderlust, so I just up\nand left. Wild, huh? On the\nroad, destination unknown!\nAnyway, thanks for dealing\nwith my craziness!\n"
+    },
+    {
+      "group": "mail",
+      "index": 531,
+      "label": "",
+      "original": "I realize this is a little\ncuckoo, but I've decided to\nmove. Have I lost it? No!!!\nI've just got to try to get\na fresh start. I don't even\nknow where I'm going yet!\n",
+      "new": "I realize this is a little\ncuckoo, but I've decided to\nmove. Have I lost it? No!!!\nI've just got to try to get\na fresh start. I don't even\nknow where I'm going yet!\n"
+    },
+    {
+      "group": "mail",
+      "index": 532,
+      "label": "",
+      "original": "I'm writing to tell you I left\n<<STR_FREE3>> secretly, so\ndon't bother looking for me.\nSee, I... Well, I just had to\nleave, OK? Let it lie. And\nif possible...send me fruit!\n",
+      "new": "I'm writing to tell you I left\n<<STR_FREE3>> secretly, so\ndon't bother looking for me.\nSee, I... Well, I just had to\nleave, OK? Let it lie. And\nif possible...send me fruit!\n"
+    },
+    {
+      "group": "mail",
+      "index": 533,
+      "label": "",
+      "original": "I have a hunger...and while\nI normally just grab a snack\nto fill up, this hunger will\nonly be satisfied by exotic\nfoods from far-off lands.\nSo, I'm now a wanderer! \n",
+      "new": "I have a hunger...and while\nI normally just grab a snack\nto fill up, this hunger will\nonly be satisfied by exotic\nfoods from far-off lands.\nSo, I'm now a wanderer! \n"
+    },
+    {
+      "group": "mail",
+      "index": 534,
+      "label": "",
+      "original": "Well now, I bet your bottom\nBell you didn't expect me to\ncut out and split town, huh?\nNope, I shocked the world!\nI'm turning over a new leafー\nsee you on the flip side!\n",
+      "new": "Well now, I bet your bottom\nBell you didn't expect me to\ncut out and split town, huh?\nNope, I shocked the world!\nI'm turning over a new leafー\nsee you on the flip side!\n"
+    },
+    {
+      "group": "mail",
+      "index": 535,
+      "label": "",
+      "original": "Ah, parting is such sweet,\nsweet...something or other.\nI forget the rest of that\nsaying. Anyway, I had to\nleave <<STR_FREE3>>,\nbut I'll never forget you!\n",
+      "new": "Ah, parting is such sweet,\nsweet...something or other.\nI forget the rest of that\nsaying. Anyway, I had to\nleave <<STR_FREE3>>,\nbut I'll never forget you!\n"
+    },
+    {
+      "group": "mail",
+      "index": 536,
+      "label": "",
+      "original": "Hey! How ya been, jellybean?\nI know, I know...you're real\nbummed that I left, right?\nWell, that's the way it goes!\nEven if our paths never meet\nagain, we'll still be friends!\n",
+      "new": "Hey! How ya been, jellybean?\nI know, I know...you're real\nbummed that I left, right?\nWell, that's the way it goes!\nEven if our paths never meet\nagain, we'll still be friends!\n"
+    },
+    {
+      "group": "mail",
+      "index": 537,
+      "label": "",
+      "original": "So, I bolted to begin a long\njourney of discovery. When\nwill I be back? Never!\nBut turn that frown upside\ndownーI am who I am! You\nbe you, and life'll be fine!\n",
+      "new": "So, I bolted to begin a long\njourney of discovery. When\nwill I be back? Never!\nBut turn that frown upside\ndownーI am who I am! You\nbe you, and life'll be fine!\n"
+    },
+    {
+      "group": "mail",
+      "index": 538,
+      "label": "",
+      "original": "How're things? Good? That's\nnice. Well, enough chitchat!\nDid you notice I left town?\nWhat's wrong with you?\nNot that I expected a going-\naway party or anything...\n",
+      "new": "How're things? Good? That's\nnice. Well, enough chitchat!\nDid you notice I left town?\nWhat's wrong with you?\nNot that I expected a going-\naway party or anything...\n"
+    },
+    {
+      "group": "mail",
+      "index": 539,
+      "label": "",
+      "original": "Well, my streak continues...\nI just can't seem to settle\ndown in any town for long.\nThis is kind of odd, because\nI've said so many goodbyes,\nbut this one actually hurts...\n",
+      "new": "Well, my streak continues...\nI just can't seem to settle\ndown in any town for long.\nThis is kind of odd, because\nI've said so many goodbyes,\nbut this one actually hurts...\n"
+    },
+    {
+      "group": "mail",
+      "index": 540,
+      "label": "",
+      "original": "Sorry if this throws you for\na loop, but I'm ditching this\none-human town, and I may\nnot be coming back. Thanks\nfor being tolerable. Maybe\nwe'll meet again sometime.\n",
+      "new": "Sorry if this throws you for\na loop, but I'm ditching this\none-human town, and I may\nnot be coming back. Thanks\nfor being tolerable. Maybe\nwe'll meet again sometime.\n"
+    },
+    {
+      "group": "mail",
+      "index": 541,
+      "label": "",
+      "original": "I can't stand for anyone to\nsee me cry... You must know,\nthat's the only reason I left\nwithout saying goodbye.\nEven now, the tears are...\nI can't bear it! Farewell!\n",
+      "new": "I can't stand for anyone to\nsee me cry... You must know,\nthat's the only reason I left\nwithout saying goodbye.\nEven now, the tears are...\nI can't bear it! Farewell!\n"
+    },
+    {
+      "group": "mail",
+      "index": 542,
+      "label": "",
+      "original": "During my entire move,\nI was sure I was forgetting\nsomething. You know what it\nwas? I forgot to say adieu\nto you. I hope this letter\nwill ease your devastation...\n",
+      "new": "During my entire move,\nI was sure I was forgetting\nsomething. You know what it\nwas? I forgot to say adieu\nto you. I hope this letter\nwill ease your devastation...\n"
+    },
+    {
+      "group": "mail",
+      "index": 543,
+      "label": "",
+      "original": "I'm sure you've become an\nemotional wreck looking for\nme, but I'm gone now! I'm\nsorry I left without a word.\nIt isn't like I don't like you.\nIt was just time to move on.\n",
+      "new": "I'm sure you've become an\nemotional wreck looking for\nme, but I'm gone now! I'm\nsorry I left without a word.\nIt isn't like I don't like you.\nIt was just time to move on.\n"
+    },
+    {
+      "group": "mail",
+      "index": 544,
+      "label": "",
+      "original": "Your current layout earns\n<<STR_FREE0>> points, but the size\nof your house is wasted.\nWhy have all that space if\nyou don't fabulize it?\n     <<STR_FREE4>> <<STR_FREE5>>, <<STR_FREE3>>\n",
+      "new": "Your current layout earns\n<<STR_FREE0>> points, but the size\nof your house is wasted.\nWhy have all that space if\nyou don't fabulize it?\n     <<STR_FREE4>> <<STR_FREE5>>, <<STR_FREE3>>\n"
+    },
+    {
+      "group": "mail",
+      "index": 545,
+      "label": "",
+      "original": "Congratulations! You've\nearned <<STR_FREE0>> points!\nThis is the first time you've\nbroken 70,000 points! We\nhere feel you've earned this\nsmall reward.\n",
+      "new": "Congratulations! You've\nearned <<STR_FREE0>> points!\nThis is the first time you've\nbroken 70,000 points! We\nhere feel you've earned this\nsmall reward.\n"
+    },
+    {
+      "group": "mail",
+      "index": 546,
+      "label": "",
+      "original": "Congratulations! You've\nearned <<STR_FREE0>> points!\nYou've achieved the\nimpossible and broken the\n100,000-point barrier!\nPlease accept this gift.\n",
+      "new": "Congratulations! You've\nearned <<STR_FREE0>> points!\nYou've achieved the\nimpossible and broken the\n100,000-point barrier!\nPlease accept this gift.\n"
+    },
+    {
+      "group": "mail",
+      "index": 547,
+      "label": "",
+      "original": "\n\n\n\n\n\n",
+      "new": "\n\n\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 548,
+      "label": "",
+      "original": "\n\n\n\n\n\n",
+      "new": "\n\n\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 549,
+      "label": "",
+      "original": "\n\n\n\n\n\n",
+      "new": "\n\n\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 550,
+      "label": "",
+      "original": "\n\n\n\n\n\n",
+      "new": "\n\n\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 551,
+      "label": "",
+      "original": "\n\n\n\n\n\n",
+      "new": "\n\n\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 552,
+      "label": "",
+      "original": "\n\n\n\n\n\n",
+      "new": "\n\n\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 553,
+      "label": "",
+      "original": "\n\n\n\n\n\n",
+      "new": "\n\n\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 554,
+      "label": "",
+      "original": "\n\n\n\n\n\n",
+      "new": "\n\n\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 555,
+      "label": "",
+      "original": "We would like to offer our\nutmost gratitude for your\nrecent, generous donation of\n<<STR_FREE1>>. You can\nfind it on exhibit in our\nmusuem in <<STR_FREE0>>.\n",
+      "new": "We would like to offer our\nutmost gratitude for your\nrecent, generous donation of\n<<STR_FREE1>>. You can\nfind it on exhibit in our\nmusuem in <<STR_FREE0>>.\n"
+    },
+    {
+      "group": "mail",
+      "index": 556,
+      "label": "",
+      "original": "We would like to offer our\ngratitude for your donation\nof a fine <<CUTARTICLE>><<STR_FREE1>>,\nbut sadly, there is already\none on display in our\nmuseum in <<STR_FREE0>>.\n",
+      "new": "We would like to offer our\ngratitude for your donation\nof a fine <<CUTARTICLE>><<STR_FREE1>>,\nbut sadly, there is already\none on display in our\nmuseum in <<STR_FREE0>>.\n"
+    },
+    {
+      "group": "mail",
+      "index": 557,
+      "label": "",
+      "original": "Thank you for the donation\nof your <<CUTARTICLE>><<STR_FREE1>>.\nRegrettably, this piece does\nnot suit any of our current\ncollections, so we must\nrespectfully return it to you.\n",
+      "new": "Thank you for the donation\nof your <<CUTARTICLE>><<STR_FREE1>>.\nRegrettably, this piece does\nnot suit any of our current\ncollections, so we must\nrespectfully return it to you.\n"
+    },
+    {
+      "group": "mail",
+      "index": 558,
+      "label": "",
+      "original": "Thank you very much for\nyour <<CUTARTICLE>><<STR_FREE1>>.\nHowever, we respectfully\nrequest that you make all\ndonations through your\nown village's museum.\n",
+      "new": "Thank you very much for\nyour <<CUTARTICLE>><<STR_FREE1>>.\nHowever, we respectfully\nrequest that you make all\ndonations through your\nown village's museum.\n"
+    },
+    {
+      "group": "mail",
+      "index": 559,
+      "label": "",
+      "original": "The <<STR_FREE0>> museum\nhas completed its collection!\nWe'd like to offer our thanks\nto all your contributions\nPlease accept our gift to\nmark this joyous occasion.\n",
+      "new": "The <<STR_FREE0>> museum\nhas completed its collection!\nWe'd like to offer our thanks\nto all your contributions\nPlease accept our gift to\nmark this joyous occasion.\n"
+    },
+    {
+      "group": "mail",
+      "index": 560,
+      "label": "",
+      "original": "\n\n\n\n\n\n",
+      "new": "\n\n\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 561,
+      "label": "",
+      "original": "\n\n\n\n\n\n",
+      "new": "\n\n\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 562,
+      "label": "",
+      "original": "\n\n\n\n\n\n",
+      "new": "\n\n\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 563,
+      "label": "",
+      "original": "\n\n\n\n\n\n",
+      "new": "\n\n\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 564,
+      "label": "",
+      "original": "\n\n\n\n\n\n",
+      "new": "\n\n\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 565,
+      "label": "",
+      "original": "\n\n\n\n\n\n",
+      "new": "\n\n\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 566,
+      "label": "",
+      "original": "\n\n\n\n\n\n",
+      "new": "\n\n\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 567,
+      "label": "",
+      "original": "\n\n\n\n\n\n",
+      "new": "\n\n\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 568,
+      "label": "",
+      "original": "\n\n\n\n\n\n",
+      "new": "\n\n\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 569,
+      "label": "",
+      "original": "\n\n\n\n\n\n",
+      "new": "\n\n\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 570,
+      "label": "",
+      "original": "\n\n\n\n\n\n",
+      "new": "\n\n\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 571,
+      "label": "",
+      "original": "\n\n\n\n\n\n",
+      "new": "\n\n\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 572,
+      "label": "",
+      "original": "\n\n\n\n\n\n",
+      "new": "\n\n\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 573,
+      "label": "",
+      "original": "\n\n\n\n\n\n",
+      "new": "\n\n\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 574,
+      "label": "",
+      "original": "Congratulations on your\nvictory in the Fishing\nTourney! You really made\na big splash! Nyuuuk nyuk!\nThe prize you hooked is this\n<<CUTARTICLE>><<STR_FREE0>>!\n",
+      "new": "Congratulations on your\nvictory in the Fishing\nTourney! You really made\na big splash! Nyuuuk nyuk!\nThe prize you hooked is this\n<<CUTARTICLE>><<STR_FREE0>>!\n"
+    },
+    {
+      "group": "mail",
+      "index": 575,
+      "label": "",
+      "original": "Congrats on reeling in a\nFishing Tourney victory!\nNyuuuk nyuk nyuk! I'm\nsending you your prize,\n<<STR_FREE0>>! Remember,\nthere's always a bigger fish!\n",
+      "new": "Congrats on reeling in a\nFishing Tourney victory!\nNyuuuk nyuk nyuk! I'm\nsending you your prize,\n<<STR_FREE0>>! Remember,\nthere's always a bigger fish!\n"
+    },
+    {
+      "group": "mail",
+      "index": 576,
+      "label": "",
+      "original": "Congratulations on landing a\nFishing Tourney victory!\nHere's the <<CUTARTICLE>><<STR_FREE0>>\nyou netted! Keep it up, and\nthe prize will never be the\none that got away!\n",
+      "new": "Congratulations on landing a\nFishing Tourney victory!\nHere's the <<CUTARTICLE>><<STR_FREE0>>\nyou netted! Keep it up, and\nthe prize will never be the\none that got away!\n"
+    },
+    {
+      "group": "mail",
+      "index": 577,
+      "label": "",
+      "original": "Congrats on hooking up a\nFishing Tourney victory!\nWhat'd you use, the old\n\"bait and switch\"? Nyuk!\nHere's your <<CUTARTICLE>><<STR_FREE0>>.\nThat winning bass was tasty!\n",
+      "new": "Congrats on hooking up a\nFishing Tourney victory!\nWhat'd you use, the old\n\"bait and switch\"? Nyuk!\nHere's your <<CUTARTICLE>><<STR_FREE0>>.\nThat winning bass was tasty!\n"
+    },
+    {
+      "group": "mail",
+      "index": 578,
+      "label": "",
+      "original": "<<STR_FREE0>> <<STR_FREE1>>\nFishing Tourney Results!\nChampion: <<STR_FREE2>>, for\ncatching a <<STR_FREE3>>-incher!\nYour prize is in the mail!\n             from Chip\n",
+      "new": "<<STR_FREE0>> <<STR_FREE1>>\nFishing Tourney Results!\nChampion: <<STR_FREE2>>, for\ncatching a <<STR_FREE3>>-incher!\nYour prize is in the mail!\n             from Chip\n"
+    },
+    {
+      "group": "mail",
+      "index": 579,
+      "label": "",
+      "original": "<<STR_FREE0>> <<STR_FREE1>>\nFishing Tourney Results!\nChampion: <<STR_FREE2>>, for\ncatching a <<STR_FREE3>>-incher!\nCatch you next time! Nyuk!\n                    -Chip\n",
+      "new": "<<STR_FREE0>> <<STR_FREE1>>\nFishing Tourney Results!\nChampion: <<STR_FREE2>>, for\ncatching a <<STR_FREE3>>-incher!\nCatch you next time! Nyuk!\n                    -Chip\n"
+    },
+    {
+      "group": "mail",
+      "index": 580,
+      "label": "",
+      "original": "<<STR_FREE0>> <<STR_FREE1>>\nFishing Tourney Results!\nChampion: <<STR_FREE2>>, for\ncatching a <<STR_FREE3>>-incher!\nHook me up with some bigger\nfish next time!       -Chip\n",
+      "new": "<<STR_FREE0>> <<STR_FREE1>>\nFishing Tourney Results!\nChampion: <<STR_FREE2>>, for\ncatching a <<STR_FREE3>>-incher!\nHook me up with some bigger\nfish next time!       -Chip\n"
+    },
+    {
+      "group": "mail",
+      "index": 581,
+      "label": "",
+      "original": "<<STR_FREE0>> <<STR_FREE1>>\nFishing Tourney Results!\nChampion: <<STR_FREE2>>, for\ncatching a <<STR_FREE3>>-incher!\nA fish-tastic prize is on its\nway!                -Chip\n",
+      "new": "<<STR_FREE0>> <<STR_FREE1>>\nFishing Tourney Results!\nChampion: <<STR_FREE2>>, for\ncatching a <<STR_FREE3>>-incher!\nA fish-tastic prize is on its\nway!                -Chip\n"
+    },
+    {
+      "group": "mail",
+      "index": 582,
+      "label": "",
+      "original": "We'd like to offer you a\ntoken of our appreciation in\nhonor of your most loyal\npatronage, as well as to\ncommemorate the fact that\nyou saved one million Bells!\n",
+      "new": "We'd like to offer you a\ntoken of our appreciation in\nhonor of your most loyal\npatronage, as well as to\ncommemorate the fact that\nyou saved one million Bells!\n"
+    },
+    {
+      "group": "mail",
+      "index": 583,
+      "label": "",
+      "original": "We'd like to offer you a\ntoken of our appreciation in\nhonor of your most loyal\npatronage, as well as to\ncommemorate the fact that\nyou saved ten million Bells!\n",
+      "new": "We'd like to offer you a\ntoken of our appreciation in\nhonor of your most loyal\npatronage, as well as to\ncommemorate the fact that\nyou saved ten million Bells!\n"
+    },
+    {
+      "group": "mail",
+      "index": 584,
+      "label": "",
+      "original": "We'd like to offer you a\ntoken of appreciation, and\nexpress our utter surprise.\nWe never expected anyone to\nsave up one hundred million\nBells! Please accept this.\n",
+      "new": "We'd like to offer you a\ntoken of appreciation, and\nexpress our utter surprise.\nWe never expected anyone to\nsave up one hundred million\nBells! Please accept this.\n"
+    },
+    {
+      "group": "mail",
+      "index": 585,
+      "label": "",
+      "original": "We never thought anyone\ncould save so much money,\n<<STR_FREE1>>. Incredible!\nSurely, you are the only one\nin the entire world to whom\nwe've sent this letter!\n",
+      "new": "We never thought anyone\ncould save so much money,\n<<STR_FREE1>>. Incredible!\nSurely, you are the only one\nin the entire world to whom\nwe've sent this letter!\n"
+    },
+    {
+      "group": "mail",
+      "index": 586,
+      "label": "",
+      "original": "The weirdest thing happened\nto me! Check it out: I dozed\noff while reading your letter\n(not that it was boring!),\nand when I woke up, I found\nthis sitting in front of me!\n",
+      "new": "The weirdest thing happened\nto me! Check it out: I dozed\noff while reading your letter\n(not that it was boring!),\nand when I woke up, I found\nthis sitting in front of me!\n"
+    },
+    {
+      "group": "mail",
+      "index": 587,
+      "label": "",
+      "original": "Yesterday, I was out jogging\nwhen this guy I'd never seen\nbefore goes, \"You know the\npassword?\" When I told him\nabout your letter, he gave\nme this!\n",
+      "new": "Yesterday, I was out jogging\nwhen this guy I'd never seen\nbefore goes, \"You know the\npassword?\" When I told him\nabout your letter, he gave\nme this!\n"
+    },
+    {
+      "group": "mail",
+      "index": 588,
+      "label": "",
+      "original": "Hey, I showed my uncle your\nletter, and he freaked out!\n\"The hero!\" he yelled. \"The\ngreat hero has come, as the\ntales foretold! You must give\nthis to him!\" Nutty, huh?\n",
+      "new": "Hey, I showed my uncle your\nletter, and he freaked out!\n\"The hero!\" he yelled. \"The\ngreat hero has come, as the\ntales foretold! You must give\nthis to him!\" Nutty, huh?\n"
+    },
+    {
+      "group": "mail",
+      "index": 589,
+      "label": "",
+      "original": "Hey, who told you that\npassword!? I mean, after\nall this time, YOU'RE the one\nI'm supposed to give our\nancient family heirloom to?\nOh well. That's fate for you.\n",
+      "new": "Hey, who told you that\npassword!? I mean, after\nall this time, YOU'RE the one\nI'm supposed to give our\nancient family heirloom to?\nOh well. That's fate for you.\n"
+    },
+    {
+      "group": "mail",
+      "index": 590,
+      "label": "",
+      "original": "I can't believe it. You, of\nall people, knew my pass-\nword. Long ago, I was told\n\"When the secret-bearer\nappears, give the gift you've\nkept for years.\" Dunno why.\n",
+      "new": "I can't believe it. You, of\nall people, knew my pass-\nword. Long ago, I was told\n\"When the secret-bearer\nappears, give the gift you've\nkept for years.\" Dunno why.\n"
+    },
+    {
+      "group": "mail",
+      "index": 591,
+      "label": "",
+      "original": "What madness is this!? I\nhave a magic chest that\nnever opens, but I read this\nboorish letter of yours\naloud, and suddenly, the\nlock opens to reveal this!\n",
+      "new": "What madness is this!? I\nhave a magic chest that\nnever opens, but I read this\nboorish letter of yours\naloud, and suddenly, the\nlock opens to reveal this!\n"
+    },
+    {
+      "group": "mail",
+      "index": 592,
+      "label": "",
+      "original": "The weirdest thing happened!\nI dozed off while I was\nreading your letter, and\nwhen I woke up, all the\nwords on it had vanished!\nIsn't that a little odd?\n",
+      "new": "The weirdest thing happened!\nI dozed off while I was\nreading your letter, and\nwhen I woke up, all the\nwords on it had vanished!\nIsn't that a little odd?\n"
+    },
+    {
+      "group": "mail",
+      "index": 593,
+      "label": "",
+      "original": "So I was just out running\naround when this guy I'd\nnever seen before asked me\nfor the \"password.\" I gave\nhim that letter you wrote,\nbut he just laughed at me!\n",
+      "new": "So I was just out running\naround when this guy I'd\nnever seen before asked me\nfor the \"password.\" I gave\nhim that letter you wrote,\nbut he just laughed at me!\n"
+    },
+    {
+      "group": "mail",
+      "index": 594,
+      "label": "",
+      "original": "Hey, so I show my uncle your\nletter, and he gets all freaky\nand screams, \"What the heck\nare these chicken scratches?\nThis doesn't even make\nsense!\" Boy, was he mad.\n",
+      "new": "Hey, so I show my uncle your\nletter, and he gets all freaky\nand screams, \"What the heck\nare these chicken scratches?\nThis doesn't even make\nsense!\" Boy, was he mad.\n"
+    },
+    {
+      "group": "mail",
+      "index": 595,
+      "label": "",
+      "original": "You think you know my\npassword? You don't know\nanything! I'm not about to\ngive you my ancient family\nheirloom! I swore to keep it\nsafe until the One appears!\n",
+      "new": "You think you know my\npassword? You don't know\nanything! I'm not about to\ngive you my ancient family\nheirloom! I swore to keep it\nsafe until the One appears!\n"
+    },
+    {
+      "group": "mail",
+      "index": 596,
+      "label": "",
+      "original": "I have no idea what that\npassword you sent was,\nyou irritating little gnat!\nBug me all you want. You're\nnot getting anything from\nme. Mind your own beeswax!\n",
+      "new": "I have no idea what that\npassword you sent was,\nyou irritating little gnat!\nBug me all you want. You're\nnot getting anything from\nme. Mind your own beeswax!\n"
+    },
+    {
+      "group": "mail",
+      "index": 597,
+      "label": "",
+      "original": "What was that letter meant\nto be, some sad little love\nnote? I should show it to\neveryone so they'd all see\njust how crazy you are!\nStill...it IS kind of cute.\n",
+      "new": "What was that letter meant\nto be, some sad little love\nnote? I should show it to\neveryone so they'd all see\njust how crazy you are!\nStill...it IS kind of cute.\n"
+    },
+    {
+      "group": "mail",
+      "index": 598,
+      "label": "",
+      "original": "Thank you very much!\nIt's nice to know that you\nlike me so much! I might as\nwell tell you the feeling\nis definitely mutual... ♥\n\n",
+      "new": "Thank you very much!\nIt's nice to know that you\nlike me so much! I might as\nwell tell you the feeling\nis definitely mutual... ♥\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 599,
+      "label": "",
+      "original": "<<STR_FREE0>>! You voted\nfor me in that contest?\nGolly, thanks so much! 😃\nI totally like you even more\nnow! You're the best ever!\n♥♥♥\n",
+      "new": "<<STR_FREE0>>! You voted\nfor me in that contest?\nGolly, thanks so much! 😃\nI totally like you even more\nnow! You're the best ever!\n♥♥♥\n"
+    },
+    {
+      "group": "mail",
+      "index": 600,
+      "label": "",
+      "original": "Wow, <<STR_FREE0>>! Boy,\nis my face red! You voted\nfor me in that contest?\nI forgot to vote for me, and\nI didn't think anyone would!\nSo thanks for the ego boost!\n",
+      "new": "Wow, <<STR_FREE0>>! Boy,\nis my face red! You voted\nfor me in that contest?\nI forgot to vote for me, and\nI didn't think anyone would!\nSo thanks for the ego boost!\n"
+    },
+    {
+      "group": "mail",
+      "index": 601,
+      "label": "",
+      "original": "What up, <<STR_FREE0>>?\nWhy didn't you tell me you\nthought I was that cool?\nNo biggieーI know now!\nThanks for the shout-out!\n\n",
+      "new": "What up, <<STR_FREE0>>?\nWhy didn't you tell me you\nthought I was that cool?\nNo biggieーI know now!\nThanks for the shout-out!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 602,
+      "label": "",
+      "original": "Hey, <<STR_FREE0>>!\nI heard you voted for me in\nsome contest? Dang it! Don't\ndo that again! Winning stuff\nmakes the corners of my\nmouth stretch up painfully!\n",
+      "new": "Hey, <<STR_FREE0>>!\nI heard you voted for me in\nsome contest? Dang it! Don't\ndo that again! Winning stuff\nmakes the corners of my\nmouth stretch up painfully!\n"
+    },
+    {
+      "group": "mail",
+      "index": 603,
+      "label": "",
+      "original": "Thank you so, so much! ♥\nDon't be coyーI know you\nvoted for me in that contest.\nI like you, <<STR_FREE0>>.\nA lot. I hope we'll be close\nfor a long, long time. ♥\n",
+      "new": "Thank you so, so much! ♥\nDon't be coyーI know you\nvoted for me in that contest.\nI like you, <<STR_FREE0>>.\nA lot. I hope we'll be close\nfor a long, long time. ♥\n"
+    },
+    {
+      "group": "mail",
+      "index": 604,
+      "label": "",
+      "original": "<<STR_FREE6>> told me a\nlittle secret about you....\nYou voted for me, huh?\nThat was so nice of you!\nI wanted to thank you, so I\ngot you this.\n",
+      "new": "<<STR_FREE6>> told me a\nlittle secret about you....\nYou voted for me, huh?\nThat was so nice of you!\nI wanted to thank you, so I\ngot you this.\n"
+    },
+    {
+      "group": "mail",
+      "index": 605,
+      "label": "",
+      "original": "<<STR_FREE6>> told me all\nabout it! I was, like, totally\nfloored to hear that you like\nme so much! Wowser! ♥\nThanks for voting for me in\nthat contest!!! 😃\n",
+      "new": "<<STR_FREE6>> told me all\nabout it! I was, like, totally\nfloored to hear that you like\nme so much! Wowser! ♥\nThanks for voting for me in\nthat contest!!! 😃\n"
+    },
+    {
+      "group": "mail",
+      "index": 606,
+      "label": "",
+      "original": "<<STR_FREE6>> gave me\nsome tasty infoーyou voted\nfor me in a contest! Whoa!\nSweetness! I guess some\nthanks are in order, huh?\nOK, here you go....\n",
+      "new": "<<STR_FREE6>> gave me\nsome tasty infoーyou voted\nfor me in a contest! Whoa!\nSweetness! I guess some\nthanks are in order, huh?\nOK, here you go....\n"
+    },
+    {
+      "group": "mail",
+      "index": 607,
+      "label": "",
+      "original": "<<STR_FREE6>> says that you\nvoted for me in the contest!\nDude! I had no idea you\nthought so highly of my\ncoolness! Thanks for the\nmad props! Yeaaah!\n",
+      "new": "<<STR_FREE6>> says that you\nvoted for me in the contest!\nDude! I had no idea you\nthought so highly of my\ncoolness! Thanks for the\nmad props! Yeaaah!\n"
+    },
+    {
+      "group": "mail",
+      "index": 608,
+      "label": "",
+      "original": "<<STR_FREE6>> told me all\nabout it. Yeah, that's right!\nDon't deny it! You voted for\nme, didn't you? DIDN'T you!?\nWhat, I'm nice, now? NICE?\nME? ..................Well, thanks.\n",
+      "new": "<<STR_FREE6>> told me all\nabout it. Yeah, that's right!\nDon't deny it! You voted for\nme, didn't you? DIDN'T you!?\nWhat, I'm nice, now? NICE?\nME? ..................Well, thanks.\n"
+    },
+    {
+      "group": "mail",
+      "index": 609,
+      "label": "",
+      "original": "I heard some gossip about\nyou from <<STR_FREE6>>.... 😃\nYou voted for me in that\ncontest, didn't you? Well...\nyou have good taste! ♥\nThank you ever so much!\n",
+      "new": "I heard some gossip about\nyou from <<STR_FREE6>>.... 😃\nYou voted for me in that\ncontest, didn't you? Well...\nyou have good taste! ♥\nThank you ever so much!\n"
+    },
+    {
+      "group": "mail",
+      "index": 610,
+      "label": "",
+      "original": "Have you ever heard the call\nof Mother Ocean speaking\nin the gentle waves? I have.\nShe said you voted for me\nin a contest. Is it true? Are\nYOU true? Think about it.\n",
+      "new": "Have you ever heard the call\nof Mother Ocean speaking\nin the gentle waves? I have.\nShe said you voted for me\nin a contest. Is it true? Are\nYOU true? Think about it.\n"
+    },
+    {
+      "group": "mail",
+      "index": 611,
+      "label": "",
+      "original": "So...you actually like me?\nWeird. I think I prefered\nnot knowing that morsel\nof information. Oh, well. I'm\nout of practice at this, but\nI guess I owe you something.\n",
+      "new": "So...you actually like me?\nWeird. I think I prefered\nnot knowing that morsel\nof information. Oh, well. I'm\nout of practice at this, but\nI guess I owe you something.\n"
+    },
+    {
+      "group": "mail",
+      "index": 612,
+      "label": "",
+      "original": "Why is it my fate to be\nloved by the world I chose\nto leave behind? How can I\nrespond when I loathe all of\nsociety's cries of approval?\nI don't know how to react.\n",
+      "new": "Why is it my fate to be\nloved by the world I chose\nto leave behind? How can I\nrespond when I loathe all of\nsociety's cries of approval?\nI don't know how to react.\n"
+    },
+    {
+      "group": "mail",
+      "index": 613,
+      "label": "",
+      "original": "Ohhh, DUDE! I heard the\nmost killer story! There was\nthis huge contest...and you\nvoted for ME! So...RAD!\nYou rock my world! You rip!\nHang loose, surf-rah!\n",
+      "new": "Ohhh, DUDE! I heard the\nmost killer story! There was\nthis huge contest...and you\nvoted for ME! So...RAD!\nYou rock my world! You rip!\nHang loose, surf-rah!\n"
+    },
+    {
+      "group": "mail",
+      "index": 614,
+      "label": "",
+      "original": "Hmmm... I must admit, your\nactions have taken me aback.\nThe boldness! The absolute\ncheekiness! To think, you'd\nvote for me! My charisma\nhas grown too powerful!\n",
+      "new": "Hmmm... I must admit, your\nactions have taken me aback.\nThe boldness! The absolute\ncheekiness! To think, you'd\nvote for me! My charisma\nhas grown too powerful!\n"
+    },
+    {
+      "group": "mail",
+      "index": 615,
+      "label": "",
+      "original": "So, you like me, huh? That\nis so adorable! Really, that's\njust too precious! I don't\nencourage flattery as a rule,\nbut in your case, I'll make a\n♥special♥ exception!\n",
+      "new": "So, you like me, huh? That\nis so adorable! Really, that's\njust too precious! I don't\nencourage flattery as a rule,\nbut in your case, I'll make a\n♥special♥ exception!\n"
+    },
+    {
+      "group": "mail",
+      "index": 616,
+      "label": "",
+      "original": "Did you you vote for me in a\ncontest? Truly, I can't begin\nto express my gratitude\nfor this honor. I'd open my\nshop 24 hours a day if I\ncould! Come again soon!\n",
+      "new": "Did you you vote for me in a\ncontest? Truly, I can't begin\nto express my gratitude\nfor this honor. I'd open my\nshop 24 hours a day if I\ncould! Come again soon!\n"
+    },
+    {
+      "group": "mail",
+      "index": 617,
+      "label": "",
+      "original": "Word is you voted for me\nin some contest or other. As\na traveling artist, I have\nreally limited means...so this\nis all I can offer in thanks.\nNow, off to procure lunch!\n",
+      "new": "Word is you voted for me\nin some contest or other. As\na traveling artist, I have\nreally limited means...so this\nis all I can offer in thanks.\nNow, off to procure lunch!\n"
+    },
+    {
+      "group": "mail",
+      "index": 618,
+      "label": "",
+      "original": "Did you vote for me in\nsome kind of contest?\nThat was very nice of\nyou. Thank you. Please\naccept this. I can't wait\nfor our next trade-in.\n",
+      "new": "Did you vote for me in\nsome kind of contest?\nThat was very nice of\nyou. Thank you. Please\naccept this. I can't wait\nfor our next trade-in.\n"
+    },
+    {
+      "group": "mail",
+      "index": 619,
+      "label": "",
+      "original": "How's your whole deal going,\nbabe? Hot hot hot, I hope!\nListen, darling, I heard the\nword that you liked me...\nand all I have to say is\nFABU! You have fine taste!\n",
+      "new": "How's your whole deal going,\nbabe? Hot hot hot, I hope!\nListen, darling, I heard the\nword that you liked me...\nand all I have to say is\nFABU! You have fine taste!\n"
+    },
+    {
+      "group": "mail",
+      "index": 620,
+      "label": "",
+      "original": "Where in the wide world did\nyou find a contest to vote\nfor me in, junior? Honestly!\nAs old as I am, I don't even\nthink I'd be picked for jury\nduty! Still...I thank you.\n",
+      "new": "Where in the wide world did\nyou find a contest to vote\nfor me in, junior? Honestly!\nAs old as I am, I don't even\nthink I'd be picked for jury\nduty! Still...I thank you.\n"
+    },
+    {
+      "group": "mail",
+      "index": 621,
+      "label": "",
+      "original": "I see you...standing before a\nsquare box...somewhere...\nYou look puzzled... Something\ntroubles you. Yes...but...\nAh hah! You overcome doubt\nand choose wisely.... Good.\n",
+      "new": "I see you...standing before a\nsquare box...somewhere...\nYou look puzzled... Something\ntroubles you. Yes...but...\nAh hah! You overcome doubt\nand choose wisely.... Good.\n"
+    },
+    {
+      "group": "mail",
+      "index": 622,
+      "label": "",
+      "original": "I've received reports from\n<<STR_FREE6>> claiming that\nyou voted for me in a\ncontest! I believe this intel\nto be true, repeat, true.\nThank you for your support!\n",
+      "new": "I've received reports from\n<<STR_FREE6>> claiming that\nyou voted for me in a\ncontest! I believe this intel\nto be true, repeat, true.\nThank you for your support!\n"
+    },
+    {
+      "group": "mail",
+      "index": 623,
+      "label": "",
+      "original": "Boo! Heh heh...I guess that's\nless scary in writing. So, we\nonly meet once a year, but\nyou remembered me! Thanks!\nThis Halloween, I'll give you\na free gift! Trick or treat!\n",
+      "new": "Boo! Heh heh...I guess that's\nless scary in writing. So, we\nonly meet once a year, but\nyou remembered me! Thanks!\nThis Halloween, I'll give you\na free gift! Trick or treat!\n"
+    },
+    {
+      "group": "mail",
+      "index": 624,
+      "label": "",
+      "original": "Well, you're certainly more\nnice than naughty! Are you\nsure I'm your favorite? Talk\nabout jolly! It's nice to be\naccepted for the average\nreindeer that I am.\n",
+      "new": "Well, you're certainly more\nnice than naughty! Are you\nsure I'm your favorite? Talk\nabout jolly! It's nice to be\naccepted for the average\nreindeer that I am.\n"
+    },
+    {
+      "group": "mail",
+      "index": 625,
+      "label": "",
+      "original": "<<STR_FREE6>> told me you\nlike me. Well, that's just\nplain nice. I hope this finds\nyou wellーthings are going\ngreat with Pelly. Her sister,\nPhyllis, still hates me.\n",
+      "new": "<<STR_FREE6>> told me you\nlike me. Well, that's just\nplain nice. I hope this finds\nyou wellーthings are going\ngreat with Pelly. Her sister,\nPhyllis, still hates me.\n"
+    },
+    {
+      "group": "mail",
+      "index": 626,
+      "label": "",
+      "original": "<<STR_FREE6>> tells me you\nvoted for me in a contest.\nDid you? Do you really like\nme that much? I'm so\nflattered! Aren't you just a\nlittle sweetheart?\n",
+      "new": "<<STR_FREE6>> tells me you\nvoted for me in a contest.\nDid you? Do you really like\nme that much? I'm so\nflattered! Aren't you just a\nlittle sweetheart?\n"
+    },
+    {
+      "group": "mail",
+      "index": 627,
+      "label": "",
+      "original": "Did you really vote for me?\nI thought nobody liked me,\nso I'm a little shocked.\nNow that I think about it,\nwhy was my name even on\nthe ballot? That's irritating!\n",
+      "new": "Did you really vote for me?\nI thought nobody liked me,\nso I'm a little shocked.\nNow that I think about it,\nwhy was my name even on\nthe ballot? That's irritating!\n"
+    },
+    {
+      "group": "mail",
+      "index": 628,
+      "label": "",
+      "original": "<<STR_FREE6>> tells me that\nyou voted for me in some\nkind of contest. We've only\ntalked a little on the train,\nso I'm amazed you even\nremember me! Thanks!\n",
+      "new": "<<STR_FREE6>> tells me that\nyou voted for me in some\nkind of contest. We've only\ntalked a little on the train,\nso I'm amazed you even\nremember me! Thanks!\n"
+    },
+    {
+      "group": "mail",
+      "index": 629,
+      "label": "",
+      "original": "Hey, thanks for checking out\nmy jams by the station and\nfor all your supportーhaving\nfans is so far out, man.\nI'm glad your ears are into\nthe scene. See you Saturday!\n",
+      "new": "Hey, thanks for checking out\nmy jams by the station and\nfor all your supportーhaving\nfans is so far out, man.\nI'm glad your ears are into\nthe scene. See you Saturday!\n"
+    },
+    {
+      "group": "mail",
+      "index": 630,
+      "label": "",
+      "original": "What's this <<STR_FREE6>>\ntold me about a contest? If\nit's a fishing contest, says\nme, I'm there! But no! It's a\npopularity test? For fish?\nBoy, was I ever confused!\n",
+      "new": "What's this <<STR_FREE6>>\ntold me about a contest? If\nit's a fishing contest, says\nme, I'm there! But no! It's a\npopularity test? For fish?\nBoy, was I ever confused!\n"
+    },
+    {
+      "group": "mail",
+      "index": 631,
+      "label": "",
+      "original": "Until my conversation with\n<<STR_FREE6>>, I had no\nidea anyone liked me much.\nI'm amazed. Maybe now\nI'll get self-confidence...\nMaybe...\n",
+      "new": "Until my conversation with\n<<STR_FREE6>>, I had no\nidea anyone liked me much.\nI'm amazed. Maybe now\nI'll get self-confidence...\nMaybe...\n"
+    },
+    {
+      "group": "mail",
+      "index": 632,
+      "label": "",
+      "original": "<<STR_FREE6>> told me that\nyou voted for me in some\ncontest or something. Sweet!\nI'm better than Tommy at\nsomething! Whoop! There\nit is! Can you feel it?!\n",
+      "new": "<<STR_FREE6>> told me that\nyou voted for me in some\ncontest or something. Sweet!\nI'm better than Tommy at\nsomething! Whoop! There\nit is! Can you feel it?!\n"
+    },
+    {
+      "group": "mail",
+      "index": 633,
+      "label": "",
+      "original": "<<STR_FREE6>> says you voted\nfor me in a contest.\nThanks! Seriously! Wait'll\nI tell Timmy that you chose\nme over him! He'll be so\njealous, his fur'll fall out!\n",
+      "new": "<<STR_FREE6>> says you voted\nfor me in a contest.\nThanks! Seriously! Wait'll\nI tell Timmy that you chose\nme over him! He'll be so\njealous, his fur'll fall out!\n"
+    },
+    {
+      "group": "mail",
+      "index": 634,
+      "label": "",
+      "original": "Crazy Redd here! Rumor has\nit your eyes are trained to\nsee true quality in more\nthan just furniture! Thanks\nfor your support! I'm crazy\nabout you, kid! Crrrrrazy!\n",
+      "new": "Crazy Redd here! Rumor has\nit your eyes are trained to\nsee true quality in more\nthan just furniture! Thanks\nfor your support! I'm crazy\nabout you, kid! Crrrrrazy!\n"
+    },
+    {
+      "group": "mail",
+      "index": 635,
+      "label": "",
+      "original": "<<STR_FREE0>>, <<STR_FREE6>>\ntold me everything. I figured\nyou hated me, because I only\nsee you when I'm...so very,\nvery, angry at you. How odd.\nYour vote changes nothing!!!\n",
+      "new": "<<STR_FREE0>>, <<STR_FREE6>>\ntold me everything. I figured\nyou hated me, because I only\nsee you when I'm...so very,\nvery, angry at you. How odd.\nYour vote changes nothing!!!\n"
+    },
+    {
+      "group": "mail",
+      "index": 636,
+      "label": "",
+      "original": "Ahoy! I felt so stalkedー\nI mean, shockedーwhen I\nheard you voted for me! Ha!\nThat's...really very cool\nand great. Thanks! Good luck\nand everything!\n",
+      "new": "Ahoy! I felt so stalkedー\nI mean, shockedーwhen I\nheard you voted for me! Ha!\nThat's...really very cool\nand great. Thanks! Good luck\nand everything!\n"
+    },
+    {
+      "group": "mail",
+      "index": 637,
+      "label": "",
+      "original": "<<STR_FREE6>> tells me that\nyou voted for me in a\ncontest! But you have so\nmany friends. Why me? Oh,\nwho cares? Hooray! I'm the\nmonkey king of the world!!!\n",
+      "new": "<<STR_FREE6>> tells me that\nyou voted for me in a\ncontest! But you have so\nmany friends. Why me? Oh,\nwho cares? Hooray! I'm the\nmonkey king of the world!!!\n"
+    },
+    {
+      "group": "mail",
+      "index": 638,
+      "label": "",
+      "original": "<<STR_FREE6>> was so good\nas to inform me that you\nchose to cast your vote for\nyours truly. I feel profoundly\nhonored. I should hope that\nI continue to impress!\n",
+      "new": "<<STR_FREE6>> was so good\nas to inform me that you\nchose to cast your vote for\nyours truly. I feel profoundly\nhonored. I should hope that\nI continue to impress!\n"
+    },
+    {
+      "group": "mail",
+      "index": 639,
+      "label": "",
+      "original": "I mostly avoid contact with\nlandlubbers, but I hear ye\npicked me as yer favorite\nshipmate or somethin'. Well,\nI'm in yer debt. Ye really\nfloat me boat, too!\n",
+      "new": "I mostly avoid contact with\nlandlubbers, but I hear ye\npicked me as yer favorite\nshipmate or somethin'. Well,\nI'm in yer debt. Ye really\nfloat me boat, too!\n"
+    },
+    {
+      "group": "mail",
+      "index": 640,
+      "label": "",
+      "original": "Ever since I heard you voted\nfor me in that contest, I've\nbeen in stitches! I just bust\ninto giggles of delight with\nno warning! It's a little bit\nembarrassing! But thanks!\n",
+      "new": "Ever since I heard you voted\nfor me in that contest, I've\nbeen in stitches! I just bust\ninto giggles of delight with\nno warning! It's a little bit\nembarrassing! But thanks!\n"
+    },
+    {
+      "group": "mail",
+      "index": 641,
+      "label": "",
+      "original": "I can't believe you voted for\nme, despite the fact that\nwe've never really talked.\nWow. I wish we had more\ntime to get to know each\nother. Instead, take this.\n",
+      "new": "I can't believe you voted for\nme, despite the fact that\nwe've never really talked.\nWow. I wish we had more\ntime to get to know each\nother. Instead, take this.\n"
+    },
+    {
+      "group": "mail",
+      "index": 642,
+      "label": "",
+      "original": "<<STR_FREE6>> tells me that\nyou voted for me. What for?\nI had no idea there was\neven an election! Did I win?\nAm I still mayor? Why does\nno one tell me these things?\n",
+      "new": "<<STR_FREE6>> tells me that\nyou voted for me. What for?\nI had no idea there was\neven an election! Did I win?\nAm I still mayor? Why does\nno one tell me these things?\n"
+    },
+    {
+      "group": "mail",
+      "index": 643,
+      "label": "",
+      "original": "The spirits told me that you\nvoted for me in a contest.\nI hope you won't live to\nregret your choice....\n\n\n",
+      "new": "The spirits told me that you\nvoted for me in a contest.\nI hope you won't live to\nregret your choice....\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 644,
+      "label": "",
+      "original": "<<STR_FREE6>> told me what\nyou said. Truly, that's just\nthe nicest thing I've heard\nin a long time. I never win\nanything, what with the job\nand all. How nice for me!\n",
+      "new": "<<STR_FREE6>> told me what\nyou said. Truly, that's just\nthe nicest thing I've heard\nin a long time. I never win\nanything, what with the job\nand all. How nice for me!\n"
+    },
+    {
+      "group": "mail",
+      "index": 645,
+      "label": "",
+      "original": "What a surprise! I never\ndared hope that someone\nwith a face as plain as\nmine could be so popular!\nI'd better get all gussied up\nfor my acceptance speech!\n",
+      "new": "What a surprise! I never\ndared hope that someone\nwith a face as plain as\nmine could be so popular!\nI'd better get all gussied up\nfor my acceptance speech!\n"
+    },
+    {
+      "group": "mail",
+      "index": 646,
+      "label": "",
+      "original": "You voted for me? Why? Is\nit because I'm tasty? And\ntender? And juicy? You want\nto eat me, don't you?!\nYou don't? Really??? In\nthat case, thanks.\n",
+      "new": "You voted for me? Why? Is\nit because I'm tasty? And\ntender? And juicy? You want\nto eat me, don't you?!\nYou don't? Really??? In\nthat case, thanks.\n"
+    },
+    {
+      "group": "mail",
+      "index": 647,
+      "label": "",
+      "original": "I am amazed that anyone\nwould vote for me. You truly\ndo love the environment.\nI hope I can encourage you\nto continue to care for\nthe trees.\n",
+      "new": "I am amazed that anyone\nwould vote for me. You truly\ndo love the environment.\nI hope I can encourage you\nto continue to care for\nthe trees.\n"
+    },
+    {
+      "group": "mail",
+      "index": 648,
+      "label": "",
+      "original": "What's this about a secret?\nI'm really sorry, but I have\nno clue what you mean.\nIf you don't mind, please\nwrite something more\ncoherent on your next note.\n",
+      "new": "What's this about a secret?\nI'm really sorry, but I have\nno clue what you mean.\nIf you don't mind, please\nwrite something more\ncoherent on your next note.\n"
+    },
+    {
+      "group": "mail",
+      "index": 649,
+      "label": "",
+      "original": "What secret? Are you nuts?\nAm I? I have no idea what\nyou're talking about! Did you\neat something that made you\ngo crazy? Don't worryーthat\nhappens to us animals, too!\n",
+      "new": "What secret? Are you nuts?\nAm I? I have no idea what\nyou're talking about! Did you\neat something that made you\ngo crazy? Don't worryーthat\nhappens to us animals, too!\n"
+    },
+    {
+      "group": "mail",
+      "index": 650,
+      "label": "",
+      "original": "I have no idea what secret\nyou're talking about! You're\nnot involved in something\nyou shouldn't be, are you?\nI've always wondered about\nsome of your friends....\n",
+      "new": "I have no idea what secret\nyou're talking about! You're\nnot involved in something\nyou shouldn't be, are you?\nI've always wondered about\nsome of your friends....\n"
+    },
+    {
+      "group": "mail",
+      "index": 651,
+      "label": "",
+      "original": "Huh, <<STR_FREE0>>?\nSecrets? Say what? If you're\ntalking about ninja secrets,\nI know them all...but about\nwhatever secret you're\ntalking about, I'm clueless.\n",
+      "new": "Huh, <<STR_FREE0>>?\nSecrets? Say what? If you're\ntalking about ninja secrets,\nI know them all...but about\nwhatever secret you're\ntalking about, I'm clueless.\n"
+    },
+    {
+      "group": "mail",
+      "index": 652,
+      "label": "",
+      "original": "Hey, <<STR_FREE0>>! Are\nyou sure you meant to send\nthat letter to me? I have no\nidea what secret you're\nyapping about! Matter of\nfact, I doubt anybody would!\n",
+      "new": "Hey, <<STR_FREE0>>! Are\nyou sure you meant to send\nthat letter to me? I have no\nidea what secret you're\nyapping about! Matter of\nfact, I doubt anybody would!\n"
+    },
+    {
+      "group": "mail",
+      "index": 653,
+      "label": "",
+      "original": "What secret? I don't know\nany secrets, and even if I\ndid, I wouldn't tell them to\nanybody! Of course, if it's\nhot gossip you want, I'm\nthe girl with the goods!\n",
+      "new": "What secret? I don't know\nany secrets, and even if I\ndid, I wouldn't tell them to\nanybody! Of course, if it's\nhot gossip you want, I'm\nthe girl with the goods!\n"
+    },
+    {
+      "group": "mail",
+      "index": 654,
+      "label": "",
+      "original": "Hey, thanks for entering.\nI have great news! You won\nthe drawing! Congrats!\nYou must be so happy!\n\n\n",
+      "new": "Hey, thanks for entering.\nI have great news! You won\nthe drawing! Congrats!\nYou must be so happy!\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 655,
+      "label": "",
+      "original": "Hey there, you! Thanks for\ntaking part in my contest.\nI'm writing to inform you\nthat, oh, by the way,\nYOU TOTALLY WON!\nCongrats, <<STR_FREE0>>!\n",
+      "new": "Hey there, you! Thanks for\ntaking part in my contest.\nI'm writing to inform you\nthat, oh, by the way,\nYOU TOTALLY WON!\nCongrats, <<STR_FREE0>>!\n"
+    },
+    {
+      "group": "mail",
+      "index": 656,
+      "label": "",
+      "original": "Thanks for entering your\nname. It looks like it was\nworth it for you, because\nyou won. You're so lucky,\n<<STR_FREE0>>!\n\n",
+      "new": "Thanks for entering your\nname. It looks like it was\nworth it for you, because\nyou won. You're so lucky,\n<<STR_FREE0>>!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 657,
+      "label": "",
+      "original": "Yo! Entering this contest\nwas the smartest thing you\never did! Why? Because you\nwon, that's why! Dang! Why\ncouldn't it have been me,\n<<STR_FREE0>>? Double dang!\n",
+      "new": "Yo! Entering this contest\nwas the smartest thing you\never did! Why? Because you\nwon, that's why! Dang! Why\ncouldn't it have been me,\n<<STR_FREE0>>? Double dang!\n"
+    },
+    {
+      "group": "mail",
+      "index": 658,
+      "label": "",
+      "original": "Nothing ever goes my way.\nI must've been born under a\nbad sign. Why didn't I win?\nWHY?!? Why did it have\nto be you, <<STR_FREE0>>!?\nHere's your <<CUTARTICLE>><<STR_FREE4>>.\n",
+      "new": "Nothing ever goes my way.\nI must've been born under a\nbad sign. Why didn't I win?\nWHY?!? Why did it have\nto be you, <<STR_FREE0>>!?\nHere's your <<CUTARTICLE>><<STR_FREE4>>.\n"
+    },
+    {
+      "group": "mail",
+      "index": 659,
+      "label": "",
+      "original": "Well, you must think you're\npretty lucky. You, my dear,\nhave won my contest!\nCongratulations! Here's your\nprize: <<STR_FREE4>>.\n\n",
+      "new": "Well, you must think you're\npretty lucky. You, my dear,\nhave won my contest!\nCongratulations! Here's your\nprize: <<STR_FREE4>>.\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 660,
+      "label": "",
+      "original": "Thank you very much for\nentering, but unfortunately,\nyou didn't win. I'm really\nsorry. Better luck next time!\n\n\n",
+      "new": "Thank you very much for\nentering, but unfortunately,\nyou didn't win. I'm really\nsorry. Better luck next time!\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 661,
+      "label": "",
+      "original": "Hey there! Thanks a bundle\nfor entering the contest, but\nI'm really sorry to say you\ndidn't win! Oh well! That's\nthe way the cookie crumbles,\n<<STR_FREE0>>! Next time!\n",
+      "new": "Hey there! Thanks a bundle\nfor entering the contest, but\nI'm really sorry to say you\ndidn't win! Oh well! That's\nthe way the cookie crumbles,\n<<STR_FREE0>>! Next time!\n"
+    },
+    {
+      "group": "mail",
+      "index": 662,
+      "label": "",
+      "original": "Thanks for entering...but you\ndidn't win... Bummer. Well, I\nguess that's luck for you,\n<<STR_FREE0>>... Sometimes,\nbad luck's the only kind you\nget. Better luck next time!\n",
+      "new": "Thanks for entering...but you\ndidn't win... Bummer. Well, I\nguess that's luck for you,\n<<STR_FREE0>>... Sometimes,\nbad luck's the only kind you\nget. Better luck next time!\n"
+    },
+    {
+      "group": "mail",
+      "index": 663,
+      "label": "",
+      "original": "Hey, thanks so much for\nentering! I never expected\nsuch an enthusiastic\nresponse! Too bad you didn't\nwin, but don't let it get you\ndown, <<STR_FREE0>>!\n",
+      "new": "Hey, thanks so much for\nentering! I never expected\nsuch an enthusiastic\nresponse! Too bad you didn't\nwin, but don't let it get you\ndown, <<STR_FREE0>>!\n"
+    },
+    {
+      "group": "mail",
+      "index": 664,
+      "label": "",
+      "original": "CONGRATULATIONS...\non not winning. Too bad.\nThere are no consolation\nprizes, but please feel free\nto try again sometime!\n\n",
+      "new": "CONGRATULATIONS...\non not winning. Too bad.\nThere are no consolation\nprizes, but please feel free\nto try again sometime!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 665,
+      "label": "",
+      "original": "Thank you so very much for\nentering my drawing, but I'm\nsorryーyou didn't win. Don't\nbe too broken-hearted,\nthough. Maybe you'll have\nbetter luck next time!\n",
+      "new": "Thank you so very much for\nentering my drawing, but I'm\nsorryーyou didn't win. Don't\nbe too broken-hearted,\nthough. Maybe you'll have\nbetter luck next time!\n"
+    },
+    {
+      "group": "mail",
+      "index": 666,
+      "label": "",
+      "original": "Hey, listen, I don't know\nwhat secret you're talking\nabout. You'll just have to\nexplain yourself a little\nbetter next time, all right?\n\n",
+      "new": "Hey, listen, I don't know\nwhat secret you're talking\nabout. You'll just have to\nexplain yourself a little\nbetter next time, all right?\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 667,
+      "label": "",
+      "original": "Hey there! Listen, I'm really\nsorry, but I don't have the\nslightest idea what your\nletter meant! Were you trying\nto tell me a secret, or did\nyou want me to tell one?\n",
+      "new": "Hey there! Listen, I'm really\nsorry, but I don't have the\nslightest idea what your\nletter meant! Were you trying\nto tell me a secret, or did\nyou want me to tell one?\n"
+    },
+    {
+      "group": "mail",
+      "index": 668,
+      "label": "",
+      "original": "What's all this \"secret\"\nstuff you're talking about?\nWhatever it is, it went\ncompletely over my head.\nIn fact, you're starting to\nfreak me out a little bit.\n",
+      "new": "What's all this \"secret\"\nstuff you're talking about?\nWhatever it is, it went\ncompletely over my head.\nIn fact, you're starting to\nfreak me out a little bit.\n"
+    },
+    {
+      "group": "mail",
+      "index": 669,
+      "label": "",
+      "original": "What's up, <<STR_FREE0>>?\nIf you're talking about ninja\nsecrets, I know them all!\nBut I definitely don't know\nanything about that secret\nyou sent me.\n",
+      "new": "What's up, <<STR_FREE0>>?\nIf you're talking about ninja\nsecrets, I know them all!\nBut I definitely don't know\nanything about that secret\nyou sent me.\n"
+    },
+    {
+      "group": "mail",
+      "index": 670,
+      "label": "",
+      "original": "So, <<STR_FREE0>>, what\nwas with that letter? Did\nyou mean to send it to me?\nBecause I sure don't know\nthe secret you're talking\nabout. Get it together!\n",
+      "new": "So, <<STR_FREE0>>, what\nwas with that letter? Did\nyou mean to send it to me?\nBecause I sure don't know\nthe secret you're talking\nabout. Get it together!\n"
+    },
+    {
+      "group": "mail",
+      "index": 671,
+      "label": "",
+      "original": "Secret? What secret? I'm\nsure I don't know it! If it's\ngossip you want to hear,\nI can tell you the next time\nwe go for a walk together!\nWhen is that again?♥\n",
+      "new": "Secret? What secret? I'm\nsure I don't know it! If it's\ngossip you want to hear,\nI can tell you the next time\nwe go for a walk together!\nWhen is that again?♥\n"
+    },
+    {
+      "group": "mail",
+      "index": 672,
+      "label": "",
+      "original": "You won't believe thisーI saw\nyour name printed in\n<<STR_FREE2>><<STR_FREE3>>! I guess\nyou won something! I picked\nit up for you, so here you\ngo! Congratulations!\n",
+      "new": "You won't believe thisーI saw\nyour name printed in\n<<STR_FREE2>><<STR_FREE3>>! I guess\nyou won something! I picked\nit up for you, so here you\ngo! Congratulations!\n"
+    },
+    {
+      "group": "mail",
+      "index": 673,
+      "label": "",
+      "original": "Hey! This reporter from\n<<STR_FREE2>><<STR_FREE3>> was in\ntown asking about you,\n<<STR_FREE0>>! She said you\nwon a contest, and she gave\nme the prize to give to you!\n",
+      "new": "Hey! This reporter from\n<<STR_FREE2>><<STR_FREE3>> was in\ntown asking about you,\n<<STR_FREE0>>! She said you\nwon a contest, and she gave\nme the prize to give to you!\n"
+    },
+    {
+      "group": "mail",
+      "index": 674,
+      "label": "",
+      "original": "I tried to enter a contest\nin <<STR_FREE2>><<STR_FREE3>>,\nbut I was really sleepy at\nthe time, and I wrote your\nname instead. Well, you won,\nso here's your prize!\n",
+      "new": "I tried to enter a contest\nin <<STR_FREE2>><<STR_FREE3>>,\nbut I was really sleepy at\nthe time, and I wrote your\nname instead. Well, you won,\nso here's your prize!\n"
+    },
+    {
+      "group": "mail",
+      "index": 675,
+      "label": "",
+      "original": "We are two lucky dogs! I\nsaw both our names in a\nlist of contest winners in\n<<STR_FREE2>><<STR_FREE3>>! I won, too,\nso I picked up your prize\nalong with mine! Here!\n",
+      "new": "We are two lucky dogs! I\nsaw both our names in a\nlist of contest winners in\n<<STR_FREE2>><<STR_FREE3>>! I won, too,\nso I picked up your prize\nalong with mine! Here!\n"
+    },
+    {
+      "group": "mail",
+      "index": 676,
+      "label": "",
+      "original": "Talk about a prank gone\nhaywire! I sent a letter to\n<<STR_FREE2>><<STR_FREE3>> and signed\nit \"<<STR_FREE0>>\"! Well\nguess what! You won this\n<<STR_FREE4>>! Sheesh!\n",
+      "new": "Talk about a prank gone\nhaywire! I sent a letter to\n<<STR_FREE2>><<STR_FREE3>> and signed\nit \"<<STR_FREE0>>\"! Well\nguess what! You won this\n<<STR_FREE4>>! Sheesh!\n"
+    },
+    {
+      "group": "mail",
+      "index": 677,
+      "label": "",
+      "original": "Are you the type that enters\nyour name in every contest\nthat comes around? I saw\nyour name in <<STR_FREE2>><<STR_FREE3>>.\nYou finally won! Here's your\n<<STR_FREE4>>.\n",
+      "new": "Are you the type that enters\nyour name in every contest\nthat comes around? I saw\nyour name in <<STR_FREE2>><<STR_FREE3>>.\nYou finally won! Here's your\n<<STR_FREE4>>.\n"
+    },
+    {
+      "group": "mail",
+      "index": 678,
+      "label": "",
+      "original": "I entered your name in a\ncontest in <<STR_FREE2>><<STR_FREE3>>,\nbut it turns out you didn't\nwin. Oh, well. It's the\nthought that counts, right?\n\n",
+      "new": "I entered your name in a\ncontest in <<STR_FREE2>><<STR_FREE3>>,\nbut it turns out you didn't\nwin. Oh, well. It's the\nthought that counts, right?\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 679,
+      "label": "",
+      "original": "A reporter from\n<<STR_FREE2>><<STR_FREE3>> was\nin town the other day. She\nsaid you didn't win the\ncontest you entered.\nBetter luck next time!\n",
+      "new": "A reporter from\n<<STR_FREE2>><<STR_FREE3>> was\nin town the other day. She\nsaid you didn't win the\ncontest you entered.\nBetter luck next time!\n"
+    },
+    {
+      "group": "mail",
+      "index": 680,
+      "label": "",
+      "original": "I entered this contest in\n<<STR_FREE2>><<STR_FREE3>>, but I\nwas pretty sleepy, and I\naccidently entered your\nname. Sorry, but you didn't\nwin. Maybe next time!\n",
+      "new": "I entered this contest in\n<<STR_FREE2>><<STR_FREE3>>, but I\nwas pretty sleepy, and I\naccidently entered your\nname. Sorry, but you didn't\nwin. Maybe next time!\n"
+    },
+    {
+      "group": "mail",
+      "index": 681,
+      "label": "",
+      "original": "We are so unlucky,\n<<STR_FREE0>>. Neither of\nour names was in the list\nof contest winners in\n<<STR_FREE2>><<STR_FREE3>>...\nLame!\n",
+      "new": "We are so unlucky,\n<<STR_FREE0>>. Neither of\nour names was in the list\nof contest winners in\n<<STR_FREE2>><<STR_FREE3>>...\nLame!\n"
+    },
+    {
+      "group": "mail",
+      "index": 682,
+      "label": "",
+      "original": "What a great prank! I\nentered your name in a\ncontest, but you lost!\nI checked the winners in\n<<STR_FREE2>><<STR_FREE3>>, but\nyou weren't in there!\n",
+      "new": "What a great prank! I\nentered your name in a\ncontest, but you lost!\nI checked the winners in\n<<STR_FREE2>><<STR_FREE3>>, but\nyou weren't in there!\n"
+    },
+    {
+      "group": "mail",
+      "index": 683,
+      "label": "",
+      "original": "I'm sorry to bear the bad\nnews, but you didn't win\nthat contest that you entered\nin <<STR_FREE2>><<STR_FREE3>>.\nBetter luck next time!\n\n",
+      "new": "I'm sorry to bear the bad\nnews, but you didn't win\nthat contest that you entered\nin <<STR_FREE2>><<STR_FREE3>>.\nBetter luck next time!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 684,
+      "label": "",
+      "original": "Umm, I don't really\nunderstand that letter\nyou sent me. What was it?\nSome kind of password?\nIt didn't make much sense\nto me. \n",
+      "new": "Umm, I don't really\nunderstand that letter\nyou sent me. What was it?\nSome kind of password?\nIt didn't make much sense\nto me. \n"
+    },
+    {
+      "group": "mail",
+      "index": 685,
+      "label": "",
+      "original": "What was with that letter\nyou sent me? It was all\nweirded-out! Was it some\nkind of code? Well, I sure\ndon't get it, <<STR_FREE0>>!\nI think you're just nuts!\n",
+      "new": "What was with that letter\nyou sent me? It was all\nweirded-out! Was it some\nkind of code? Well, I sure\ndon't get it, <<STR_FREE0>>!\nI think you're just nuts!\n"
+    },
+    {
+      "group": "mail",
+      "index": 686,
+      "label": "",
+      "original": "Hey, when you send me\nletters with secret codes\nin them, make sure the\nsecret codes make sense.\nOtherwise, it's just no fun\nat all!\n",
+      "new": "Hey, when you send me\nletters with secret codes\nin them, make sure the\nsecret codes make sense.\nOtherwise, it's just no fun\nat all!\n"
+    },
+    {
+      "group": "mail",
+      "index": 687,
+      "label": "",
+      "original": "What's the deal? That letter\ndidn't make any sense!\nWas it some kind of ninja\npassword? 'Cause that would\nbe cool! Yeah, ninjas are\nway cool.\n",
+      "new": "What's the deal? That letter\ndidn't make any sense!\nWas it some kind of ninja\npassword? 'Cause that would\nbe cool! Yeah, ninjas are\nway cool.\n"
+    },
+    {
+      "group": "mail",
+      "index": 688,
+      "label": "",
+      "original": "Hey! Did you send that\nletter to the wrong guy?\nJust what are you up to?\nAre you some kind of spy?\nWas that a secret code?\nAnswer me!!!\n",
+      "new": "Hey! Did you send that\nletter to the wrong guy?\nJust what are you up to?\nAre you some kind of spy?\nWas that a secret code?\nAnswer me!!!\n"
+    },
+    {
+      "group": "mail",
+      "index": 689,
+      "label": "",
+      "original": "I am afraid I don't know\nhow to respond to your\nsecret code. To be honest, it\nstirred up emotions in me\nthat I didn't know I had,\nlike confusion...\n",
+      "new": "I am afraid I don't know\nhow to respond to your\nsecret code. To be honest, it\nstirred up emotions in me\nthat I didn't know I had,\nlike confusion...\n"
+    },
+    {
+      "group": "mail",
+      "index": 690,
+      "label": "",
+      "original": "Hi, <<STR_FREE0>>.\nHow are things? Going well,\nI hope! Obviously, I'm pretty\n<<STR_FREE2>><<STR_FREE3>>.\nAnd to that, I say pthhpth!\nTake care!\n",
+      "new": "Hi, <<STR_FREE0>>.\nHow are things? Going well,\nI hope! Obviously, I'm pretty\n<<STR_FREE2>><<STR_FREE3>>.\nAnd to that, I say pthhpth!\nTake care!\n"
+    },
+    {
+      "group": "mail",
+      "index": 691,
+      "label": "",
+      "original": "Hi, <<STR_FREE0>>!\nWhat's up? I'm doing great!\nIf I had to sum up my\nmood, I'd say I'm feeling\n<<STR_FREE2>><<STR_FREE3>>,\nI guess...<<STR_FREE5>>.\n",
+      "new": "Hi, <<STR_FREE0>>!\nWhat's up? I'm doing great!\nIf I had to sum up my\nmood, I'd say I'm feeling\n<<STR_FREE2>><<STR_FREE3>>,\nI guess...<<STR_FREE5>>.\n"
+    },
+    {
+      "group": "mail",
+      "index": 692,
+      "label": "",
+      "original": "Hello, <<STR_FREE0>>. How are\nyou? Me? Do you need to\nask? I'm as happy as\n<<STR_FREE2>><<STR_FREE3>>,\n<<STR_FREE5>>!\nSee you soon!\n",
+      "new": "Hello, <<STR_FREE0>>. How are\nyou? Me? Do you need to\nask? I'm as happy as\n<<STR_FREE2>><<STR_FREE3>>,\n<<STR_FREE5>>!\nSee you soon!\n"
+    },
+    {
+      "group": "mail",
+      "index": 693,
+      "label": "",
+      "original": "How have you been doing?\nI've been having fun doing\n<<STR_FREE2>><<STR_FREE3>>\nevery day! You should try it,\ntoo! What do you say,\n<<STR_FREE5>>?\n",
+      "new": "How have you been doing?\nI've been having fun doing\n<<STR_FREE2>><<STR_FREE3>>\nevery day! You should try it,\ntoo! What do you say,\n<<STR_FREE5>>?\n"
+    },
+    {
+      "group": "mail",
+      "index": 694,
+      "label": "",
+      "original": "Hi there! How ARE you? In\ncase you can't tell, this is\nTangy! Do you know why\nI'm called Tangy? 'Cause I'm\n<<STR_FREE2>><<STR_FREE3>>!\nBut that's our secret!\n",
+      "new": "Hi there! How ARE you? In\ncase you can't tell, this is\nTangy! Do you know why\nI'm called Tangy? 'Cause I'm\n<<STR_FREE2>><<STR_FREE3>>!\nBut that's our secret!\n"
+    },
+    {
+      "group": "mail",
+      "index": 695,
+      "label": "",
+      "original": "You have to understand that\nI'm <<STR_FREE2>><<STR_FREE3>>.\nDon't forget it! And take\ngood care of my PR photo,\n<<STR_FREE5>>! I did give\nyou one, right?\n",
+      "new": "You have to understand that\nI'm <<STR_FREE2>><<STR_FREE3>>.\nDon't forget it! And take\ngood care of my PR photo,\n<<STR_FREE5>>! I did give\nyou one, right?\n"
+    },
+    {
+      "group": "mail",
+      "index": 696,
+      "label": "",
+      "original": "I want to become the kind\nof versatile actress that can\ndo action flicks, too. Then\neveryone will say I'm\n<<STR_FREE2>><<STR_FREE3>>,\n<<STR_FREE5>>.\n",
+      "new": "I want to become the kind\nof versatile actress that can\ndo action flicks, too. Then\neveryone will say I'm\n<<STR_FREE2>><<STR_FREE3>>,\n<<STR_FREE5>>.\n"
+    },
+    {
+      "group": "mail",
+      "index": 697,
+      "label": "",
+      "original": "How have you been,\n<<STR_FREE0>>? I'm great,\nas usual. I've been\nspending my days doing\n<<STR_FREE2>><<STR_FREE3>>. It's\ngreat, <<STR_FREE5>>.\n",
+      "new": "How have you been,\n<<STR_FREE0>>? I'm great,\nas usual. I've been\nspending my days doing\n<<STR_FREE2>><<STR_FREE3>>. It's\ngreat, <<STR_FREE5>>.\n"
+    },
+    {
+      "group": "mail",
+      "index": 698,
+      "label": "",
+      "original": "I wonder what it's like\nto get sore muscles from\n<<STR_FREE2>><<STR_FREE3>>...\nThat's all I can think about\nthese days, <<STR_FREE5>>.\n\n",
+      "new": "I wonder what it's like\nto get sore muscles from\n<<STR_FREE2>><<STR_FREE3>>...\nThat's all I can think about\nthese days, <<STR_FREE5>>.\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 699,
+      "label": "",
+      "original": "Hi, <<STR_FREE0>>. How have\nyou been? Good, I hope. You\nreally should get out and do\nmore <<STR_FREE2>><<STR_FREE3>>. \nOtherwise, you'll get fat,\n<<STR_FREE5>>.\n",
+      "new": "Hi, <<STR_FREE0>>. How have\nyou been? Good, I hope. You\nreally should get out and do\nmore <<STR_FREE2>><<STR_FREE3>>. \nOtherwise, you'll get fat,\n<<STR_FREE5>>.\n"
+    },
+    {
+      "group": "mail",
+      "index": 700,
+      "label": "",
+      "original": "Hi. How are things? I'm\nfine. I just wish I were as\nyoung and sprightly as you.\nI like the way you listen\nto <<STR_FREE2>><<STR_FREE3>>.\n\n",
+      "new": "Hi. How are things? I'm\nfine. I just wish I were as\nyoung and sprightly as you.\nI like the way you listen\nto <<STR_FREE2>><<STR_FREE3>>.\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 701,
+      "label": "",
+      "original": "What's up, <<STR_FREE0>>?\nAre things good? When you're\nbeat, you should eat\n<<STR_FREE2>><<STR_FREE3>>\nand sleep. Nothing makes\nme feel better, <<STR_FREE5>>!\n",
+      "new": "What's up, <<STR_FREE0>>?\nAre things good? When you're\nbeat, you should eat\n<<STR_FREE2>><<STR_FREE3>>\nand sleep. Nothing makes\nme feel better, <<STR_FREE5>>!\n"
+    },
+    {
+      "group": "mail",
+      "index": 702,
+      "label": "",
+      "original": "If I had to say what I was\nbest at...it would be\n<<STR_FREE2>><<STR_FREE3>>.\nI guess. But that's our\nsecret.\n\n",
+      "new": "If I had to say what I was\nbest at...it would be\n<<STR_FREE2>><<STR_FREE3>>.\nI guess. But that's our\nsecret.\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 703,
+      "label": "",
+      "original": "Hi, <<STR_FREE0>>. I've\nbeen spending all my time\nbaking sweets. I even\nmade <<STR_FREE2>><<STR_FREE3>>\nlast Sunday, <<STR_FREE5>>!\n\n",
+      "new": "Hi, <<STR_FREE0>>. I've\nbeen spending all my time\nbaking sweets. I even\nmade <<STR_FREE2>><<STR_FREE3>>\nlast Sunday, <<STR_FREE5>>!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 704,
+      "label": "",
+      "original": "Hi there! How is everything,\n<<STR_FREE0>>? So, what\nkind of music do you like?\nI'm all about the\n<<STR_FREE2>><<STR_FREE3>>\nlately, <<STR_FREE5>>.\n",
+      "new": "Hi there! How is everything,\n<<STR_FREE0>>? So, what\nkind of music do you like?\nI'm all about the\n<<STR_FREE2>><<STR_FREE3>>\nlately, <<STR_FREE5>>.\n"
+    },
+    {
+      "group": "mail",
+      "index": 705,
+      "label": "",
+      "original": "I like ants. They are so...\nhow should I put this?\n...<<CAPTIALIZE>><<STR_FREE2>><<STR_FREE3>>!\nI can't get enough of it,\n<<STR_FREE5>>!\n\n",
+      "new": "I like ants. They are so...\nhow should I put this?\n...<<CAPTIALIZE>><<STR_FREE2>><<STR_FREE3>>!\nI can't get enough of it,\n<<STR_FREE5>>!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 706,
+      "label": "",
+      "original": "Hey! What's going on?\nDon't get so stressed\nover minute details!\nDo a little <<STR_FREE2>>\n<<STR_FREE3>> and burn\noff some of that stress.\n",
+      "new": "Hey! What's going on?\nDon't get so stressed\nover minute details!\nDo a little <<STR_FREE2>>\n<<STR_FREE3>> and burn\noff some of that stress.\n"
+    },
+    {
+      "group": "mail",
+      "index": 707,
+      "label": "",
+      "original": "How are you, <<STR_FREE0>>?\nI don't like complications.\nI like things to be simple.\nTry to be a little more\n<<STR_FREE2>><<STR_FREE3>>,\n<<STR_FREE5>>.\n",
+      "new": "How are you, <<STR_FREE0>>?\nI don't like complications.\nI like things to be simple.\nTry to be a little more\n<<STR_FREE2>><<STR_FREE3>>,\n<<STR_FREE5>>.\n"
+    },
+    {
+      "group": "mail",
+      "index": 708,
+      "label": "",
+      "original": "Hi. Have you been working\nout much lately? I've been\nspending all my time on\n<<STR_FREE2>><<STR_FREE3>>\nlately. Anyway, gotta\nrun!\n",
+      "new": "Hi. Have you been working\nout much lately? I've been\nspending all my time on\n<<STR_FREE2>><<STR_FREE3>>\nlately. Anyway, gotta\nrun!\n"
+    },
+    {
+      "group": "mail",
+      "index": 709,
+      "label": "",
+      "original": "Hey, how have you been?\nI've been wasting my time\non <<STR_FREE2>><<STR_FREE3>>\nand stuff like that. The\nmore you relax, the less\nstress you have!\n",
+      "new": "Hey, how have you been?\nI've been wasting my time\non <<STR_FREE2>><<STR_FREE3>>\nand stuff like that. The\nmore you relax, the less\nstress you have!\n"
+    },
+    {
+      "group": "mail",
+      "index": 710,
+      "label": "",
+      "original": "Hi, <<STR_FREE0>>. I had this\ndream the other night\nwhere I became the\nchampion of <<STR_FREE2>>\n<<STR_FREE3>>. You were\nthe judge.\n",
+      "new": "Hi, <<STR_FREE0>>. I had this\ndream the other night\nwhere I became the\nchampion of <<STR_FREE2>>\n<<STR_FREE3>>. You were\nthe judge.\n"
+    },
+    {
+      "group": "mail",
+      "index": 711,
+      "label": "",
+      "original": "Hey, <<STR_FREE0>>! I'm\ngoing to throw a \n<<STR_FREE2>><<STR_FREE3>>\nparty, so dress yourself up!\nI just hope I can make a\n<<STR_FREE2>><<STR_FREE3>>.\n",
+      "new": "Hey, <<STR_FREE0>>! I'm\ngoing to throw a \n<<STR_FREE2>><<STR_FREE3>>\nparty, so dress yourself up!\nI just hope I can make a\n<<STR_FREE2>><<STR_FREE3>>.\n"
+    },
+    {
+      "group": "mail",
+      "index": 712,
+      "label": "",
+      "original": "Hey, <<STR_FREE0>>. Once\nyou make up your own\nmind, don't pay any heed\nto what others say. Just be\n<<STR_FREE2>><<STR_FREE3>>.\n\n",
+      "new": "Hey, <<STR_FREE0>>. Once\nyou make up your own\nmind, don't pay any heed\nto what others say. Just be\n<<STR_FREE2>><<STR_FREE3>>.\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 713,
+      "label": "",
+      "original": "Nothing looks cuter than\na tutu, <<STR_FREE5>>.\nIt's so <<STR_FREE2>><<STR_FREE3>>,\ndon't you think? ♥\n\n\n",
+      "new": "Nothing looks cuter than\na tutu, <<STR_FREE5>>.\nIt's so <<STR_FREE2>><<STR_FREE3>>,\ndon't you think? ♥\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 714,
+      "label": "",
+      "original": "Hello, <<STR_FREE0>>. How\nhave you been? I'm just\nheavenly, of course.\nI just want to scream\n<<STR_FREE2>><<STR_FREE3>>,\n<<STR_FREE5>>.\n",
+      "new": "Hello, <<STR_FREE0>>. How\nhave you been? I'm just\nheavenly, of course.\nI just want to scream\n<<STR_FREE2>><<STR_FREE3>>,\n<<STR_FREE5>>.\n"
+    },
+    {
+      "group": "mail",
+      "index": 715,
+      "label": "",
+      "original": "Have you ever been in\ntrouble? Well, you just think\nof me as your\n<<STR_FREE2>><<STR_FREE3>>!\nIf I feel like it, I'll help\nyou out, <<STR_FREE5>>.\n",
+      "new": "Have you ever been in\ntrouble? Well, you just think\nof me as your\n<<STR_FREE2>><<STR_FREE3>>!\nIf I feel like it, I'll help\nyou out, <<STR_FREE5>>.\n"
+    },
+    {
+      "group": "mail",
+      "index": 716,
+      "label": "",
+      "original": "I don't know why, but I love\nthe taste of bamboo.\nI just love eating\n<<STR_FREE2>><<STR_FREE3>> on\nthe weekend, <<STR_FREE5>>♥\n\n",
+      "new": "I don't know why, but I love\nthe taste of bamboo.\nI just love eating\n<<STR_FREE2>><<STR_FREE3>> on\nthe weekend, <<STR_FREE5>>♥\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 717,
+      "label": "",
+      "original": "Hey, <<STR_FREE0>>. Have\nyou put on some weight\nlately? Maybe you should\ntry a little exercise, like\n<<STR_FREE4>>!\n\n",
+      "new": "Hey, <<STR_FREE0>>. Have\nyou put on some weight\nlately? Maybe you should\ntry a little exercise, like\n<<STR_FREE4>>!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 718,
+      "label": "",
+      "original": "Do you know what I'm\nbest at? I bet you'd never\nguess <<STR_FREE2>><<STR_FREE3>>!\nThat's why I don't scare\neasily at night, <<STR_FREE5>>.\n\n",
+      "new": "Do you know what I'm\nbest at? I bet you'd never\nguess <<STR_FREE2>><<STR_FREE3>>!\nThat's why I don't scare\neasily at night, <<STR_FREE5>>.\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 719,
+      "label": "",
+      "original": "Letters are a real pain.\nSo I'm just going to give\nyou a nice little\n<<STR_FREE4>>,\n<<STR_FREE5>>. Enjoy!\n\n",
+      "new": "Letters are a real pain.\nSo I'm just going to give\nyou a nice little\n<<STR_FREE4>>,\n<<STR_FREE5>>. Enjoy!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 720,
+      "label": "",
+      "original": "Be thorough at everything\nyou do. That's my motto!\nIn fact, I was up all night\nworking on my\n<<STR_FREE2>><<STR_FREE3>> the\nother night, <<STR_FREE5>>!\n",
+      "new": "Be thorough at everything\nyou do. That's my motto!\nIn fact, I was up all night\nworking on my\n<<STR_FREE2>><<STR_FREE3>> the\nother night, <<STR_FREE5>>!\n"
+    },
+    {
+      "group": "mail",
+      "index": 721,
+      "label": "",
+      "original": "I hate it when things are\nout of line, <<STR_FREE5>>!\nI like them as straight as\na <<STR_FREE2>><<STR_FREE3>>!\nNever bend, <<STR_FREE0>>!\nNever, <<STR_FREE5>>!\n",
+      "new": "I hate it when things are\nout of line, <<STR_FREE5>>!\nI like them as straight as\na <<STR_FREE2>><<STR_FREE3>>!\nNever bend, <<STR_FREE0>>!\nNever, <<STR_FREE5>>!\n"
+    },
+    {
+      "group": "mail",
+      "index": 722,
+      "label": "",
+      "original": "The other day, a\n<<STR_FREE2>><<STR_FREE3>>\ncame to my place,\n<<STR_FREE5>>. I was kind\nof surprised, but it was\nnice...\n",
+      "new": "The other day, a\n<<STR_FREE2>><<STR_FREE3>>\ncame to my place,\n<<STR_FREE5>>. I was kind\nof surprised, but it was\nnice...\n"
+    },
+    {
+      "group": "mail",
+      "index": 723,
+      "label": "",
+      "original": "Hello, <<STR_FREE0>>.\nEveryone says my house is\ntoo elegant, but I'm actually\nthinking of getting my own\n<<STR_FREE2>><<STR_FREE3>>.\nI go well with anything.\n",
+      "new": "Hello, <<STR_FREE0>>.\nEveryone says my house is\ntoo elegant, but I'm actually\nthinking of getting my own\n<<STR_FREE2>><<STR_FREE3>>.\nI go well with anything.\n"
+    },
+    {
+      "group": "mail",
+      "index": 724,
+      "label": "",
+      "original": "Hello, <<STR_FREE0>>. I think\nit's about time for me to\nchange my feathers. Do you\nthink <<STR_FREE2>><<STR_FREE3>>\nwould look good? Maybe I\nshould check out your place.\n",
+      "new": "Hello, <<STR_FREE0>>. I think\nit's about time for me to\nchange my feathers. Do you\nthink <<STR_FREE2>><<STR_FREE3>>\nwould look good? Maybe I\nshould check out your place.\n"
+    },
+    {
+      "group": "mail",
+      "index": 725,
+      "label": "",
+      "original": "Aces high, <<STR_FREE0>>!\nNot that I care, but you\nseem like you're into\n<<STR_FREE2>><<STR_FREE3>> and\nstuff like that, <<STR_FREE5>>.\nMaybe I'll go too next time!\n",
+      "new": "Aces high, <<STR_FREE0>>!\nNot that I care, but you\nseem like you're into\n<<STR_FREE2>><<STR_FREE3>> and\nstuff like that, <<STR_FREE5>>.\nMaybe I'll go too next time!\n"
+    },
+    {
+      "group": "mail",
+      "index": 726,
+      "label": "",
+      "original": "Don't lose, <<STR_FREE0>>!\nWhatever you do, just don't\ngive up! And if things get\nrough, have a little\n<<STR_FREE2>><<STR_FREE3>>\nand relax, <<STR_FREE5>>.\n",
+      "new": "Don't lose, <<STR_FREE0>>!\nWhatever you do, just don't\ngive up! And if things get\nrough, have a little\n<<STR_FREE2>><<STR_FREE3>>\nand relax, <<STR_FREE5>>.\n"
+    },
+    {
+      "group": "mail",
+      "index": 727,
+      "label": "",
+      "original": "Hey, hey! How have you\nbeen? You know what?\nEating a vitamin-packed \n<<STR_FREE2>><<STR_FREE3>>\nonce in a while really\nboosts your stamina!\n",
+      "new": "Hey, hey! How have you\nbeen? You know what?\nEating a vitamin-packed \n<<STR_FREE2>><<STR_FREE3>>\nonce in a while really\nboosts your stamina!\n"
+    },
+    {
+      "group": "mail",
+      "index": 728,
+      "label": "",
+      "original": "What's cookin'? I had this\ndream that we had a\n<<STR_FREE2>><<STR_FREE3>>-eating\ncontest, <<STR_FREE5>>.\nYou ate like a horse!\n\n",
+      "new": "What's cookin'? I had this\ndream that we had a\n<<STR_FREE2>><<STR_FREE3>>-eating\ncontest, <<STR_FREE5>>.\nYou ate like a horse!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 729,
+      "label": "",
+      "original": "Just a quick heads up!\nIf all you ever do is\n<<STR_FREE2>><<STR_FREE3>>, you'll\nnever have much luck.\nNo, <<STR_FREE5>>?\nThat's all I have to say!\n",
+      "new": "Just a quick heads up!\nIf all you ever do is\n<<STR_FREE2>><<STR_FREE3>>, you'll\nnever have much luck.\nNo, <<STR_FREE5>>?\nThat's all I have to say!\n"
+    },
+    {
+      "group": "mail",
+      "index": 730,
+      "label": "",
+      "original": "How are you these days?\nEveryone tells me my house\nis too saucy, so maybe I'll\nsee if I can't find a\n<<STR_FREE2>><<STR_FREE3>>\nto tone it down.\n",
+      "new": "How are you these days?\nEveryone tells me my house\nis too saucy, so maybe I'll\nsee if I can't find a\n<<STR_FREE2>><<STR_FREE3>>\nto tone it down.\n"
+    },
+    {
+      "group": "mail",
+      "index": 731,
+      "label": "",
+      "original": "Hey, hey! How are things,\n<<STR_FREE5>>? I'm working\non my <<STR_FREE2>><<STR_FREE3>>\non a daily basis!\nYou should too!\n\n",
+      "new": "Hey, hey! How are things,\n<<STR_FREE5>>? I'm working\non my <<STR_FREE2>><<STR_FREE3>>\non a daily basis!\nYou should too!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 732,
+      "label": "",
+      "original": "I think I want to eat\n<<STR_FREE2>><<STR_FREE3>>...\nwithout cooking it first...\n\n\n\n",
+      "new": "I think I want to eat\n<<STR_FREE2>><<STR_FREE3>>...\nwithout cooking it first...\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 733,
+      "label": "",
+      "original": "Hi. How are you? Do you go\nsee movies much,\n<<STR_FREE0>>? I like to\nsee <<STR_FREE2>><<STR_FREE3>>\nfilms. But only at home on\nTV.\n",
+      "new": "Hi. How are you? Do you go\nsee movies much,\n<<STR_FREE0>>? I like to\nsee <<STR_FREE2>><<STR_FREE3>>\nfilms. But only at home on\nTV.\n"
+    },
+    {
+      "group": "mail",
+      "index": 734,
+      "label": "",
+      "original": "How are you? I had this\nawesome dream that I beat\nyou to become the local\n<<STR_FREE2>><<STR_FREE3>> champ!\nBut let me tell you, you\nwere one tough competitor!\n",
+      "new": "How are you? I had this\nawesome dream that I beat\nyou to become the local\n<<STR_FREE2>><<STR_FREE3>> champ!\nBut let me tell you, you\nwere one tough competitor!\n"
+    },
+    {
+      "group": "mail",
+      "index": 735,
+      "label": "",
+      "original": "Despite what you may think,\nI can actually do\n<<STR_FREE2>><<STR_FREE3>>, <<STR_FREE5>>!\nWell, <<STR_FREE0>>?\nHas your opinion of me\nchanged now?\n",
+      "new": "Despite what you may think,\nI can actually do\n<<STR_FREE2>><<STR_FREE3>>, <<STR_FREE5>>!\nWell, <<STR_FREE0>>?\nHas your opinion of me\nchanged now?\n"
+    },
+    {
+      "group": "mail",
+      "index": 736,
+      "label": "",
+      "original": "How are you? I have this\nquestion I've been wanting\nto ask you, <<STR_FREE0>>.\nWhat kind of movies do you\nlike? I just love watching\n<<STR_FREE2>><<STR_FREE3>> films!\n",
+      "new": "How are you? I have this\nquestion I've been wanting\nto ask you, <<STR_FREE0>>.\nWhat kind of movies do you\nlike? I just love watching\n<<STR_FREE2>><<STR_FREE3>> films!\n"
+    },
+    {
+      "group": "mail",
+      "index": 737,
+      "label": "",
+      "original": "Whoa! <<STR_FREE0>>! I know\nI'm pretty dumb and don't\nknow much, but I think I'm\ngoing to read the\n<<STR_FREE2>><<STR_FREE3>> and try\nto learn something!\n",
+      "new": "Whoa! <<STR_FREE0>>! I know\nI'm pretty dumb and don't\nknow much, but I think I'm\ngoing to read the\n<<STR_FREE2>><<STR_FREE3>> and try\nto learn something!\n"
+    },
+    {
+      "group": "mail",
+      "index": 738,
+      "label": "",
+      "original": "When I'm really mad, I just\ntake a deep breath and think\nabout <<STR_FREE2>><<STR_FREE3>>.\nIt's surprisingly soothing.\nWhat? You knew! CURSES!\n\n",
+      "new": "When I'm really mad, I just\ntake a deep breath and think\nabout <<STR_FREE2>><<STR_FREE3>>.\nIt's surprisingly soothing.\nWhat? You knew! CURSES!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 739,
+      "label": "",
+      "original": "Hidey-ho! How are you,\n<<STR_FREE0>>? Tell me,\nwhat's your favorite color,\n<<STR_FREE5>>? I like pink!\nIt just makes me feel so\n<<STR_FREE2>><<STR_FREE3>>!\n",
+      "new": "Hidey-ho! How are you,\n<<STR_FREE0>>? Tell me,\nwhat's your favorite color,\n<<STR_FREE5>>? I like pink!\nIt just makes me feel so\n<<STR_FREE2>><<STR_FREE3>>!\n"
+    },
+    {
+      "group": "mail",
+      "index": 740,
+      "label": "",
+      "original": "How are you doing?\nI'm doing all right,\n<<STR_FREE5>>. Even my friends\ncall me <<STR_FREE2>><<STR_FREE3>>.\nSee you!\n\n",
+      "new": "How are you doing?\nI'm doing all right,\n<<STR_FREE5>>. Even my friends\ncall me <<STR_FREE2>><<STR_FREE3>>.\nSee you!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 741,
+      "label": "",
+      "original": "Hello. I love stuffed animals.\nAnd not just bears. I'd be\nhappy to get a stuffed\n<<STR_FREE2>><<STR_FREE3>>\nany day! If only they made\nthem, <<STR_FREE5>>!\n",
+      "new": "Hello. I love stuffed animals.\nAnd not just bears. I'd be\nhappy to get a stuffed\n<<STR_FREE2>><<STR_FREE3>>\nany day! If only they made\nthem, <<STR_FREE5>>!\n"
+    },
+    {
+      "group": "mail",
+      "index": 742,
+      "label": "",
+      "original": "How have you been? I've\nbeen wondering a lot about\n<<STR_FREE2>><<STR_FREE3>> lately.\nJust thought I'd let you\nknow. See ya soon!\n\n",
+      "new": "How have you been? I've\nbeen wondering a lot about\n<<STR_FREE2>><<STR_FREE3>> lately.\nJust thought I'd let you\nknow. See ya soon!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 743,
+      "label": "",
+      "original": "Are you doing well?\nTell me, <<STR_FREE0>>, what\nis your favorite color?\nI love pink. It just feels so\n<<STR_FREE2>><<STR_FREE3>>.\nDo you know what I mean?\n",
+      "new": "Are you doing well?\nTell me, <<STR_FREE0>>, what\nis your favorite color?\nI love pink. It just feels so\n<<STR_FREE2>><<STR_FREE3>>.\nDo you know what I mean?\n"
+    },
+    {
+      "group": "mail",
+      "index": 744,
+      "label": "",
+      "original": "Yo! What's up? Things been\ncool with you? I've been\nmostly <<STR_FREE2>><<STR_FREE3>>,\n<<STR_FREE5>>. Now that we're\nup to date on things, see\nyou later!\n",
+      "new": "Yo! What's up? Things been\ncool with you? I've been\nmostly <<STR_FREE2>><<STR_FREE3>>,\n<<STR_FREE5>>. Now that we're\nup to date on things, see\nyou later!\n"
+    },
+    {
+      "group": "mail",
+      "index": 745,
+      "label": "",
+      "original": "Have you been well?\nLately, I've been totally and\ncompletely obsessed with\n<<STR_FREE2>><<STR_FREE3>>.\nI can't help myself,\n<<STR_FREE5>>.\n",
+      "new": "Have you been well?\nLately, I've been totally and\ncompletely obsessed with\n<<STR_FREE2>><<STR_FREE3>>.\nI can't help myself,\n<<STR_FREE5>>.\n"
+    },
+    {
+      "group": "mail",
+      "index": 746,
+      "label": "",
+      "original": "I really like people I can\ncount on when I need to.\nI guess you could say that's\nmy type of person.\nReally <<STR_FREE2>><<STR_FREE3>>\npeople are so dreamy!\n",
+      "new": "I really like people I can\ncount on when I need to.\nI guess you could say that's\nmy type of person.\nReally <<STR_FREE2>><<STR_FREE3>>\npeople are so dreamy!\n"
+    },
+    {
+      "group": "mail",
+      "index": 747,
+      "label": "",
+      "original": "Have you been well? I know\nit's not the latest thing, but\nI've been really into\n<<STR_FREE2>><<STR_FREE3>> lately.\nHave you tried it? It's good for\nyour health!\n",
+      "new": "Have you been well? I know\nit's not the latest thing, but\nI've been really into\n<<STR_FREE2>><<STR_FREE3>> lately.\nHave you tried it? It's good for\nyour health!\n"
+    },
+    {
+      "group": "mail",
+      "index": 748,
+      "label": "",
+      "original": "My house is surrounded\nby plants. It feels like my\nown personal cafe.\nNext time you come to visit,\nI just might make\n<<STR_FREE2>><<STR_FREE3>> for you!\n",
+      "new": "My house is surrounded\nby plants. It feels like my\nown personal cafe.\nNext time you come to visit,\nI just might make\n<<STR_FREE2>><<STR_FREE3>> for you!\n"
+    },
+    {
+      "group": "mail",
+      "index": 749,
+      "label": "",
+      "original": "No matter how hard things\nget, I just can't dwell on it.\nBe <<STR_FREE2>><<STR_FREE3>>!\nThat's what I say. But if\nanything were to happen to\nyou, I might cry.\n",
+      "new": "No matter how hard things\nget, I just can't dwell on it.\nBe <<STR_FREE2>><<STR_FREE3>>!\nThat's what I say. But if\nanything were to happen to\nyou, I might cry.\n"
+    },
+    {
+      "group": "mail",
+      "index": 750,
+      "label": "",
+      "original": "How are things?\nI picked up this\n<<STR_FREE4>>, but it\nwould just go to waste if I\nkept it, so I'll let you have\nit, <<STR_FREE5>>.\n",
+      "new": "How are things?\nI picked up this\n<<STR_FREE4>>, but it\nwould just go to waste if I\nkept it, so I'll let you have\nit, <<STR_FREE5>>.\n"
+    },
+    {
+      "group": "mail",
+      "index": 751,
+      "label": "",
+      "original": "What's kicking? Say, didn't\nyou say you wanted my\n<<STR_FREE4>>,\n<<STR_FREE5>>? Didn't you? I\nhonestly can't remember, but\nit's yours anyway!\n",
+      "new": "What's kicking? Say, didn't\nyou say you wanted my\n<<STR_FREE4>>,\n<<STR_FREE5>>? Didn't you? I\nhonestly can't remember, but\nit's yours anyway!\n"
+    },
+    {
+      "group": "mail",
+      "index": 752,
+      "label": "",
+      "original": "Hi! How are you? Have I\never told you my dream?\nI want to turn my house\ninto a library! Right now\nit's still <<STR_FREE2>><<STR_FREE3>>,\nthough, <<STR_FREE5>>.\n",
+      "new": "Hi! How are you? Have I\never told you my dream?\nI want to turn my house\ninto a library! Right now\nit's still <<STR_FREE2>><<STR_FREE3>>,\nthough, <<STR_FREE5>>.\n"
+    },
+    {
+      "group": "mail",
+      "index": 753,
+      "label": "",
+      "original": "Someday I wish someone\nwould say to me, \"Biskit,\nyou've really become quite\n<<STR_FREE2>><<STR_FREE3>>.\" So,\nhere! I'm giving you my\n<<STR_FREE4>>.\n",
+      "new": "Someday I wish someone\nwould say to me, \"Biskit,\nyou've really become quite\n<<STR_FREE2>><<STR_FREE3>>.\" So,\nhere! I'm giving you my\n<<STR_FREE4>>.\n"
+    },
+    {
+      "group": "mail",
+      "index": 754,
+      "label": "",
+      "original": "Hi, there! I really hate\nhaving too much stuff in\nmy house. Don't you feel\n<<STR_FREE2>><<STR_FREE3>>\nwhen things are too messy,\n<<STR_FREE5>>?\n",
+      "new": "Hi, there! I really hate\nhaving too much stuff in\nmy house. Don't you feel\n<<STR_FREE2>><<STR_FREE3>>\nwhen things are too messy,\n<<STR_FREE5>>?\n"
+    },
+    {
+      "group": "mail",
+      "index": 755,
+      "label": "",
+      "original": "What kinds of things do\nyou like? I like fossils. A\nlot! It's just so absolutely\n<<STR_FREE2>><<STR_FREE3>> that\nsomething that huge\ncould have ever lived!\n",
+      "new": "What kinds of things do\nyou like? I like fossils. A\nlot! It's just so absolutely\n<<STR_FREE2>><<STR_FREE3>> that\nsomething that huge\ncould have ever lived!\n"
+    },
+    {
+      "group": "mail",
+      "index": 756,
+      "label": "",
+      "original": "Aren't peaches great?\nThey're so <<STR_FREE2>><<STR_FREE3>>,\n<<STR_FREE5>>. I love 'em!\nExcept when they fall\nand hit me on the head...\n\n",
+      "new": "Aren't peaches great?\nThey're so <<STR_FREE2>><<STR_FREE3>>,\n<<STR_FREE5>>. I love 'em!\nExcept when they fall\nand hit me on the head...\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 757,
+      "label": "",
+      "original": "Umm, don't you think I'm\nprettier than I was before?\nI actually changed my\nmakeup, <<STR_FREE5>>.\nDon't I have a much more\n<<STR_FREE2>><<STR_FREE3>> feel?\n",
+      "new": "Umm, don't you think I'm\nprettier than I was before?\nI actually changed my\nmakeup, <<STR_FREE5>>.\nDon't I have a much more\n<<STR_FREE2>><<STR_FREE3>> feel?\n"
+    },
+    {
+      "group": "mail",
+      "index": 758,
+      "label": "",
+      "original": "I want to be the spokesgirl\nfor <<STR_FREE2>><<STR_FREE3>>.\nDon't you think I'm\nperfectly suited for it,\n<<STR_FREE0>>? Don't you,\n<<STR_FREE5>>?\n",
+      "new": "I want to be the spokesgirl\nfor <<STR_FREE2>><<STR_FREE3>>.\nDon't you think I'm\nperfectly suited for it,\n<<STR_FREE0>>? Don't you,\n<<STR_FREE5>>?\n"
+    },
+    {
+      "group": "mail",
+      "index": 759,
+      "label": "",
+      "original": "Were you ever any good at\nsports? Not me! I'm horrible\nat them. But a long time ago,\nI did play a little\n<<STR_FREE2>><<STR_FREE3>>,\n<<STR_FREE5>>.\n",
+      "new": "Were you ever any good at\nsports? Not me! I'm horrible\nat them. But a long time ago,\nI did play a little\n<<STR_FREE2>><<STR_FREE3>>,\n<<STR_FREE5>>.\n"
+    },
+    {
+      "group": "mail",
+      "index": 760,
+      "label": "",
+      "original": "Hi. What's up? Are you\nkeeping in shape?\nI've been pretty\n<<STR_FREE2>><<STR_FREE3>> as of\nlate, <<STR_FREE5>>! Well,\nthat's the news!\n",
+      "new": "Hi. What's up? Are you\nkeeping in shape?\nI've been pretty\n<<STR_FREE2>><<STR_FREE3>> as of\nlate, <<STR_FREE5>>! Well,\nthat's the news!\n"
+    },
+    {
+      "group": "mail",
+      "index": 761,
+      "label": "",
+      "original": "I really like the movie\n<<STR_FREE2>><<STR_FREE3>>,\n<<STR_FREE5>>! I've seen\nit, like, four times already,\nbut I still cry every time\nI watch it.\n",
+      "new": "I really like the movie\n<<STR_FREE2>><<STR_FREE3>>,\n<<STR_FREE5>>! I've seen\nit, like, four times already,\nbut I still cry every time\nI watch it.\n"
+    },
+    {
+      "group": "mail",
+      "index": 762,
+      "label": "",
+      "original": "What's quackin'? Are things\ngood? Things are good for\nme. I guess you could say\nI'm <<STR_FREE2>><<STR_FREE3>>,\n<<STR_FREE5>>! See you soon!\n\n",
+      "new": "What's quackin'? Are things\ngood? Things are good for\nme. I guess you could say\nI'm <<STR_FREE2>><<STR_FREE3>>,\n<<STR_FREE5>>! See you soon!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 763,
+      "label": "",
+      "original": "How are you? I'm having\na great month, <<STR_FREE5>>!\nMy <<STR_FREE2>><<STR_FREE3>> is\nfeeling pretty sore today.\nIt's great! Hey, have a nice\nweek!\n",
+      "new": "How are you? I'm having\na great month, <<STR_FREE5>>!\nMy <<STR_FREE2>><<STR_FREE3>> is\nfeeling pretty sore today.\nIt's great! Hey, have a nice\nweek!\n"
+    },
+    {
+      "group": "mail",
+      "index": 764,
+      "label": "",
+      "original": "Uh, why were you in my\ndream the other night?\nYou were wearing this\n<<STR_FREE2>><<STR_FREE3>> outfit.\nYou looked great,\n<<STR_FREE5>>.\n",
+      "new": "Uh, why were you in my\ndream the other night?\nYou were wearing this\n<<STR_FREE2>><<STR_FREE3>> outfit.\nYou looked great,\n<<STR_FREE5>>.\n"
+    },
+    {
+      "group": "mail",
+      "index": 765,
+      "label": "",
+      "original": "My boyfriend is so\n<<STR_FREE2>><<STR_FREE3>>!\nAre you shocked,\n<<STR_FREE5>>? I guess\nweirdness really catches\nmy fancy. ♥♥♥\n",
+      "new": "My boyfriend is so\n<<STR_FREE2>><<STR_FREE3>>!\nAre you shocked,\n<<STR_FREE5>>? I guess\nweirdness really catches\nmy fancy. ♥♥♥\n"
+    },
+    {
+      "group": "mail",
+      "index": 766,
+      "label": "",
+      "original": "Whenever someone tells\nme \"you look like so-and-\nso,\" I get pretty\n<<STR_FREE2>><<STR_FREE3>>, <<STR_FREE5>>.\nDon't you?\n\n",
+      "new": "Whenever someone tells\nme \"you look like so-and-\nso,\" I get pretty\n<<STR_FREE2>><<STR_FREE3>>, <<STR_FREE5>>.\nDon't you?\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 767,
+      "label": "",
+      "original": "The other day, I picked\nup a <<STR_FREE2>><<STR_FREE3>>,\n<<STR_FREE5>>. It looked pretty\ndelish, but I don't think\nI can eat it. Too bad...\n\n",
+      "new": "The other day, I picked\nup a <<STR_FREE2>><<STR_FREE3>>,\n<<STR_FREE5>>. It looked pretty\ndelish, but I don't think\nI can eat it. Too bad...\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 768,
+      "label": "",
+      "original": "Guess what! All my clothes\nare extra-large,\n<<STR_FREE5>>. Isn't that totally\n<<STR_FREE2>><<STR_FREE3>>?\nIsn't it?\n\n",
+      "new": "Guess what! All my clothes\nare extra-large,\n<<STR_FREE5>>. Isn't that totally\n<<STR_FREE2>><<STR_FREE3>>?\nIsn't it?\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 769,
+      "label": "",
+      "original": "You must tell meーis there\nanything that you're totally\nobsessed with? You know,\nthat you're collecting? I'm\nall about green furniture!\nIt's so <<STR_FREE2>><<STR_FREE3>>!\n",
+      "new": "You must tell meーis there\nanything that you're totally\nobsessed with? You know,\nthat you're collecting? I'm\nall about green furniture!\nIt's so <<STR_FREE2>><<STR_FREE3>>!\n"
+    },
+    {
+      "group": "mail",
+      "index": 770,
+      "label": "",
+      "original": "Don't you think I've been\nunusually <<STR_FREE2>><<STR_FREE3>>\nlately, <<STR_FREE5>>? Well,\nI have. So I want you\nto have my\n<<STR_FREE4>>!\n",
+      "new": "Don't you think I've been\nunusually <<STR_FREE2>><<STR_FREE3>>\nlately, <<STR_FREE5>>? Well,\nI have. So I want you\nto have my\n<<STR_FREE4>>!\n"
+    },
+    {
+      "group": "mail",
+      "index": 771,
+      "label": "",
+      "original": "Don't judge a book by\nits cover, <<STR_FREE0>>!\nOpen your heart!\nStop and look at some\n<<STR_FREE2>><<STR_FREE3>> scenery!\nCan't see any? Too bad!\n",
+      "new": "Don't judge a book by\nits cover, <<STR_FREE0>>!\nOpen your heart!\nStop and look at some\n<<STR_FREE2>><<STR_FREE3>> scenery!\nCan't see any? Too bad!\n"
+    },
+    {
+      "group": "mail",
+      "index": 772,
+      "label": "",
+      "original": "Have you been well?\nI have been magnificent!\nI'm most busy with my\n<<STR_FREE2>><<STR_FREE3>> practice.\nI should like to challenge\nyou to a match!\n",
+      "new": "Have you been well?\nI have been magnificent!\nI'm most busy with my\n<<STR_FREE2>><<STR_FREE3>> practice.\nI should like to challenge\nyou to a match!\n"
+    },
+    {
+      "group": "mail",
+      "index": 773,
+      "label": "",
+      "original": "Did you know I sing\n<<STR_FREE2>><<STR_FREE3>> ballads\nquite often? I'd like it if\nI could sing one to you,\nsometime! I know I'm good!\n\n",
+      "new": "Did you know I sing\n<<STR_FREE2>><<STR_FREE3>> ballads\nquite often? I'd like it if\nI could sing one to you,\nsometime! I know I'm good!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 774,
+      "label": "",
+      "original": "Have you seen my Froggy\nChair? I love seeing the\nlook on my guests' faces\nwhenever they sit in it.\nThey always look so\n<<STR_FREE2>><<STR_FREE3>>!\n",
+      "new": "Have you seen my Froggy\nChair? I love seeing the\nlook on my guests' faces\nwhenever they sit in it.\nThey always look so\n<<STR_FREE2>><<STR_FREE3>>!\n"
+    },
+    {
+      "group": "mail",
+      "index": 775,
+      "label": "",
+      "original": "The other night I ate wild\nmushrooms...in a dream.\nNow I want to eat them so\nbadly, I feel totally\n<<STR_FREE2>><<STR_FREE3>>,\n<<STR_FREE5>>.\n",
+      "new": "The other night I ate wild\nmushrooms...in a dream.\nNow I want to eat them so\nbadly, I feel totally\n<<STR_FREE2>><<STR_FREE3>>,\n<<STR_FREE5>>.\n"
+    },
+    {
+      "group": "mail",
+      "index": 776,
+      "label": "",
+      "original": "Lately, everyone has been\nsaying \"Huck, you seem so\n<<STR_FREE2>><<STR_FREE3>>.\"\nI don't know why though,\n<<STR_FREE5>>...\n\n",
+      "new": "Lately, everyone has been\nsaying \"Huck, you seem so\n<<STR_FREE2>><<STR_FREE3>>.\"\nI don't know why though,\n<<STR_FREE5>>...\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 777,
+      "label": "",
+      "original": "I have never let myself\noff guard for even a\nsecond. Never! Except when\nI am sleeping. Especially\nwhen I'm having a\n<<STR_FREE2>><<STR_FREE3>> dream!\n",
+      "new": "I have never let myself\noff guard for even a\nsecond. Never! Except when\nI am sleeping. Especially\nwhen I'm having a\n<<STR_FREE2>><<STR_FREE3>> dream!\n"
+    },
+    {
+      "group": "mail",
+      "index": 778,
+      "label": "",
+      "original": "I don't really know what\nto write, <<STR_FREE5>>.\nI guess I can say that I\nam <<STR_FREE2>><<STR_FREE3>>!\nGood-bye!\n\n",
+      "new": "I don't really know what\nto write, <<STR_FREE5>>.\nI guess I can say that I\nam <<STR_FREE2>><<STR_FREE3>>!\nGood-bye!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 779,
+      "label": "",
+      "original": "Lately, everyone has told\nme I look like\n<<STR_FREE2>><<STR_FREE3>>!\nIt's kind of embarrassing,\n<<STR_FREE5>>.\n\n",
+      "new": "Lately, everyone has told\nme I look like\n<<STR_FREE2>><<STR_FREE3>>!\nIt's kind of embarrassing,\n<<STR_FREE5>>.\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 780,
+      "label": "",
+      "original": "Don't think I'm weird or\nanything. I'm just always\ntrying to make my house a\nlittle more\n<<STR_FREE2>><<STR_FREE3>>.\nThat's all, <<STR_FREE5>>.\n",
+      "new": "Don't think I'm weird or\nanything. I'm just always\ntrying to make my house a\nlittle more\n<<STR_FREE2>><<STR_FREE3>>.\nThat's all, <<STR_FREE5>>.\n"
+    },
+    {
+      "group": "mail",
+      "index": 781,
+      "label": "",
+      "original": "Hey, do you like soccer?\nI do, <<STR_FREE5>>. It's\nthe coolest. I just wish\nthey'd cut out the\n<<STR_FREE2>><<STR_FREE3>>.\n\n",
+      "new": "Hey, do you like soccer?\nI do, <<STR_FREE5>>. It's\nthe coolest. I just wish\nthey'd cut out the\n<<STR_FREE2>><<STR_FREE3>>.\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 782,
+      "label": "",
+      "original": "Oh, where is my prince,\nand what could he be\ndoing? Whenever I start\nthinking such thoughts, I\nalways start feeling so\n<<STR_FREE2>><<STR_FREE3>>, <<STR_FREE5>>.\n",
+      "new": "Oh, where is my prince,\nand what could he be\ndoing? Whenever I start\nthinking such thoughts, I\nalways start feeling so\n<<STR_FREE2>><<STR_FREE3>>, <<STR_FREE5>>.\n"
+    },
+    {
+      "group": "mail",
+      "index": 783,
+      "label": "",
+      "original": "Lately I've been told I'm\nvery <<STR_FREE2>><<STR_FREE3>>.\nI've heard it a lot,\n<<STR_FREE5>>. But that's a\ncompliment, right,\n<<STR_FREE0>>? Right?!\n",
+      "new": "Lately I've been told I'm\nvery <<STR_FREE2>><<STR_FREE3>>.\nI've heard it a lot,\n<<STR_FREE5>>. But that's a\ncompliment, right,\n<<STR_FREE0>>? Right?!\n"
+    },
+    {
+      "group": "mail",
+      "index": 784,
+      "label": "",
+      "original": "Rock on! Whenever anyone\nasks me about music, I say\nrock on! Yeah! I couldn't\ncare less about that crazy\n<<STR_FREE2>><<STR_FREE3>> music!\nYou got me? Yeah!\n",
+      "new": "Rock on! Whenever anyone\nasks me about music, I say\nrock on! Yeah! I couldn't\ncare less about that crazy\n<<STR_FREE2>><<STR_FREE3>> music!\nYou got me? Yeah!\n"
+    },
+    {
+      "group": "mail",
+      "index": 785,
+      "label": "",
+      "original": "For some strange reason,\na lot of <<STR_FREE4>>\nhave been gathering\naround me lately. Do you\nsuppose our fates are tied\ntogether, <<STR_FREE5>>?\n",
+      "new": "For some strange reason,\na lot of <<STR_FREE4>>\nhave been gathering\naround me lately. Do you\nsuppose our fates are tied\ntogether, <<STR_FREE5>>?\n"
+    },
+    {
+      "group": "mail",
+      "index": 786,
+      "label": "",
+      "original": "Have you been studying at\nall, lately? You have to be\nsure you complete your\nstudies! But once you do,\nit's OK to eat some delicious\n<<STR_FREE2>><<STR_FREE3>>, <<STR_FREE5>>.\n",
+      "new": "Have you been studying at\nall, lately? You have to be\nsure you complete your\nstudies! But once you do,\nit's OK to eat some delicious\n<<STR_FREE2>><<STR_FREE3>>, <<STR_FREE5>>.\n"
+    },
+    {
+      "group": "mail",
+      "index": 787,
+      "label": "",
+      "original": "Hey! Don't be such a slacker!\nGet out and get that body\nmoving! Move to that\n<<STR_FREE2>><<STR_FREE3>> rhythm\nand dance all night!\nFeel the fever!\n",
+      "new": "Hey! Don't be such a slacker!\nGet out and get that body\nmoving! Move to that\n<<STR_FREE2>><<STR_FREE3>> rhythm\nand dance all night!\nFeel the fever!\n"
+    },
+    {
+      "group": "mail",
+      "index": 788,
+      "label": "",
+      "original": "People think they're so\nfunny . I've been asked\n\"Do you want a banana?\"\nat least 20,000 times! The\nanswer is NO! I like\n<<STR_FREE2>><<STR_FREE3>>, <<STR_FREE5>>!\n",
+      "new": "People think they're so\nfunny . I've been asked\n\"Do you want a banana?\"\nat least 20,000 times! The\nanswer is NO! I like\n<<STR_FREE2>><<STR_FREE3>>, <<STR_FREE5>>!\n"
+    },
+    {
+      "group": "mail",
+      "index": 789,
+      "label": "",
+      "original": "It never seems to stop.\nI am totally cramped up\nfrom <<STR_FREE2>><<STR_FREE3>>,\n<<STR_FREE5>>. If only it\nreally would last forever.\n\n",
+      "new": "It never seems to stop.\nI am totally cramped up\nfrom <<STR_FREE2>><<STR_FREE3>>,\n<<STR_FREE5>>. If only it\nreally would last forever.\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 790,
+      "label": "",
+      "original": "I love exercising so much,\nI just can't help myself.\nEvery day, I could go all\nout in <<STR_FREE2>><<STR_FREE3>>\nand feel totally fine! I\nnever cramp up!\n",
+      "new": "I love exercising so much,\nI just can't help myself.\nEvery day, I could go all\nout in <<STR_FREE2>><<STR_FREE3>>\nand feel totally fine! I\nnever cramp up!\n"
+    },
+    {
+      "group": "mail",
+      "index": 791,
+      "label": "",
+      "original": "Rollo is a really cool name,\nbut it's so weird...\nI forget it sometimes. Maybe\nit would have been better if\nI had been named something\nlike <<STR_FREE2>><<STR_FREE3>>...\n",
+      "new": "Rollo is a really cool name,\nbut it's so weird...\nI forget it sometimes. Maybe\nit would have been better if\nI had been named something\nlike <<STR_FREE2>><<STR_FREE3>>...\n"
+    },
+    {
+      "group": "mail",
+      "index": 792,
+      "label": "",
+      "original": "Isn't <<STR_FREE2>><<STR_FREE3>>\ntotally delicious? I'm on this\nspecial diet, so I get to eat\nit every day, <<STR_FREE5>>!\nMaybe you should try it!\nThe diet, I mean.\n",
+      "new": "Isn't <<STR_FREE2>><<STR_FREE3>>\ntotally delicious? I'm on this\nspecial diet, so I get to eat\nit every day, <<STR_FREE5>>!\nMaybe you should try it!\nThe diet, I mean.\n"
+    },
+    {
+      "group": "mail",
+      "index": 793,
+      "label": "",
+      "original": "Hello. I just want you to\nknow that I'm working on\nbeing a little more casual.\nI can't always be so\n<<STR_FREE2>><<STR_FREE3>>. That\nwould be embarrassing.\n",
+      "new": "Hello. I just want you to\nknow that I'm working on\nbeing a little more casual.\nI can't always be so\n<<STR_FREE2>><<STR_FREE3>>. That\nwould be embarrassing.\n"
+    },
+    {
+      "group": "mail",
+      "index": 794,
+      "label": "",
+      "original": "Hi. How are you? I'm good.\nOne could even say I'm\n<<STR_FREE2>><<STR_FREE3>>.\nYup. That's the truth.\nSee you later, <<STR_FREE5>>.\n\n",
+      "new": "Hi. How are you? I'm good.\nOne could even say I'm\n<<STR_FREE2>><<STR_FREE3>>.\nYup. That's the truth.\nSee you later, <<STR_FREE5>>.\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 795,
+      "label": "",
+      "original": "No matter what you may\nthink, I'm very fast! If we\nwere in a <<STR_FREE2>><<STR_FREE3>>,\nthere's no way I'd lose!\nSo? How does that make you\nfeel about me?\n",
+      "new": "No matter what you may\nthink, I'm very fast! If we\nwere in a <<STR_FREE2>><<STR_FREE3>>,\nthere's no way I'd lose!\nSo? How does that make you\nfeel about me?\n"
+    },
+    {
+      "group": "mail",
+      "index": 796,
+      "label": "",
+      "original": "Howdy, <<STR_FREE0>>.\nPeople often mistake me for\nsomeone who is hard to\nplease. But actually, I think\nI'm much more of a\n<<STR_FREE2>><<STR_FREE3>>, <<STR_FREE5>>.\n",
+      "new": "Howdy, <<STR_FREE0>>.\nPeople often mistake me for\nsomeone who is hard to\nplease. But actually, I think\nI'm much more of a\n<<STR_FREE2>><<STR_FREE3>>, <<STR_FREE5>>.\n"
+    },
+    {
+      "group": "mail",
+      "index": 797,
+      "label": "",
+      "original": "I've been thinking, and I've\ncome to the conclusion that\n<<STR_FREE0>> is a good\nname. It seems very\n<<STR_FREE2>><<STR_FREE3>>. I had to\ntell you that, <<STR_FREE5>>.\n",
+      "new": "I've been thinking, and I've\ncome to the conclusion that\n<<STR_FREE0>> is a good\nname. It seems very\n<<STR_FREE2>><<STR_FREE3>>. I had to\ntell you that, <<STR_FREE5>>.\n"
+    },
+    {
+      "group": "mail",
+      "index": 798,
+      "label": "",
+      "original": "Hello. How have you been?\nI am wonderful, of course!\nI'm spending my days\n<<STR_FREE2>><<STR_FREE3>>.\nToodles, <<STR_FREE5>>!\n\n",
+      "new": "Hello. How have you been?\nI am wonderful, of course!\nI'm spending my days\n<<STR_FREE2>><<STR_FREE3>>.\nToodles, <<STR_FREE5>>!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 799,
+      "label": "",
+      "original": "Everyone says my room looks\nlike a little kid's room, but\nkids' rooms are full of\ndreams! Don't you think?\nIt makes me feel all\n<<STR_FREE2>><<STR_FREE3>>, <<STR_FREE5>>.\n",
+      "new": "Everyone says my room looks\nlike a little kid's room, but\nkids' rooms are full of\ndreams! Don't you think?\nIt makes me feel all\n<<STR_FREE2>><<STR_FREE3>>, <<STR_FREE5>>.\n"
+    },
+    {
+      "group": "mail",
+      "index": 800,
+      "label": "",
+      "original": "Whoa, <<STR_FREE5>>! I've\nbeen so obsessed with\n<<STR_FREE2>><<STR_FREE3>>\nlately. Maybe we can have a\nlittle one-on-one match\none of these days!\n",
+      "new": "Whoa, <<STR_FREE5>>! I've\nbeen so obsessed with\n<<STR_FREE2>><<STR_FREE3>>\nlately. Maybe we can have a\nlittle one-on-one match\none of these days!\n"
+    },
+    {
+      "group": "mail",
+      "index": 801,
+      "label": "",
+      "original": "Hello! How are things?\nThings are A-OK with me!\nI've been spending all my\ntime doing a little\n<<STR_FREE2>><<STR_FREE3>> lately.\nSee you soon, <<STR_FREE5>>!\n",
+      "new": "Hello! How are things?\nThings are A-OK with me!\nI've been spending all my\ntime doing a little\n<<STR_FREE2>><<STR_FREE3>> lately.\nSee you soon, <<STR_FREE5>>!\n"
+    },
+    {
+      "group": "mail",
+      "index": 802,
+      "label": "",
+      "original": "I have a question...\nHave you ever done any\n<<STR_FREE2>><<STR_FREE3>>, <<STR_FREE5>>?\nIt's very fun! Let me tell you!\nThat's all I've been doing\nlately, <<STR_FREE5>>.\n",
+      "new": "I have a question...\nHave you ever done any\n<<STR_FREE2>><<STR_FREE3>>, <<STR_FREE5>>?\nIt's very fun! Let me tell you!\nThat's all I've been doing\nlately, <<STR_FREE5>>.\n"
+    },
+    {
+      "group": "mail",
+      "index": 803,
+      "label": "",
+      "original": "Isn't <<STR_FREE2>><<STR_FREE3>>\ntotally fun? How do you\neven describe it? It's like...\nTotally the \"in\" thing,\n<<STR_FREE5>>!\n\n",
+      "new": "Isn't <<STR_FREE2>><<STR_FREE3>>\ntotally fun? How do you\neven describe it? It's like...\nTotally the \"in\" thing,\n<<STR_FREE5>>!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 804,
+      "label": "",
+      "original": "Can you tell me what your\nsecret to interior design is?\nMy secret is not to let a\nroom feel too lived in, but\nrather to give it a very\n<<STR_FREE2>><<STR_FREE3>> feel!\n",
+      "new": "Can you tell me what your\nsecret to interior design is?\nMy secret is not to let a\nroom feel too lived in, but\nrather to give it a very\n<<STR_FREE2>><<STR_FREE3>> feel!\n"
+    },
+    {
+      "group": "mail",
+      "index": 805,
+      "label": "",
+      "original": "Tell me, my friend...\nDo you read books? My\ncurrent recommendation\nis <<STR_FREE2>><<STR_FREE3>>.\nOnce you start reading it,\nyou just can't stop!\n",
+      "new": "Tell me, my friend...\nDo you read books? My\ncurrent recommendation\nis <<STR_FREE2>><<STR_FREE3>>.\nOnce you start reading it,\nyou just can't stop!\n"
+    },
+    {
+      "group": "mail",
+      "index": 806,
+      "label": "",
+      "original": "HI! How are things,\n<<STR_FREE5>>? I'm just\nsplendid, as usual.\nTo be more precise, I'm\nso very <<STR_FREE2>><<STR_FREE3>>,\n<<STR_FREE5>>. So VERY!\n",
+      "new": "HI! How are things,\n<<STR_FREE5>>? I'm just\nsplendid, as usual.\nTo be more precise, I'm\nso very <<STR_FREE2>><<STR_FREE3>>,\n<<STR_FREE5>>. So VERY!\n"
+    },
+    {
+      "group": "mail",
+      "index": 807,
+      "label": "",
+      "original": "G'day, <<STR_FREE0>>!\nHave you ever tried\n<<STR_FREE2>><<STR_FREE3>>? It's\na total blast! That's all\nI've been doing. I'm totally\naddicted, <<STR_FREE5>>!\n",
+      "new": "G'day, <<STR_FREE0>>!\nHave you ever tried\n<<STR_FREE2>><<STR_FREE3>>? It's\na total blast! That's all\nI've been doing. I'm totally\naddicted, <<STR_FREE5>>!\n"
+    },
+    {
+      "group": "mail",
+      "index": 808,
+      "label": "",
+      "original": "You better not be making\nfun of me 'cause I live in\na house with a straw mat!\nIt's like <<STR_FREE2>><<STR_FREE3>>;\ntotally convenient,\n<<STR_FREE5>>!\n",
+      "new": "You better not be making\nfun of me 'cause I live in\na house with a straw mat!\nIt's like <<STR_FREE2>><<STR_FREE3>>;\ntotally convenient,\n<<STR_FREE5>>!\n"
+    },
+    {
+      "group": "mail",
+      "index": 809,
+      "label": "",
+      "original": "How are you, <<STR_FREE5>>?\nI recently dreamt that I\nbecame a <<STR_FREE2>><<STR_FREE3>>,\n<<STR_FREE5>>. Cool, eh?\nSee you soon!\n\n",
+      "new": "How are you, <<STR_FREE5>>?\nI recently dreamt that I\nbecame a <<STR_FREE2>><<STR_FREE3>>,\n<<STR_FREE5>>. Cool, eh?\nSee you soon!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 810,
+      "label": "",
+      "original": "Do you read much? I don't.\nAt least not usually. But\nwhen I do, I usually read\n<<STR_FREE2>><<STR_FREE3>>. Harder\nstuff makes my head\nhurt!\n",
+      "new": "Do you read much? I don't.\nAt least not usually. But\nwhen I do, I usually read\n<<STR_FREE2>><<STR_FREE3>>. Harder\nstuff makes my head\nhurt!\n"
+    },
+    {
+      "group": "mail",
+      "index": 811,
+      "label": "",
+      "original": "I have news! I've actually\nstarted <<STR_FREE2>><<STR_FREE3>>,\n<<STR_FREE5>>. I'm still\npretty awful at it, but I hope\nwe can do it together\nsometime, <<STR_FREE0>>!\n",
+      "new": "I have news! I've actually\nstarted <<STR_FREE2>><<STR_FREE3>>,\n<<STR_FREE5>>. I'm still\npretty awful at it, but I hope\nwe can do it together\nsometime, <<STR_FREE0>>!\n"
+    },
+    {
+      "group": "mail",
+      "index": 812,
+      "label": "",
+      "original": "Sundays really are for\nrelaxing, aren't they,\n<<STR_FREE5>>? That being the\ncase, you'll probably need\nthis <<STR_FREE4>>.\n\n",
+      "new": "Sundays really are for\nrelaxing, aren't they,\n<<STR_FREE5>>? That being the\ncase, you'll probably need\nthis <<STR_FREE4>>.\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 813,
+      "label": "",
+      "original": "I've been told that I'm\n<<STR_FREE2>><<STR_FREE3>> a lot\nlately, <<STR_FREE5>>. Do you\nthink it's because I'm\nalways out training,\n<<STR_FREE5>>?\n",
+      "new": "I've been told that I'm\n<<STR_FREE2>><<STR_FREE3>> a lot\nlately, <<STR_FREE5>>. Do you\nthink it's because I'm\nalways out training,\n<<STR_FREE5>>?\n"
+    },
+    {
+      "group": "mail",
+      "index": 814,
+      "label": "",
+      "original": "What's up? I know exercise\nand practice are important\nand all, but once in a while\nyou need to sit back and\nenjoy a little\n<<STR_FREE2>><<STR_FREE3>>, <<STR_FREE5>>.\n",
+      "new": "What's up? I know exercise\nand practice are important\nand all, but once in a while\nyou need to sit back and\nenjoy a little\n<<STR_FREE2>><<STR_FREE3>>, <<STR_FREE5>>.\n"
+    },
+    {
+      "group": "mail",
+      "index": 815,
+      "label": "",
+      "original": "You good, <<STR_FREE5>>?\nWho, me? I'm incredible!\nYou could even say I'm\n<<STR_FREE2>><<STR_FREE3>>!\n\n\n",
+      "new": "You good, <<STR_FREE5>>?\nWho, me? I'm incredible!\nYou could even say I'm\n<<STR_FREE2>><<STR_FREE3>>!\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 816,
+      "label": "",
+      "original": "I am so caught up in\n<<STR_FREE2>><<STR_FREE3>> right\nnow, <<STR_FREE5>>! It's\nsurprisingly fun! What do you\nsay? Are you willing to\ngive it a try?\n",
+      "new": "I am so caught up in\n<<STR_FREE2>><<STR_FREE3>> right\nnow, <<STR_FREE5>>! It's\nsurprisingly fun! What do you\nsay? Are you willing to\ngive it a try?\n"
+    },
+    {
+      "group": "mail",
+      "index": 817,
+      "label": "",
+      "original": "Hello, there. I'm not poor.\nI'm not. And you need to know\nthat. I just enjoy a lifestyle\nthat has a little\n<<STR_FREE2>><<STR_FREE3>>. You\nknow...atmosphere!\n",
+      "new": "Hello, there. I'm not poor.\nI'm not. And you need to know\nthat. I just enjoy a lifestyle\nthat has a little\n<<STR_FREE2>><<STR_FREE3>>. You\nknow...atmosphere!\n"
+    },
+    {
+      "group": "mail",
+      "index": 818,
+      "label": "",
+      "original": "I've given it some thought,\nand I've decided that\n<<STR_FREE2>><<STR_FREE3>> really is\nbetter cold...\n\n\n",
+      "new": "I've given it some thought,\nand I've decided that\n<<STR_FREE2>><<STR_FREE3>> really is\nbetter cold...\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 819,
+      "label": "",
+      "original": "What kind of music do you\nlisten to? I'm really into\n<<STR_FREE2>><<STR_FREE3>>. It's all I\nlisten to now, <<STR_FREE5>>.\nI bet you weren't expecting\nthat! Neither was I! ♥\n",
+      "new": "What kind of music do you\nlisten to? I'm really into\n<<STR_FREE2>><<STR_FREE3>>. It's all I\nlisten to now, <<STR_FREE5>>.\nI bet you weren't expecting\nthat! Neither was I! ♥\n"
+    },
+    {
+      "group": "mail",
+      "index": 820,
+      "label": "",
+      "original": "You know how they say you\nshouldn't judge someone\nbased on their appearance?\nI think they say that because\nof me. I'm as honest as a\n<<STR_FREE2>><<STR_FREE3>>.\n",
+      "new": "You know how they say you\nshouldn't judge someone\nbased on their appearance?\nI think they say that because\nof me. I'm as honest as a\n<<STR_FREE2>><<STR_FREE3>>.\n"
+    },
+    {
+      "group": "mail",
+      "index": 821,
+      "label": "",
+      "original": "Hey there, happy you! I bet\neven someone as happy as\nyou feels low once in a\nwhile. Whenever you do, just\neat some <<STR_FREE2>><<STR_FREE3>>.\nThat should pick you up!\n",
+      "new": "Hey there, happy you! I bet\neven someone as happy as\nyou feels low once in a\nwhile. Whenever you do, just\neat some <<STR_FREE2>><<STR_FREE3>>.\nThat should pick you up!\n"
+    },
+    {
+      "group": "mail",
+      "index": 822,
+      "label": "",
+      "original": "Every once in a while, I\nget cravings for...very\nstrange foods. Like\n<<STR_FREE2>><<STR_FREE3>>... You\nsay it's not that strange?\nWhy didn't you think of it?\n",
+      "new": "Every once in a while, I\nget cravings for...very\nstrange foods. Like\n<<STR_FREE2>><<STR_FREE3>>... You\nsay it's not that strange?\nWhy didn't you think of it?\n"
+    },
+    {
+      "group": "mail",
+      "index": 823,
+      "label": "",
+      "original": "Where are you? I can tell\nyou where I've been! I've\nbeen making sweets!\nYesterday I tried making\n<<STR_FREE2>><<STR_FREE3>>.\nIt wasn't so hot.\n",
+      "new": "Where are you? I can tell\nyou where I've been! I've\nbeen making sweets!\nYesterday I tried making\n<<STR_FREE2>><<STR_FREE3>>.\nIt wasn't so hot.\n"
+    },
+    {
+      "group": "mail",
+      "index": 824,
+      "label": "",
+      "original": "No! You must not! You\ncannot! Do not eat any\ncreatures of the sea!\nEat <<STR_FREE2>><<STR_FREE3>>\ninstead, <<STR_FREE5>>!\n\n",
+      "new": "No! You must not! You\ncannot! Do not eat any\ncreatures of the sea!\nEat <<STR_FREE2>><<STR_FREE3>>\ninstead, <<STR_FREE5>>!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 825,
+      "label": "",
+      "original": "Have you ever been in my\nhouse? I tried to give it a\ndesert feel, but I couldn't\nfind any matching furniture,\nso it turned out kind of\n<<STR_FREE2>><<STR_FREE3>>.\n",
+      "new": "Have you ever been in my\nhouse? I tried to give it a\ndesert feel, but I couldn't\nfind any matching furniture,\nso it turned out kind of\n<<STR_FREE2>><<STR_FREE3>>.\n"
+    },
+    {
+      "group": "mail",
+      "index": 826,
+      "label": "",
+      "original": "What's going 'round? I tell\nyou, this year, I'm definitely\ngoing to do some\n<<STR_FREE2>><<STR_FREE3>>, <<STR_FREE5>>!\nJust you wait!\n\n",
+      "new": "What's going 'round? I tell\nyou, this year, I'm definitely\ngoing to do some\n<<STR_FREE2>><<STR_FREE3>>, <<STR_FREE5>>!\nJust you wait!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 827,
+      "label": "",
+      "original": "I'm pretty bored these days,\nso I'm thinking of starting\n<<STR_FREE2>><<STR_FREE3>>, <<STR_FREE5>>.\nWould you like to join me,\n<<STR_FREE0>>? Are you\neven capable of it?\n",
+      "new": "I'm pretty bored these days,\nso I'm thinking of starting\n<<STR_FREE2>><<STR_FREE3>>, <<STR_FREE5>>.\nWould you like to join me,\n<<STR_FREE0>>? Are you\neven capable of it?\n"
+    },
+    {
+      "group": "mail",
+      "index": 828,
+      "label": "",
+      "original": "How are you? I have some\nadvice for you. Don't dress\nlike too much of a dolt,\n<<STR_FREE5>>. Look into being\nmore <<STR_FREE2>><<STR_FREE3>>!\nGot that, <<STR_FREE5>>?\n",
+      "new": "How are you? I have some\nadvice for you. Don't dress\nlike too much of a dolt,\n<<STR_FREE5>>. Look into being\nmore <<STR_FREE2>><<STR_FREE3>>!\nGot that, <<STR_FREE5>>?\n"
+    },
+    {
+      "group": "mail",
+      "index": 829,
+      "label": "",
+      "original": "Despite looking the way I\ndo, I can't even fly. I'm so\njealous of Pete. You know,\nthe postman! It must be so\n<<STR_FREE2>><<STR_FREE3>> to soar\nthrough the skies...\n",
+      "new": "Despite looking the way I\ndo, I can't even fly. I'm so\njealous of Pete. You know,\nthe postman! It must be so\n<<STR_FREE2>><<STR_FREE3>> to soar\nthrough the skies...\n"
+    },
+    {
+      "group": "mail",
+      "index": 830,
+      "label": "",
+      "original": "What's new? I've been busy\nwith <<STR_FREE2>><<STR_FREE3>>\nlately. I can't help myself!\nYou should try it too!\nIt's very relaxing,\n<<STR_FREE5>>.\n",
+      "new": "What's new? I've been busy\nwith <<STR_FREE2>><<STR_FREE3>>\nlately. I can't help myself!\nYou should try it too!\nIt's very relaxing,\n<<STR_FREE5>>.\n"
+    },
+    {
+      "group": "mail",
+      "index": 831,
+      "label": "",
+      "original": "How are you doing? I am at\nmy peak! The peak of\nperfection! And thanks to\nmy regular workouts, my\n<<STR_FREE2>><<STR_FREE3>> is\ncompletely cramped up!\n",
+      "new": "How are you doing? I am at\nmy peak! The peak of\nperfection! And thanks to\nmy regular workouts, my\n<<STR_FREE2>><<STR_FREE3>> is\ncompletely cramped up!\n"
+    },
+    {
+      "group": "mail",
+      "index": 832,
+      "label": "",
+      "original": "I'm a girl. And don't you\nforget it, <<STR_FREE5>>.\nMaybe I'll dress up like a\nprincess and listen to\n<<STR_FREE2>><<STR_FREE3>> music,\n<<STR_FREE5>>.\n",
+      "new": "I'm a girl. And don't you\nforget it, <<STR_FREE5>>.\nMaybe I'll dress up like a\nprincess and listen to\n<<STR_FREE2>><<STR_FREE3>> music,\n<<STR_FREE5>>.\n"
+    },
+    {
+      "group": "mail",
+      "index": 833,
+      "label": "",
+      "original": "Hey, there! Until we have\nourselves a little\n<<STR_FREE2>><<STR_FREE3>> competition,\nI'll need you to hang on to\nthis <<STR_FREE4>>\nfor me, <<STR_FREE5>>!\n",
+      "new": "Hey, there! Until we have\nourselves a little\n<<STR_FREE2>><<STR_FREE3>> competition,\nI'll need you to hang on to\nthis <<STR_FREE4>>\nfor me, <<STR_FREE5>>!\n"
+    },
+    {
+      "group": "mail",
+      "index": 834,
+      "label": "",
+      "original": "Greetings! I have been\nobsessed with\n<<STR_FREE2>><<STR_FREE3>> to the\npoint that I can't stop\nthinking about it. You\nshould try it, too!\n",
+      "new": "Greetings! I have been\nobsessed with\n<<STR_FREE2>><<STR_FREE3>> to the\npoint that I can't stop\nthinking about it. You\nshould try it, too!\n"
+    },
+    {
+      "group": "mail",
+      "index": 835,
+      "label": "",
+      "original": "I have a problem. I always\nact so childish around\npeople. I'd like to be more\n<<STR_FREE2>><<STR_FREE3>>, but\nit just never works out\nthat way, <<STR_FREE5>>.\n",
+      "new": "I have a problem. I always\nact so childish around\npeople. I'd like to be more\n<<STR_FREE2>><<STR_FREE3>>, but\nit just never works out\nthat way, <<STR_FREE5>>.\n"
+    },
+    {
+      "group": "mail",
+      "index": 836,
+      "label": "",
+      "original": "Look, the reason my eyes\nare red is because I like\ngazing at the setting sun.\nIt's not a lack of sleep. It's\n<<STR_FREE2>><<STR_FREE3>>, and it\nsets my soul at ease!\n",
+      "new": "Look, the reason my eyes\nare red is because I like\ngazing at the setting sun.\nIt's not a lack of sleep. It's\n<<STR_FREE2>><<STR_FREE3>>, and it\nsets my soul at ease!\n"
+    },
+    {
+      "group": "mail",
+      "index": 837,
+      "label": "",
+      "original": "Hey! How have you been?\nChillin'? You know I've\nbeen chillin'! Actually, I've\nbeen doing a lot of\n<<STR_FREE2>><<STR_FREE3>>. But I'd\nreally like to eat a peach!\n",
+      "new": "Hey! How have you been?\nChillin'? You know I've\nbeen chillin'! Actually, I've\nbeen doing a lot of\n<<STR_FREE2>><<STR_FREE3>>. But I'd\nreally like to eat a peach!\n"
+    },
+    {
+      "group": "mail",
+      "index": 838,
+      "label": "",
+      "original": "Everyone tells me I'm so\n<<STR_FREE2>><<STR_FREE3>>, <<STR_FREE5>>.\nIs that a compliment?\n\n\n\n",
+      "new": "Everyone tells me I'm so\n<<STR_FREE2>><<STR_FREE3>>, <<STR_FREE5>>.\nIs that a compliment?\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 839,
+      "label": "",
+      "original": "Hey, how are you? Ultra-fine,\nno doubt! I've been really\nbusy with <<STR_FREE2>><<STR_FREE3>>\nlately. You should give it a\ntry too. It's way fun! That's\nwhat all the girls say!\n",
+      "new": "Hey, how are you? Ultra-fine,\nno doubt! I've been really\nbusy with <<STR_FREE2>><<STR_FREE3>>\nlately. You should give it a\ntry too. It's way fun! That's\nwhat all the girls say!\n"
+    },
+    {
+      "group": "mail",
+      "index": 840,
+      "label": "",
+      "original": "Hi, there, <<STR_FREE5>>.\nDo I seem put-offish at\nfirst? Because I'm actually\nmore <<STR_FREE2>><<STR_FREE3>>.\nWell, whatever. It's not\nlike I care!\n",
+      "new": "Hi, there, <<STR_FREE5>>.\nDo I seem put-offish at\nfirst? Because I'm actually\nmore <<STR_FREE2>><<STR_FREE3>>.\nWell, whatever. It's not\nlike I care!\n"
+    },
+    {
+      "group": "mail",
+      "index": 841,
+      "label": "",
+      "original": "Yo! What's up? I want to face\noff against you in a\n<<STR_FREE2>><<STR_FREE3>> match!\nUntil then, take this\n<<STR_FREE4>>. Just\ndon't ask why, <<STR_FREE5>>!\n",
+      "new": "Yo! What's up? I want to face\noff against you in a\n<<STR_FREE2>><<STR_FREE3>> match!\nUntil then, take this\n<<STR_FREE4>>. Just\ndon't ask why, <<STR_FREE5>>!\n"
+    },
+    {
+      "group": "mail",
+      "index": 842,
+      "label": "",
+      "original": "Someday, I want to be\n<<STR_FREE2>><<STR_FREE3>>, so I can\nhear you say \"I'm a huge\nTruffles fan! ♥\"\n\n\n",
+      "new": "Someday, I want to be\n<<STR_FREE2>><<STR_FREE3>>, so I can\nhear you say \"I'm a huge\nTruffles fan! ♥\"\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 843,
+      "label": "",
+      "original": "Umm, I want to eat to\nsome <<STR_FREE2>><<STR_FREE3>>.\nJust so you know.\n\n\n\n",
+      "new": "Umm, I want to eat to\nsome <<STR_FREE2>><<STR_FREE3>>.\nJust so you know.\n\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 844,
+      "label": "",
+      "original": "The other day, I went\nto your place and ate\n<<STR_FREE2>><<STR_FREE3>>. It was\njust a dream, but thanks\nanyway. Here, take this\n<<STR_FREE4>>!\n",
+      "new": "The other day, I went\nto your place and ate\n<<STR_FREE2>><<STR_FREE3>>. It was\njust a dream, but thanks\nanyway. Here, take this\n<<STR_FREE4>>!\n"
+    },
+    {
+      "group": "mail",
+      "index": 845,
+      "label": "",
+      "original": "You thought you had a\nlosing ticket here, right?\nSorry! It's a winner! It must\nfeel <<STR_FREE2>><<STR_FREE3>> to\nget a letter from me!\n\n",
+      "new": "You thought you had a\nlosing ticket here, right?\nSorry! It's a winner! It must\nfeel <<STR_FREE2>><<STR_FREE3>> to\nget a letter from me!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 846,
+      "label": "",
+      "original": "I have no interest in\nanything cheap. I only go\nin for the real thing.\nAnyway, let's listen to\nsome <<STR_FREE2>><<STR_FREE3>> and\neat instant noodles!\n",
+      "new": "I have no interest in\nanything cheap. I only go\nin for the real thing.\nAnyway, let's listen to\nsome <<STR_FREE2>><<STR_FREE3>> and\neat instant noodles!\n"
+    },
+    {
+      "group": "mail",
+      "index": 847,
+      "label": "",
+      "original": "How are you? Well, that's how\nit goes sometimes.\nI'll always think of you as\n<<STR_FREE2>><<STR_FREE3>>!\n\n\n",
+      "new": "How are you? Well, that's how\nit goes sometimes.\nI'll always think of you as\n<<STR_FREE2>><<STR_FREE3>>!\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 848,
+      "label": "",
+      "original": "Hello. Do you like\ntraditional things? I do.\nVery much so. They make me\nfeel so <<STR_FREE2>><<STR_FREE3>>.\nThey're quite relaxing,\n<<STR_FREE5>>.\n",
+      "new": "Hello. Do you like\ntraditional things? I do.\nVery much so. They make me\nfeel so <<STR_FREE2>><<STR_FREE3>>.\nThey're quite relaxing,\n<<STR_FREE5>>.\n"
+    },
+    {
+      "group": "mail",
+      "index": 849,
+      "label": "",
+      "original": "I'm just gonna come right\nout and say this. My name\nmay be Cobb, but I'm no\n<<STR_FREE2>><<STR_FREE3>>! No siree!\nNot at all. You remember\nthat, you hear, <<STR_FREE0>>?\n",
+      "new": "I'm just gonna come right\nout and say this. My name\nmay be Cobb, but I'm no\n<<STR_FREE2>><<STR_FREE3>>! No siree!\nNot at all. You remember\nthat, you hear, <<STR_FREE0>>?\n"
+    },
+    {
+      "group": "mail",
+      "index": 850,
+      "label": "",
+      "original": "The world is complicated.\nJust 'cause someone looks\nmean doesn't make 'em bad.\nAnd polite language doesn't\nmake someone good. So don't\nbe <<STR_FREE2>><<STR_FREE3>>!\n",
+      "new": "The world is complicated.\nJust 'cause someone looks\nmean doesn't make 'em bad.\nAnd polite language doesn't\nmake someone good. So don't\nbe <<STR_FREE2>><<STR_FREE3>>!\n"
+    },
+    {
+      "group": "mail",
+      "index": 851,
+      "label": "",
+      "original": "Oh, guess what! I went to\n<<STR_FREE2>><<STR_FREE3>> the\nother day, <<STR_FREE5>>!\nI just wish you could\nhave come with me.\n😃😃😃\n",
+      "new": "Oh, guess what! I went to\n<<STR_FREE2>><<STR_FREE3>> the\nother day, <<STR_FREE5>>!\nI just wish you could\nhave come with me.\n😃😃😃\n"
+    },
+    {
+      "group": "mail",
+      "index": 852,
+      "label": "",
+      "original": "What's up? You're quite the\n<<STR_FREE2>><<STR_FREE3>>, aren't\nyou, <<STR_FREE5>>?\nWe're like peas in a pod!\nThat's all for now!\n\n",
+      "new": "What's up? You're quite the\n<<STR_FREE2>><<STR_FREE3>>, aren't\nyou, <<STR_FREE5>>?\nWe're like peas in a pod!\nThat's all for now!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 853,
+      "label": "",
+      "original": "How have you been?\nYou really ought to try\nsome <<STR_FREE2>><<STR_FREE3>>\nnow and again! Or is it\njust too much trouble,\n<<STR_FREE5>>?\n",
+      "new": "How have you been?\nYou really ought to try\nsome <<STR_FREE2>><<STR_FREE3>>\nnow and again! Or is it\njust too much trouble,\n<<STR_FREE5>>?\n"
+    },
+    {
+      "group": "mail",
+      "index": 854,
+      "label": "",
+      "original": "Everyone says they can never\ngauge my feelings from the\nlook on my face, but I think\nmy face is very expressive!\nIn fact, right now I feel\n<<STR_FREE2>><<STR_FREE3>>!\n",
+      "new": "Everyone says they can never\ngauge my feelings from the\nlook on my face, but I think\nmy face is very expressive!\nIn fact, right now I feel\n<<STR_FREE2>><<STR_FREE3>>!\n"
+    },
+    {
+      "group": "mail",
+      "index": 855,
+      "label": "",
+      "original": "It doesn't take much for\nme to feel lonely,\n<<STR_FREE5>>. That's why\nI've been so\n<<STR_FREE2>><<STR_FREE3>> lately.\n\n",
+      "new": "It doesn't take much for\nme to feel lonely,\n<<STR_FREE5>>. That's why\nI've been so\n<<STR_FREE2>><<STR_FREE3>> lately.\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 856,
+      "label": "",
+      "original": "You know what I like\nabout you? The fact\nthat you're so\n<<STR_FREE2>><<STR_FREE3>>! I like\nthat. I really do,\n<<STR_FREE5>>! See ya!\n",
+      "new": "You know what I like\nabout you? The fact\nthat you're so\n<<STR_FREE2>><<STR_FREE3>>! I like\nthat. I really do,\n<<STR_FREE5>>! See ya!\n"
+    },
+    {
+      "group": "mail",
+      "index": 857,
+      "label": "",
+      "original": "I need you to tell me\nsomething. Just exactly\nwhat is <<STR_FREE2>><<STR_FREE3>>\nmade of? It's been\nbothering me for some\ntime now...\n",
+      "new": "I need you to tell me\nsomething. Just exactly\nwhat is <<STR_FREE2>><<STR_FREE3>>\nmade of? It's been\nbothering me for some\ntime now...\n"
+    },
+    {
+      "group": "mail",
+      "index": 858,
+      "label": "",
+      "original": "Hah, hah! What's up? I tell\nyou, ninjas like me, we got\nit rough, <<STR_FREE5>>.\nAll I can do is hope to\nsomeday become a\n<<STR_FREE2>><<STR_FREE3>>!\n",
+      "new": "Hah, hah! What's up? I tell\nyou, ninjas like me, we got\nit rough, <<STR_FREE5>>.\nAll I can do is hope to\nsomeday become a\n<<STR_FREE2>><<STR_FREE3>>!\n"
+    },
+    {
+      "group": "mail",
+      "index": 859,
+      "label": "",
+      "original": "I've been obsessed with\n<<STR_FREE2>><<STR_FREE3>> lately,\n<<STR_FREE5>>. I can't\nhelp myself. I want to be\na semipro at\n<<STR_FREE2>><<STR_FREE3>>!\n",
+      "new": "I've been obsessed with\n<<STR_FREE2>><<STR_FREE3>> lately,\n<<STR_FREE5>>. I can't\nhelp myself. I want to be\na semipro at\n<<STR_FREE2>><<STR_FREE3>>!\n"
+    },
+    {
+      "group": "mail",
+      "index": 860,
+      "label": "",
+      "original": "Lately everyone's been\nasking me, \"why is your\nname Tank?\" Isn't that just\n<<STR_FREE2>><<STR_FREE3>>,\n<<STR_FREE5>>?\n\n",
+      "new": "Lately everyone's been\nasking me, \"why is your\nname Tank?\" Isn't that just\n<<STR_FREE2>><<STR_FREE3>>,\n<<STR_FREE5>>?\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 861,
+      "label": "",
+      "original": "Yo! <<STR_FREE0>>! You\ngotta be motivated! And\nstrong! That's what makes\nthe world go 'round! \nEvery day, you gotta\n<<STR_FREE2>><<STR_FREE3>>!\n",
+      "new": "Yo! <<STR_FREE0>>! You\ngotta be motivated! And\nstrong! That's what makes\nthe world go 'round! \nEvery day, you gotta\n<<STR_FREE2>><<STR_FREE3>>!\n"
+    },
+    {
+      "group": "mail",
+      "index": 862,
+      "label": "",
+      "original": "Why am I always restraining\nmyself? I'm going all out\nthis time! Get ready to see\na gorgeous, pure white,\n<<STR_FREE2>><<STR_FREE3>> house!\nBut maybe I shouldn't...\n",
+      "new": "Why am I always restraining\nmyself? I'm going all out\nthis time! Get ready to see\na gorgeous, pure white,\n<<STR_FREE2>><<STR_FREE3>> house!\nBut maybe I shouldn't...\n"
+    },
+    {
+      "group": "mail",
+      "index": 863,
+      "label": "",
+      "original": "I just love clothes. I wish\nI could be an Able Sister.\nThen I'd make lots and lots\nof <<STR_FREE2>><<STR_FREE3>>\nclothes, <<STR_FREE5>>.\n\n",
+      "new": "I just love clothes. I wish\nI could be an Able Sister.\nThen I'd make lots and lots\nof <<STR_FREE2>><<STR_FREE3>>\nclothes, <<STR_FREE5>>.\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 864,
+      "label": "",
+      "original": "My <<STR_FREE4>> is\nso cool, <<STR_FREE5>>. It\nfits you to a tee. It doesn't\nquite fit me, though,\nso you can have it,\n<<STR_FREE0>>.\n",
+      "new": "My <<STR_FREE4>> is\nso cool, <<STR_FREE5>>. It\nfits you to a tee. It doesn't\nquite fit me, though,\nso you can have it,\n<<STR_FREE0>>.\n"
+    },
+    {
+      "group": "mail",
+      "index": 865,
+      "label": "",
+      "original": "Hello, there, stranger.\nDo you like reading?\nI do, but only\n<<STR_FREE2>><<STR_FREE3>>.\nTime just flies by when I\nread one of those.\n",
+      "new": "Hello, there, stranger.\nDo you like reading?\nI do, but only\n<<STR_FREE2>><<STR_FREE3>>.\nTime just flies by when I\nread one of those.\n"
+    },
+    {
+      "group": "mail",
+      "index": 866,
+      "label": "",
+      "original": "<<STR_FREE0>>! How are you,\n<<STR_FREE5>>? I'm totally,\nincredibly good! A ball\nof energy! You might even\nsay I'm <<STR_FREE2>><<STR_FREE3>>!\nSee you soon!\n",
+      "new": "<<STR_FREE0>>! How are you,\n<<STR_FREE5>>? I'm totally,\nincredibly good! A ball\nof energy! You might even\nsay I'm <<STR_FREE2>><<STR_FREE3>>!\nSee you soon!\n"
+    },
+    {
+      "group": "mail",
+      "index": 867,
+      "label": "",
+      "original": "If I told you I've been an\nunstoppable force when it\ncomes to making sweets,\nwould you laugh? Last\nSaturday I even made a\n<<STR_FREE2>><<STR_FREE3>>!\n",
+      "new": "If I told you I've been an\nunstoppable force when it\ncomes to making sweets,\nwould you laugh? Last\nSaturday I even made a\n<<STR_FREE2>><<STR_FREE3>>!\n"
+    },
+    {
+      "group": "mail",
+      "index": 868,
+      "label": "",
+      "original": "For me, and probably for\nyou, too, teeth are everything\nin the world. Without them,\nyou couldn't even nibble on\n<<STR_FREE2>><<STR_FREE3>>!\nSo brush your teeth!\n",
+      "new": "For me, and probably for\nyou, too, teeth are everything\nin the world. Without them,\nyou couldn't even nibble on\n<<STR_FREE2>><<STR_FREE3>>!\nSo brush your teeth!\n"
+    },
+    {
+      "group": "mail",
+      "index": 869,
+      "label": "",
+      "original": "I haven't had enough\nstimulation lately. I really\nneed a good charge now\nand then. Surprisingly,\n<<STR_FREE2>><<STR_FREE3>> really\ngets me revved up!\n",
+      "new": "I haven't had enough\nstimulation lately. I really\nneed a good charge now\nand then. Surprisingly,\n<<STR_FREE2>><<STR_FREE3>> really\ngets me revved up!\n"
+    },
+    {
+      "group": "mail",
+      "index": 870,
+      "label": "",
+      "original": "Ahhh! Hello, <<STR_FREE0>>,\nHow are you, <<STR_FREE5>>?\nI feel totally refreshed!\nI'm spending my days on\n<<STR_FREE2>><<STR_FREE3>>.\nSee you soon, <<STR_FREE5>>.\n",
+      "new": "Ahhh! Hello, <<STR_FREE0>>,\nHow are you, <<STR_FREE5>>?\nI feel totally refreshed!\nI'm spending my days on\n<<STR_FREE2>><<STR_FREE3>>.\nSee you soon, <<STR_FREE5>>.\n"
+    },
+    {
+      "group": "mail",
+      "index": 871,
+      "label": "",
+      "original": "You don't think I'm too\ntoothy, do you? Not that\nthat's bad. I like it. It has\n<<STR_FREE2>><<STR_FREE3>>!\nSo there!\n\n",
+      "new": "You don't think I'm too\ntoothy, do you? Not that\nthat's bad. I like it. It has\n<<STR_FREE2>><<STR_FREE3>>!\nSo there!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 872,
+      "label": "",
+      "original": "Yo! What is up,\n<<STR_FREE0>>? I really want\nto have people tell me\nI'm <<STR_FREE2>><<STR_FREE3>>,\nso I've been training\ndaily. Wish me luck!\n",
+      "new": "Yo! What is up,\n<<STR_FREE0>>? I really want\nto have people tell me\nI'm <<STR_FREE2>><<STR_FREE3>>,\nso I've been training\ndaily. Wish me luck!\n"
+    },
+    {
+      "group": "mail",
+      "index": 873,
+      "label": "",
+      "original": "Listen here. I can cook.\nI can! In fact, I've made\n<<STR_FREE2>><<STR_FREE3>> before!\n\"How was it?\" you ask?\nWell, let's just say I don't\nmake it anymore.\n",
+      "new": "Listen here. I can cook.\nI can! In fact, I've made\n<<STR_FREE2>><<STR_FREE3>> before!\n\"How was it?\" you ask?\nWell, let's just say I don't\nmake it anymore.\n"
+    },
+    {
+      "group": "mail",
+      "index": 874,
+      "label": "",
+      "original": "Tell me something: isn't\nBangle kind of too obvious\na name? But I think that's\nOK. After all, it is quite\n<<STR_FREE2>><<STR_FREE3>>. Thanks!\nI feel better already!\n",
+      "new": "Tell me something: isn't\nBangle kind of too obvious\na name? But I think that's\nOK. After all, it is quite\n<<STR_FREE2>><<STR_FREE3>>. Thanks!\nI feel better already!\n"
+    },
+    {
+      "group": "mail",
+      "index": 875,
+      "label": "",
+      "original": "I may pretend like I'm a\nlone wolf, but sometimes\neven I can feel isolated and\nalone. That's when I watch\n<<STR_FREE2>><<STR_FREE3>> to\ncheer myself up.\n",
+      "new": "I may pretend like I'm a\nlone wolf, but sometimes\neven I can feel isolated and\nalone. That's when I watch\n<<STR_FREE2>><<STR_FREE3>> to\ncheer myself up.\n"
+    },
+    {
+      "group": "mail",
+      "index": 876,
+      "label": "",
+      "original": "Do you have any worries?\nI worry about the color of\nfur. My house looks great,\nbut what's with this\n<<STR_FREE2>><<STR_FREE3>> pink?\nMaybe I'll dye it darker!\n",
+      "new": "Do you have any worries?\nI worry about the color of\nfur. My house looks great,\nbut what's with this\n<<STR_FREE2>><<STR_FREE3>> pink?\nMaybe I'll dye it darker!\n"
+    },
+    {
+      "group": "mail",
+      "index": 877,
+      "label": "",
+      "original": "Being Chief is hard. Let me\ntell you! There's so much\nresponsibility! Decisions to\nmake! The stress overwhelms\nme. Sometimes I just need\nsome <<STR_FREE2>><<STR_FREE3>>.\n",
+      "new": "Being Chief is hard. Let me\ntell you! There's so much\nresponsibility! Decisions to\nmake! The stress overwhelms\nme. Sometimes I just need\nsome <<STR_FREE2>><<STR_FREE3>>.\n"
+    },
+    {
+      "group": "mail",
+      "index": 878,
+      "label": "",
+      "original": "The other day, I ate some\n<<STR_FREE2>><<STR_FREE3>>, but\nit made me really sick to my\nstomach. You'd better watch\nout, <<STR_FREE0>>.\n\n",
+      "new": "The other day, I ate some\n<<STR_FREE2>><<STR_FREE3>>, but\nit made me really sick to my\nstomach. You'd better watch\nout, <<STR_FREE0>>.\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 879,
+      "label": "",
+      "original": "Are you good at any sports,\n<<STR_FREE0>>? 'Cause, if you\ncan't even <<STR_FREE2>><<STR_FREE3>>,\nthat's totally uncool. Maybe\nyou should start practicing.\nToday. Got it, <<STR_FREE5>>?\n",
+      "new": "Are you good at any sports,\n<<STR_FREE0>>? 'Cause, if you\ncan't even <<STR_FREE2>><<STR_FREE3>>,\nthat's totally uncool. Maybe\nyou should start practicing.\nToday. Got it, <<STR_FREE5>>?\n"
+    },
+    {
+      "group": "mail",
+      "index": 880,
+      "label": "",
+      "original": "I guess thinking that you're\ngood enough to get by on\nyour own without help from\nanyone else is a good thing.\nYou can call folk like that\n<<STR_FREE2>><<STR_FREE3>>!\n",
+      "new": "I guess thinking that you're\ngood enough to get by on\nyour own without help from\nanyone else is a good thing.\nYou can call folk like that\n<<STR_FREE2>><<STR_FREE3>>!\n"
+    },
+    {
+      "group": "mail",
+      "index": 881,
+      "label": "",
+      "original": "How's your stomach feeling,\n<<STR_FREE0>>? I think I'm\nall right, <<STR_FREE5>>.\nI mean, I did eat\n<<STR_FREE2>><<STR_FREE3>>!\n\n",
+      "new": "How's your stomach feeling,\n<<STR_FREE0>>? I think I'm\nall right, <<STR_FREE5>>.\nI mean, I did eat\n<<STR_FREE2>><<STR_FREE3>>!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 882,
+      "label": "",
+      "original": "I think it's a good thing\nthat there are stubborn,\nuncompromising old boors\nin the world. Someone has\nto be able to handle all the\n<<STR_FREE2>><<STR_FREE3>>!\n",
+      "new": "I think it's a good thing\nthat there are stubborn,\nuncompromising old boors\nin the world. Someone has\nto be able to handle all the\n<<STR_FREE2>><<STR_FREE3>>!\n"
+    },
+    {
+      "group": "mail",
+      "index": 883,
+      "label": "",
+      "original": "What's cookin',\n<<STR_FREE0>>? Hey, I've\ndecided I'm gonna catch\nme a <<STR_FREE2>><<STR_FREE3>>\nthis year, <<STR_FREE5>>.\nIf they really exist...\n",
+      "new": "What's cookin',\n<<STR_FREE0>>? Hey, I've\ndecided I'm gonna catch\nme a <<STR_FREE2>><<STR_FREE3>>\nthis year, <<STR_FREE5>>.\nIf they really exist...\n"
+    },
+    {
+      "group": "mail",
+      "index": 884,
+      "label": "",
+      "original": "What's going down,\n<<STR_FREE0>>? I'm busy\ntraining to be a professional\n<<STR_FREE2>><<STR_FREE3>>!\nYeah!\n\n",
+      "new": "What's going down,\n<<STR_FREE0>>? I'm busy\ntraining to be a professional\n<<STR_FREE2>><<STR_FREE3>>!\nYeah!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 885,
+      "label": "",
+      "original": "My time has been so\nconsumed by\n<<STR_FREE2>><<STR_FREE3>> lately.\nI do it at least once a\nday, <<STR_FREE5>>.\n\n",
+      "new": "My time has been so\nconsumed by\n<<STR_FREE2>><<STR_FREE3>> lately.\nI do it at least once a\nday, <<STR_FREE5>>.\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 886,
+      "label": "",
+      "original": "Are you diggin' things\nthese days, <<STR_FREE0>>?\nWho, me? I'm totally\nenthralled with\n<<STR_FREE2>><<STR_FREE3>>\nright now, <<STR_FREE5>>.\n",
+      "new": "Are you diggin' things\nthese days, <<STR_FREE0>>?\nWho, me? I'm totally\nenthralled with\n<<STR_FREE2>><<STR_FREE3>>\nright now, <<STR_FREE5>>.\n"
+    },
+    {
+      "group": "mail",
+      "index": 887,
+      "label": "",
+      "original": "<<STR_FREE0>>, what kinds\nof things do you worry\nabout? I worry about\npeople thinking I have a\nbeard. But I'll be fine if I'm\n<<STR_FREE2>><<STR_FREE3>>.\n",
+      "new": "<<STR_FREE0>>, what kinds\nof things do you worry\nabout? I worry about\npeople thinking I have a\nbeard. But I'll be fine if I'm\n<<STR_FREE2>><<STR_FREE3>>.\n"
+    },
+    {
+      "group": "mail",
+      "index": 888,
+      "label": "",
+      "original": "I've decided to watch what\nI eat, so I made myself some\nspecial dessert, but\n<<STR_FREE2>><<STR_FREE3>> without\nsugar isn't that tasty,\n<<STR_FREE5>>.\n",
+      "new": "I've decided to watch what\nI eat, so I made myself some\nspecial dessert, but\n<<STR_FREE2>><<STR_FREE3>> without\nsugar isn't that tasty,\n<<STR_FREE5>>.\n"
+    },
+    {
+      "group": "mail",
+      "index": 889,
+      "label": "",
+      "original": "I don't bite or anything, so\nif you see me, come talk\nto me. But you may want me\nto hush up after you hear\nme talking about \n<<STR_FREE2>><<STR_FREE3>>.\n",
+      "new": "I don't bite or anything, so\nif you see me, come talk\nto me. But you may want me\nto hush up after you hear\nme talking about \n<<STR_FREE2>><<STR_FREE3>>.\n"
+    },
+    {
+      "group": "mail",
+      "index": 890,
+      "label": "",
+      "original": "You know what? I think\nLulu is an incredibly\n<<STR_FREE2>><<STR_FREE3>>\nname. I really like it.\n\n\n",
+      "new": "You know what? I think\nLulu is an incredibly\n<<STR_FREE2>><<STR_FREE3>>\nname. I really like it.\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 891,
+      "label": "",
+      "original": "Hello, <<STR_FREE0>>! Listen,\nI need to know what kind\nof music you like. I've\nbeen listening to a lot\nof <<STR_FREE2>><<STR_FREE3>>,\nbut it's an acquired taste.\n",
+      "new": "Hello, <<STR_FREE0>>! Listen,\nI need to know what kind\nof music you like. I've\nbeen listening to a lot\nof <<STR_FREE2>><<STR_FREE3>>,\nbut it's an acquired taste.\n"
+    },
+    {
+      "group": "mail",
+      "index": 892,
+      "label": "",
+      "original": "Hi! How are you? Guess\nwhat! I'm studying cooking\nnow. Yesterday I made\n<<STR_FREE2>><<STR_FREE3>>.\nBut I'm not ready to discuss\nhow good it was.\n",
+      "new": "Hi! How are you? Guess\nwhat! I'm studying cooking\nnow. Yesterday I made\n<<STR_FREE2>><<STR_FREE3>>.\nBut I'm not ready to discuss\nhow good it was.\n"
+    },
+    {
+      "group": "mail",
+      "index": 893,
+      "label": "",
+      "original": "Hi. How are things? Life as\nan elephant is quite rough,\nparticularly when it comes\nto skin care. Is eating\n<<STR_FREE2>><<STR_FREE3>>\ngood for your skin?\n",
+      "new": "Hi. How are things? Life as\nan elephant is quite rough,\nparticularly when it comes\nto skin care. Is eating\n<<STR_FREE2>><<STR_FREE3>>\ngood for your skin?\n"
+    },
+    {
+      "group": "mail",
+      "index": 894,
+      "label": "",
+      "original": "How have you been,\n<<STR_FREE5>>? I'm always\ndoing spectacularly! I feel\nso great, I could eat three\nhelpings of some fine\n<<STR_FREE2>><<STR_FREE3>>!\n",
+      "new": "How have you been,\n<<STR_FREE5>>? I'm always\ndoing spectacularly! I feel\nso great, I could eat three\nhelpings of some fine\n<<STR_FREE2>><<STR_FREE3>>!\n"
+    },
+    {
+      "group": "mail",
+      "index": 895,
+      "label": "",
+      "original": "I hope you are doing well.\nI've been quite busy working\non some of my recipes. In\nfact, I perfected my\n<<STR_FREE2>><<STR_FREE3>>\njust yesterday!\n",
+      "new": "I hope you are doing well.\nI've been quite busy working\non some of my recipes. In\nfact, I perfected my\n<<STR_FREE2>><<STR_FREE3>>\njust yesterday!\n"
+    },
+    {
+      "group": "mail",
+      "index": 896,
+      "label": "",
+      "original": "The other night I had the\nweirdest dream... I was\ndiving deep in the ocean,\nlooking for pearls. Isn't\nthat <<STR_FREE2>><<STR_FREE3>>?\n\n",
+      "new": "The other night I had the\nweirdest dream... I was\ndiving deep in the ocean,\nlooking for pearls. Isn't\nthat <<STR_FREE2>><<STR_FREE3>>?\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 897,
+      "label": "",
+      "original": "I trust the world is treating\nyou well. I am passing my\ntime with my daily\n<<STR_FREE2>><<STR_FREE3>>.\nWould you like to try? It's\nquite fun, <<STR_FREE5>>.\n",
+      "new": "I trust the world is treating\nyou well. I am passing my\ntime with my daily\n<<STR_FREE2>><<STR_FREE3>>.\nWould you like to try? It's\nquite fun, <<STR_FREE5>>.\n"
+    },
+    {
+      "group": "mail",
+      "index": 898,
+      "label": "",
+      "original": "I have no concept of time\nwhen I'm reading. The other\nnight, I started reading a\n<<STR_FREE2>><<STR_FREE3>> before\nI went to bed, but before I\nknew it, the sun was up!\n",
+      "new": "I have no concept of time\nwhen I'm reading. The other\nnight, I started reading a\n<<STR_FREE2>><<STR_FREE3>> before\nI went to bed, but before I\nknew it, the sun was up!\n"
+    },
+    {
+      "group": "mail",
+      "index": 899,
+      "label": "",
+      "original": "So, are you good at sports,\nor what? I am. I'm a total\njock! When it comes to\n<<STR_FREE2>><<STR_FREE3>>, no one\nsurpasses me!\n\n",
+      "new": "So, are you good at sports,\nor what? I am. I'm a total\njock! When it comes to\n<<STR_FREE2>><<STR_FREE3>>, no one\nsurpasses me!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 900,
+      "label": "",
+      "original": "Hello, <<STR_FREE0>>. You\nshould know that I am very\ninterested in clothing and\naccessories. Someday, I'd\nlike to have my own\n<<STR_FREE2>><<STR_FREE3>> shop.\n",
+      "new": "Hello, <<STR_FREE0>>. You\nshould know that I am very\ninterested in clothing and\naccessories. Someday, I'd\nlike to have my own\n<<STR_FREE2>><<STR_FREE3>> shop.\n"
+    },
+    {
+      "group": "mail",
+      "index": 901,
+      "label": "",
+      "original": "Everyone always asks me\nif I've been crying. Do I\nlook like I've been crying?\nI'm always very, very\n<<STR_FREE2>><<STR_FREE3>>!\nRight, <<STR_FREE5>>?\n",
+      "new": "Everyone always asks me\nif I've been crying. Do I\nlook like I've been crying?\nI'm always very, very\n<<STR_FREE2>><<STR_FREE3>>!\nRight, <<STR_FREE5>>?\n"
+    },
+    {
+      "group": "mail",
+      "index": 902,
+      "label": "",
+      "original": "I love flowers! Plants are\nso great! They make me\nfeel <<STR_FREE2>><<STR_FREE3>>!\nI wish I could plant flowers\nindoors. I want to sleep\non a bed of flowers.\n",
+      "new": "I love flowers! Plants are\nso great! They make me\nfeel <<STR_FREE2>><<STR_FREE3>>!\nI wish I could plant flowers\nindoors. I want to sleep\non a bed of flowers.\n"
+    },
+    {
+      "group": "mail",
+      "index": 903,
+      "label": "",
+      "original": "I haven't been able to sleep\nlately. I think my mattress\nisn't very good. I wonder\nwhere I might find an\nextravagant mattress some\n<<STR_FREE2>><<STR_FREE3>> used...\n",
+      "new": "I haven't been able to sleep\nlately. I think my mattress\nisn't very good. I wonder\nwhere I might find an\nextravagant mattress some\n<<STR_FREE2>><<STR_FREE3>> used...\n"
+    },
+    {
+      "group": "mail",
+      "index": 904,
+      "label": "",
+      "original": "<<STR_FREE0>>, my dream\nis to have someone ask\nme \"What's\n<<STR_FREE2>><<STR_FREE3>>?\" in an\ninterview, <<STR_FREE5>>.\nWhat's your dream?\n",
+      "new": "<<STR_FREE0>>, my dream\nis to have someone ask\nme \"What's\n<<STR_FREE2>><<STR_FREE3>>?\" in an\ninterview, <<STR_FREE5>>.\nWhat's your dream?\n"
+    },
+    {
+      "group": "mail",
+      "index": 905,
+      "label": "",
+      "original": "I have an incredible ability\nto master sports,\n<<STR_FREE5>>. In fact, I used\nto play quite a bit of\n<<STR_FREE2>><<STR_FREE3>>!\n\n",
+      "new": "I have an incredible ability\nto master sports,\n<<STR_FREE5>>. In fact, I used\nto play quite a bit of\n<<STR_FREE2>><<STR_FREE3>>!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 906,
+      "label": "",
+      "original": "Hello there, <<STR_FREE0>>.\nThe next time you come see\nme, I'm going to treat you\nto some <<STR_FREE2>><<STR_FREE3>>.\nJust don't expect a doggy\nbag, OK.\n",
+      "new": "Hello there, <<STR_FREE0>>.\nThe next time you come see\nme, I'm going to treat you\nto some <<STR_FREE2>><<STR_FREE3>>.\nJust don't expect a doggy\nbag, OK.\n"
+    },
+    {
+      "group": "mail",
+      "index": 907,
+      "label": "",
+      "original": "Top o' the mornin' to you!\nIs it morning? I've been so\nabsorbed with my\n<<STR_FREE2>><<STR_FREE3>>\nthat I don't even know\nanymore, <<STR_FREE5>>.\n",
+      "new": "Top o' the mornin' to you!\nIs it morning? I've been so\nabsorbed with my\n<<STR_FREE2>><<STR_FREE3>>\nthat I don't even know\nanymore, <<STR_FREE5>>.\n"
+    },
+    {
+      "group": "mail",
+      "index": 908,
+      "label": "",
+      "original": "Are you happy? Life can be\nhard, but I try to live in a\nstate of pure joy. To prove\nit, I'm sharing my\n<<STR_FREE4>>\nwith you, <<STR_FREE5>>.\n",
+      "new": "Are you happy? Life can be\nhard, but I try to live in a\nstate of pure joy. To prove\nit, I'm sharing my\n<<STR_FREE4>>\nwith you, <<STR_FREE5>>.\n"
+    },
+    {
+      "group": "mail",
+      "index": 909,
+      "label": "",
+      "original": "Hey, what's up? It's time\nto relax. Let things go. Be\ncasual. You're always out\nand about. Listen to some\n<<STR_FREE2>><<STR_FREE3>> and\nrelax! Catch my drift?\n",
+      "new": "Hey, what's up? It's time\nto relax. Let things go. Be\ncasual. You're always out\nand about. Listen to some\n<<STR_FREE2>><<STR_FREE3>> and\nrelax! Catch my drift?\n"
+    },
+    {
+      "group": "mail",
+      "index": 910,
+      "label": "",
+      "original": "Whoa! What's up? Get\nthings squared away so\nyou can come hang out\nwith me and enjoy some\n<<STR_FREE2>><<STR_FREE3>>! It'll\nbe awesome, <<STR_FREE5>>!\n",
+      "new": "Whoa! What's up? Get\nthings squared away so\nyou can come hang out\nwith me and enjoy some\n<<STR_FREE2>><<STR_FREE3>>! It'll\nbe awesome, <<STR_FREE5>>!\n"
+    },
+    {
+      "group": "mail",
+      "index": 911,
+      "label": "",
+      "original": "How are you? I'm managing\nto get by all right. Lately,\n<<STR_FREE2>><<STR_FREE3>> has\nworked its way into my\ndaily routine. It's quite\nfun, <<STR_FREE5>>.\n",
+      "new": "How are you? I'm managing\nto get by all right. Lately,\n<<STR_FREE2>><<STR_FREE3>> has\nworked its way into my\ndaily routine. It's quite\nfun, <<STR_FREE5>>.\n"
+    },
+    {
+      "group": "mail",
+      "index": 912,
+      "label": "",
+      "original": "How have things been?\nI am the same as ever.\nIn fact, I tried to make\n<<STR_FREE2>><<STR_FREE3>>\nthe other day, but failed!\n\n",
+      "new": "How have things been?\nI am the same as ever.\nIn fact, I tried to make\n<<STR_FREE2>><<STR_FREE3>>\nthe other day, but failed!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 913,
+      "label": "",
+      "original": "How are you feeling?\nI'm feeling like\n<<STR_FREE2>><<STR_FREE3>>\nmyself, <<STR_FREE5>>!\nI wish I could feel this way\nforever.\n",
+      "new": "How are you feeling?\nI'm feeling like\n<<STR_FREE2>><<STR_FREE3>>\nmyself, <<STR_FREE5>>!\nI wish I could feel this way\nforever.\n"
+    },
+    {
+      "group": "mail",
+      "index": 914,
+      "label": "",
+      "original": "How are things? It's been a\nwhile since I began my life\non the island, but I still long\nfor the flavor of some\n<<STR_FREE2>><<STR_FREE3>>\nhometown cooking. Ook ook.\n",
+      "new": "How are things? It's been a\nwhile since I began my life\non the island, but I still long\nfor the flavor of some\n<<STR_FREE2>><<STR_FREE3>>\nhometown cooking. Ook ook.\n"
+    },
+    {
+      "group": "mail",
+      "index": 915,
+      "label": "",
+      "original": "Yo! <<STR_FREE0>>! How are\nya, <<STR_FREE5>>? I\npicked up this\n<<STR_FREE4>> on\nthe beach the other day. I\ndon't want it, so it's yours!\n",
+      "new": "Yo! <<STR_FREE0>>! How are\nya, <<STR_FREE5>>? I\npicked up this\n<<STR_FREE4>> on\nthe beach the other day. I\ndon't want it, so it's yours!\n"
+    },
+    {
+      "group": "mail",
+      "index": 916,
+      "label": "",
+      "original": "Ahhh... I've been so listless\nlately. And my face has\nbroken out. Maybe I'll start\n<<STR_FREE2>><<STR_FREE3>> for\na change of pace...\nBut that's too much work.\n",
+      "new": "Ahhh... I've been so listless\nlately. And my face has\nbroken out. Maybe I'll start\n<<STR_FREE2>><<STR_FREE3>> for\na change of pace...\nBut that's too much work.\n"
+    },
+    {
+      "group": "mail",
+      "index": 917,
+      "label": "",
+      "original": "Have you been eating?\nI made myself some\n<<STR_FREE2>><<STR_FREE3>>\nthe other day, and for some\nreason, I thought of you.\n\n",
+      "new": "Have you been eating?\nI made myself some\n<<STR_FREE2>><<STR_FREE3>>\nthe other day, and for some\nreason, I thought of you.\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 918,
+      "label": "",
+      "original": "<<STR_FREE0>>, do you\nknow anything about\n<<STR_FREE2>><<STR_FREE3>>,\n<<STR_FREE5>>? I hear\nit's very fun. Maybe we\ncan try it sometime!\n",
+      "new": "<<STR_FREE0>>, do you\nknow anything about\n<<STR_FREE2>><<STR_FREE3>>,\n<<STR_FREE5>>? I hear\nit's very fun. Maybe we\ncan try it sometime!\n"
+    },
+    {
+      "group": "mail",
+      "index": 919,
+      "label": "",
+      "original": "Let me give a shout out\nto you, <<STR_FREE0>>!\nWhat's with manners these\ndays. I wish people would\nread <<STR_FREE2>><<STR_FREE3>>.\nThat would open their eyes!\n",
+      "new": "Let me give a shout out\nto you, <<STR_FREE0>>!\nWhat's with manners these\ndays. I wish people would\nread <<STR_FREE2>><<STR_FREE3>>.\nThat would open their eyes!\n"
+    },
+    {
+      "group": "mail",
+      "index": 920,
+      "label": "",
+      "original": "Je t'aime, <<STR_FREE0>>.\nHow is life? I'm feeling\nquite <<STR_FREE2>><<STR_FREE3>>\nmyself, <<STR_FREE5>>.\nAdios!\n\n",
+      "new": "Je t'aime, <<STR_FREE0>>.\nHow is life? I'm feeling\nquite <<STR_FREE2>><<STR_FREE3>>\nmyself, <<STR_FREE5>>.\nAdios!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 921,
+      "label": "",
+      "original": "Listen to this, <<STR_FREE0>>.\nThe other night I dreamt\nI turned into\n<<STR_FREE2>><<STR_FREE3>>! Even\nthough it was just a dream,\nit made me so happy!\n",
+      "new": "Listen to this, <<STR_FREE0>>.\nThe other night I dreamt\nI turned into\n<<STR_FREE2>><<STR_FREE3>>! Even\nthough it was just a dream,\nit made me so happy!\n"
+    },
+    {
+      "group": "mail",
+      "index": 922,
+      "label": "",
+      "original": "Do I seem all that pushy\nto you? People often think\nI'm a guy🌢. How could\nthey when I'm so\n<<STR_FREE2>><<STR_FREE3>>?\n\n",
+      "new": "Do I seem all that pushy\nto you? People often think\nI'm a guy🌢. How could\nthey when I'm so\n<<STR_FREE2>><<STR_FREE3>>?\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 923,
+      "label": "",
+      "original": "Arr! How arr you? I've\ngotten used to life on land,\nbut I want to get me sea\nlegs back! I love the sea!\nIt has such a\n<<STR_FREE2>><<STR_FREE3>> feel!\n",
+      "new": "Arr! How arr you? I've\ngotten used to life on land,\nbut I want to get me sea\nlegs back! I love the sea!\nIt has such a\n<<STR_FREE2>><<STR_FREE3>> feel!\n"
+    },
+    {
+      "group": "mail",
+      "index": 924,
+      "label": "",
+      "original": "So, <<STR_FREE0>>, how do\nyou manage to stay so young\nand beautiful? I drink\n<<STR_FREE2>><<STR_FREE3>> every\nday, <<STR_FREE5>>!\n\n",
+      "new": "So, <<STR_FREE0>>, how do\nyou manage to stay so young\nand beautiful? I drink\n<<STR_FREE2>><<STR_FREE3>> every\nday, <<STR_FREE5>>!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 925,
+      "label": "",
+      "original": "Let me ask you something,\n<<STR_FREE0>>... Is my name\nweird? Whenever I introduce\nmyself, people always say\n\"<<STR_FREE2>><<STR_FREE3>>!\"\nWhy? I don't get it...\n",
+      "new": "Let me ask you something,\n<<STR_FREE0>>... Is my name\nweird? Whenever I introduce\nmyself, people always say\n\"<<STR_FREE2>><<STR_FREE3>>!\"\nWhy? I don't get it...\n"
+    },
+    {
+      "group": "mail",
+      "index": 926,
+      "label": "",
+      "original": "To thank you much for\nalways shopping at my\nshop, I have a special\n<<STR_FREE4>>\nto give you, <<STR_FREE0>>.\nPlease accept it.\n",
+      "new": "To thank you much for\nalways shopping at my\nshop, I have a special\n<<STR_FREE4>>\nto give you, <<STR_FREE0>>.\nPlease accept it.\n"
+    },
+    {
+      "group": "mail",
+      "index": 927,
+      "label": "",
+      "original": "I get so hungry from\nwalking so much. I wish I\ncould catch my own fish\nto eat. I carry an umbrella,\nbut a fishing rod might be\na better <<STR_FREE2>><<STR_FREE3>>...\n",
+      "new": "I get so hungry from\nwalking so much. I wish I\ncould catch my own fish\nto eat. I carry an umbrella,\nbut a fishing rod might be\na better <<STR_FREE2>><<STR_FREE3>>...\n"
+    },
+    {
+      "group": "mail",
+      "index": 928,
+      "label": "",
+      "original": "Are you using my carpet?\nIt is very fine carpet. It\nwill last you a long time.\nIt is <<STR_FREE2>><<STR_FREE3>>.\nAxel likes it. Let's barter\nagain soon.\n",
+      "new": "Are you using my carpet?\nIt is very fine carpet. It\nwill last you a long time.\nIt is <<STR_FREE2>><<STR_FREE3>>.\nAxel likes it. Let's barter\nagain soon.\n"
+    },
+    {
+      "group": "mail",
+      "index": 929,
+      "label": "",
+      "original": "Are you wearing one of\nmy fabulous Gracie designs?\nDon't you just love it? I\nhear you're designing clothes\ntoo, but I must say your\nwork is <<STR_FREE2>><<STR_FREE3>>.\n",
+      "new": "Are you wearing one of\nmy fabulous Gracie designs?\nDon't you just love it? I\nhear you're designing clothes\ntoo, but I must say your\nwork is <<STR_FREE2>><<STR_FREE3>>.\n"
+    },
+    {
+      "group": "mail",
+      "index": 930,
+      "label": "",
+      "original": "Have you been keepin'\nyour eye on those turnip\nprices? They've been\nfluctuating something awful\nlately. Beware! Turnips are\nlike <<STR_FREE2>><<STR_FREE3>>!\n",
+      "new": "Have you been keepin'\nyour eye on those turnip\nprices? They've been\nfluctuating something awful\nlately. Beware! Turnips are\nlike <<STR_FREE2>><<STR_FREE3>>!\n"
+    },
+    {
+      "group": "mail",
+      "index": 931,
+      "label": "",
+      "original": "You have nothing to fear.\nYou and I are linked. The\nkey word that will unlock\nyour good fortune is\n<<STR_FREE2>><<STR_FREE3>>. Keep\nnear your heart!\n",
+      "new": "You have nothing to fear.\nYou and I are linked. The\nkey word that will unlock\nyour good fortune is\n<<STR_FREE2>><<STR_FREE3>>. Keep\nnear your heart!\n"
+    },
+    {
+      "group": "mail",
+      "index": 932,
+      "label": "",
+      "original": "Watching you run freely\naround in safety is one of\nmy secret pleasures. Take\ncare not to <<STR_FREE2>><<STR_FREE3>>,\n<<STR_FREE0>>!\n\n",
+      "new": "Watching you run freely\naround in safety is one of\nmy secret pleasures. Take\ncare not to <<STR_FREE2>><<STR_FREE3>>,\n<<STR_FREE0>>!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 933,
+      "label": "",
+      "original": "I know we can only meet\nonce a year on October\n31st, but please have lots\nof candy ready for me!\nIt's my <<STR_FREE2>><<STR_FREE3>>!\nSee you next Halloween!\n",
+      "new": "I know we can only meet\nonce a year on October\n31st, but please have lots\nof candy ready for me!\nIt's my <<STR_FREE2>><<STR_FREE3>>!\nSee you next Halloween!\n"
+    },
+    {
+      "group": "mail",
+      "index": 934,
+      "label": "",
+      "original": "Things up north are quite\nbusy getting ready for the\nupcoming festive season.\nBut I just deliver, so I'm\njust <<STR_FREE2>><<STR_FREE3>>\nand taking it easy now!\n",
+      "new": "Things up north are quite\nbusy getting ready for the\nupcoming festive season.\nBut I just deliver, so I'm\njust <<STR_FREE2>><<STR_FREE3>>\nand taking it easy now!\n"
+    },
+    {
+      "group": "mail",
+      "index": 935,
+      "label": "",
+      "original": "I always get to deliver all\nthe fine letters that all you\nfolk write, but sometimes\nwriting the letters isn't bad\neither. Maybe I'll write one\nto <<STR_FREE2>><<STR_FREE3>> next.\n",
+      "new": "I always get to deliver all\nthe fine letters that all you\nfolk write, but sometimes\nwriting the letters isn't bad\neither. Maybe I'll write one\nto <<STR_FREE2>><<STR_FREE3>> next.\n"
+    },
+    {
+      "group": "mail",
+      "index": 936,
+      "label": "",
+      "original": "You always seem so happy\nwhen you come to mail\nletters, <<STR_FREE0>>,\nso it makes me happy, too.\nLetters are like\n<<STR_FREE2>><<STR_FREE3>>, aren't they?\n",
+      "new": "You always seem so happy\nwhen you come to mail\nletters, <<STR_FREE0>>,\nso it makes me happy, too.\nLetters are like\n<<STR_FREE2>><<STR_FREE3>>, aren't they?\n"
+    },
+    {
+      "group": "mail",
+      "index": 937,
+      "label": "",
+      "original": "You may not realize it, but\nI'm really doing the best I\ncan. My saucy looks are just\nmisunderstood. I'm sure it's\n<<STR_FREE2>><<STR_FREE3>>.\n\n",
+      "new": "You may not realize it, but\nI'm really doing the best I\ncan. My saucy looks are just\nmisunderstood. I'm sure it's\n<<STR_FREE2>><<STR_FREE3>>.\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 938,
+      "label": "",
+      "original": "The only time we ever talk\nis on the train, isn't it?\nWell, <<STR_FREE0>>, like you\nI'm <<STR_FREE2>><<STR_FREE3>>...\nI just love to travel!\nSee you on the train!\n",
+      "new": "The only time we ever talk\nis on the train, isn't it?\nWell, <<STR_FREE0>>, like you\nI'm <<STR_FREE2>><<STR_FREE3>>...\nI just love to travel!\nSee you on the train!\n"
+    },
+    {
+      "group": "mail",
+      "index": 939,
+      "label": "",
+      "original": "Thanks for coming out to\nhear me wail. You're a real\nhipster. Have you heard\n<<STR_FREE2>><<STR_FREE3>> yet? It's\none wild tune. Don't be\nsquare! Keep comin' around.\n",
+      "new": "Thanks for coming out to\nhear me wail. You're a real\nhipster. Have you heard\n<<STR_FREE2>><<STR_FREE3>> yet? It's\none wild tune. Don't be\nsquare! Keep comin' around.\n"
+    },
+    {
+      "group": "mail",
+      "index": 940,
+      "label": "",
+      "original": "Are the fish biting? Isn't\nfishing great? It's a\ncompetition, a battle! In a\nword, it's <<STR_FREE2>><<STR_FREE3>>.\nDon't you agree?\nNyuk nyuk nyuk!\n",
+      "new": "Are the fish biting? Isn't\nfishing great? It's a\ncompetition, a battle! In a\nword, it's <<STR_FREE2>><<STR_FREE3>>.\nDon't you agree?\nNyuk nyuk nyuk!\n"
+    },
+    {
+      "group": "mail",
+      "index": 941,
+      "label": "",
+      "original": "How are you? Please take\ncare not to lose anything...\nweird. The other day,\n<<STR_FREE2>><<STR_FREE3>> came in.\nI was shocked.\n\n",
+      "new": "How are you? Please take\ncare not to lose anything...\nweird. The other day,\n<<STR_FREE2>><<STR_FREE3>> came in.\nI was shocked.\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 942,
+      "label": "",
+      "original": "I'm Timmy Nook. I work on\nthe second floor at\nNookington's. As part of our\nspecial sale today, I'm\nsending you this fine\n<<STR_FREE4>>!\n",
+      "new": "I'm Timmy Nook. I work on\nthe second floor at\nNookington's. As part of our\nspecial sale today, I'm\nsending you this fine\n<<STR_FREE4>>!\n"
+    },
+    {
+      "group": "mail",
+      "index": 943,
+      "label": "",
+      "original": "I may look a little bit like\nTimmy, but my name is\nactually Tommy. But rather\nthan introduce myself, I'll\njust give you this fine\n<<STR_FREE4>>!\n",
+      "new": "I may look a little bit like\nTimmy, but my name is\nactually Tommy. But rather\nthan introduce myself, I'll\njust give you this fine\n<<STR_FREE4>>!\n"
+    },
+    {
+      "group": "mail",
+      "index": 944,
+      "label": "",
+      "original": "Hey there, friend! I found\nthis <<CUTARTICLE>><<STR_FREE4>>\nthrough \"special\" channels,\nbut since you seem to know\nhow to find me, I'll let you\nhave it, as a \"present\"!\n",
+      "new": "Hey there, friend! I found\nthis <<CUTARTICLE>><<STR_FREE4>>\nthrough \"special\" channels,\nbut since you seem to know\nhow to find me, I'll let you\nhave it, as a \"present\"!\n"
+    },
+    {
+      "group": "mail",
+      "index": 945,
+      "label": "",
+      "original": "You haven't been resetting,\nhave you?! I guess I won't\nride you too hard today.\nNext time we meet, though,\nI'm gonna make you say\n<<STR_FREE2>><<STR_FREE3>>! Say it!\n",
+      "new": "You haven't been resetting,\nhave you?! I guess I won't\nride you too hard today.\nNext time we meet, though,\nI'm gonna make you say\n<<STR_FREE2>><<STR_FREE3>>! Say it!\n"
+    },
+    {
+      "group": "mail",
+      "index": 946,
+      "label": "",
+      "original": "It's always a pleasure! To\nbe rescued, that is! I'm\nwriting this letter on my\nship. The sea is beautiful!\nIt's <<STR_FREE2>><<STR_FREE3>>!\nJust wait for a souvenir!\n",
+      "new": "It's always a pleasure! To\nbe rescued, that is! I'm\nwriting this letter on my\nship. The sea is beautiful!\nIt's <<STR_FREE2>><<STR_FREE3>>!\nJust wait for a souvenir!\n"
+    },
+    {
+      "group": "mail",
+      "index": 947,
+      "label": "",
+      "original": "<<STR_FREE0>>, I clearly recall\nthe first day you stepped off\nthe train. I saw\n<<STR_FREE2>><<STR_FREE3>> written\nall over your face, but I\nwon't tell😃! Eek eek!\n",
+      "new": "<<STR_FREE0>>, I clearly recall\nthe first day you stepped off\nthe train. I saw\n<<STR_FREE2>><<STR_FREE3>> written\nall over your face, but I\nwon't tell😃! Eek eek!\n"
+    },
+    {
+      "group": "mail",
+      "index": 948,
+      "label": "",
+      "original": "Thank you so much for your\nsplendid contributions. But\nhave you found any\n<<STR_FREE2>><<STR_FREE3>> fossils?\nThat would bring stupendous\nfortune and glory!\n",
+      "new": "Thank you so much for your\nsplendid contributions. But\nhave you found any\n<<STR_FREE2>><<STR_FREE3>> fossils?\nThat would bring stupendous\nfortune and glory!\n"
+    },
+    {
+      "group": "mail",
+      "index": 949,
+      "label": "",
+      "original": "How's life in town, ye land\nlubber? If ever ye get bored,\nye can come fer a sail on me\nschooner! 'Tis a\n<<STR_FREE2>><<STR_FREE3>>\nafter all! I can't wait!\n",
+      "new": "How's life in town, ye land\nlubber? If ever ye get bored,\nye can come fer a sail on me\nschooner! 'Tis a\n<<STR_FREE2>><<STR_FREE3>>\nafter all! I can't wait!\n"
+    },
+    {
+      "group": "mail",
+      "index": 950,
+      "label": "",
+      "original": "It's always a pleasure,\n<<STR_FREE0>>! You are one\ntalented designer. Maybe\nif you design some\n<<STR_FREE2>><<STR_FREE3>> clothes,\nthey'll be all the rage!\n",
+      "new": "It's always a pleasure,\n<<STR_FREE0>>! You are one\ntalented designer. Maybe\nif you design some\n<<STR_FREE2>><<STR_FREE3>> clothes,\nthey'll be all the rage!\n"
+    },
+    {
+      "group": "mail",
+      "index": 951,
+      "label": "",
+      "original": "...Ummm...\nI'd like you...\n...to have...this...\n<<CUTARTICLE>><<STR_FREE4>>.\n            It's a pleasure.\n\n",
+      "new": "...Ummm...\nI'd like you...\n...to have...this...\n<<CUTARTICLE>><<STR_FREE4>>.\n            It's a pleasure.\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 952,
+      "label": "",
+      "original": "How are you, kiddo? When\nwas the last time we met?\nI'm so old now, I can't\nremember to remember!\nIs that what you'd call\n<<STR_FREE2>><<STR_FREE3>>?\n",
+      "new": "How are you, kiddo? When\nwas the last time we met?\nI'm so old now, I can't\nremember to remember!\nIs that what you'd call\n<<STR_FREE2>><<STR_FREE3>>?\n"
+    },
+    {
+      "group": "mail",
+      "index": 953,
+      "label": "",
+      "original": "Oh, boy. I think this time\n<<STR_FREE2>><<STR_FREE3>> is gonna\nbe really mad. Heeeeeee.\nI hope you'll help me out\nthen. Please...\n\n",
+      "new": "Oh, boy. I think this time\n<<STR_FREE2>><<STR_FREE3>> is gonna\nbe really mad. Heeeeeee.\nI hope you'll help me out\nthen. Please...\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 954,
+      "label": "",
+      "original": "Thanks for makin' sure\nmy brother Sonny has a\njob. I want you to have this\n<<STR_FREE4>> as a\nsign of our appreciation.\nNow scram!\n",
+      "new": "Thanks for makin' sure\nmy brother Sonny has a\njob. I want you to have this\n<<STR_FREE4>> as a\nsign of our appreciation.\nNow scram!\n"
+    },
+    {
+      "group": "mail",
+      "index": 955,
+      "label": "",
+      "original": "I hope you haven't been\nspreading bad rumors\nabout me! I'm definitely\nno <<STR_FREE2>><<STR_FREE3>>!\nDon't bad-mouth me,\nOK?\n",
+      "new": "I hope you haven't been\nspreading bad rumors\nabout me! I'm definitely\nno <<STR_FREE2>><<STR_FREE3>>!\nDon't bad-mouth me,\nOK?\n"
+    },
+    {
+      "group": "mail",
+      "index": 956,
+      "label": "",
+      "original": "Have you heard if your\ntown is holding another\nHarvest Festival this year? \nI hope not. That festival is\nso <<STR_FREE2>><<STR_FREE3>>. You\nknow what to do if they do!\n",
+      "new": "Have you heard if your\ntown is holding another\nHarvest Festival this year? \nI hope not. That festival is\nso <<STR_FREE2>><<STR_FREE3>>. You\nknow what to do if they do!\n"
+    },
+    {
+      "group": "mail",
+      "index": 957,
+      "label": "",
+      "original": "What a pleasant surprise.\nClearly you have great\nconcern for the environment\naround you. That is\n<<STR_FREE2>><<STR_FREE3>>. I wish\nmore people were like you.\n",
+      "new": "What a pleasant surprise.\nClearly you have great\nconcern for the environment\naround you. That is\n<<STR_FREE2>><<STR_FREE3>>. I wish\nmore people were like you.\n"
+    },
+    {
+      "group": "mail",
+      "index": 958,
+      "label": "",
+      "original": "What is the story behind\nthe key? Is it some kind of\nkey word? Did you wake up\nin the middle of the night\nand write this down? Next\ntime, wait 'til you're awake.\n",
+      "new": "What is the story behind\nthe key? Is it some kind of\nkey word? Did you wake up\nin the middle of the night\nand write this down? Next\ntime, wait 'til you're awake.\n"
+    },
+    {
+      "group": "mail",
+      "index": 959,
+      "label": "",
+      "original": "What was that key you sent\nme? Is it a password? Does\nit unlock something? I don't\nget it! Did you see some spy\nmovie recently, and get some\nwild ideas, <<STR_FREE0>>?\n",
+      "new": "What was that key you sent\nme? Is it a password? Does\nit unlock something? I don't\nget it! Did you see some spy\nmovie recently, and get some\nwild ideas, <<STR_FREE0>>?\n"
+    },
+    {
+      "group": "mail",
+      "index": 960,
+      "label": "",
+      "original": "Ooo! What's that key word\nyou sent me? A password?\nIs it some kind of game?\nI hope you're not having\nfun without me!\nThat's not fair!\n",
+      "new": "Ooo! What's that key word\nyou sent me? A password?\nIs it some kind of game?\nI hope you're not having\nfun without me!\nThat's not fair!\n"
+    },
+    {
+      "group": "mail",
+      "index": 961,
+      "label": "",
+      "original": "Are you all right,\n<<STR_FREE0>>? Did you hit your\nhead or something? If you're\nall right, then please don't\nsend me weird letters!\nI hope it's not a curse!\n",
+      "new": "Are you all right,\n<<STR_FREE0>>? Did you hit your\nhead or something? If you're\nall right, then please don't\nsend me weird letters!\nI hope it's not a curse!\n"
+    },
+    {
+      "group": "mail",
+      "index": 962,
+      "label": "",
+      "original": "Hey, now! Don't go sending\nme strange letters! I don't\nremember agreeing on any\npassword with you! Even if\nwe did, I could never\nremember one so long!\n",
+      "new": "Hey, now! Don't go sending\nme strange letters! I don't\nremember agreeing on any\npassword with you! Even if\nwe did, I could never\nremember one so long!\n"
+    },
+    {
+      "group": "mail",
+      "index": 963,
+      "label": "",
+      "original": "The letter you sent me had\na key drawn on it, followed\nby some weird password.\nWhy? Is that the new fad?\nOh, no! Am I behind the\ntimes? That won't do!\n",
+      "new": "The letter you sent me had\na key drawn on it, followed\nby some weird password.\nWhy? Is that the new fad?\nOh, no! Am I behind the\ntimes? That won't do!\n"
+    },
+    {
+      "group": "mail",
+      "index": 964,
+      "label": "",
+      "original": "Congratulations!\nYou won this exquisite\n<<STR_FREE4>>!\nI just hope you find it\nuseful.\n\n",
+      "new": "Congratulations!\nYou won this exquisite\n<<STR_FREE4>>!\nI just hope you find it\nuseful.\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 965,
+      "label": "",
+      "original": "Lucky you, <<STR_FREE0>>!\nThis <<STR_FREE4>>\nis yours! You won because\nyou're my friend,\n<<STR_FREE5>>! And I wanted\nto thank you for that😃!\n",
+      "new": "Lucky you, <<STR_FREE0>>!\nThis <<STR_FREE4>>\nis yours! You won because\nyou're my friend,\n<<STR_FREE5>>! And I wanted\nto thank you for that😃!\n"
+    },
+    {
+      "group": "mail",
+      "index": 966,
+      "label": "",
+      "original": "You did it, <<STR_FREE0>>!\nYou won this\n<<STR_FREE4>>!\nThanks to me, of course.\nWhy? Hmm... I wonder,\n<<STR_FREE5>>.\n",
+      "new": "You did it, <<STR_FREE0>>!\nYou won this\n<<STR_FREE4>>!\nThanks to me, of course.\nWhy? Hmm... I wonder,\n<<STR_FREE5>>.\n"
+    },
+    {
+      "group": "mail",
+      "index": 967,
+      "label": "",
+      "original": "Well, well, <<STR_FREE0>>!\nLooks like you get this cool\n<<STR_FREE4>>!\nThis is proof of our long-\nstanding friendship! Take\ncare of it, <<STR_FREE5>>!\n",
+      "new": "Well, well, <<STR_FREE0>>!\nLooks like you get this cool\n<<STR_FREE4>>!\nThis is proof of our long-\nstanding friendship! Take\ncare of it, <<STR_FREE5>>!\n"
+    },
+    {
+      "group": "mail",
+      "index": 968,
+      "label": "",
+      "original": "You won! You won! You lucky\ndog! It must be because\nyou've been such a good\nfriend to me! And friends\nwatch out for each other.\nDon't forget that!\n",
+      "new": "You won! You won! You lucky\ndog! It must be because\nyou've been such a good\nfriend to me! And friends\nwatch out for each other.\nDon't forget that!\n"
+    },
+    {
+      "group": "mail",
+      "index": 969,
+      "label": "",
+      "original": "Well, since you got my\ncard, you get my\n<<STR_FREE4>>.\nYou win! Now thank me.\nLet's get together sometime\nsoon, all right?\n",
+      "new": "Well, since you got my\ncard, you get my\n<<STR_FREE4>>.\nYou win! Now thank me.\nLet's get together sometime\nsoon, all right?\n"
+    },
+    {
+      "group": "mail",
+      "index": 970,
+      "label": "",
+      "original": "Incredible, <<STR_FREE0>>!\nYou won a fabulous\n<<STR_FREE4>>!\nI'm sure it's because of\nyour recent good behavior,\n<<STR_FREE5>>!\n",
+      "new": "Incredible, <<STR_FREE0>>!\nYou won a fabulous\n<<STR_FREE4>>!\nI'm sure it's because of\nyour recent good behavior,\n<<STR_FREE5>>!\n"
+    },
+    {
+      "group": "mail",
+      "index": 971,
+      "label": "",
+      "original": "You're awesome! That's why\nyou get this totally awesome\n<<STR_FREE4>>!\nBut rememberーit's only\nbecause I'm looking out\nfor your best interests!\n",
+      "new": "You're awesome! That's why\nyou get this totally awesome\n<<STR_FREE4>>!\nBut rememberーit's only\nbecause I'm looking out\nfor your best interests!\n"
+    },
+    {
+      "group": "mail",
+      "index": 972,
+      "label": "",
+      "original": "You won this really neat\n<<STR_FREE4>>!\nI know life can be hard,\nbut this is proof that good\nthings happen, too.\nNever forget that.\n",
+      "new": "You won this really neat\n<<STR_FREE4>>!\nI know life can be hard,\nbut this is proof that good\nthings happen, too.\nNever forget that.\n"
+    },
+    {
+      "group": "mail",
+      "index": 973,
+      "label": "",
+      "original": "Whoa! Aren't you lucky!\nOr is it my card that's\nlucky? Either way, you\nget this way-cool\n<<STR_FREE4>>!\nIsn't that great?\n",
+      "new": "Whoa! Aren't you lucky!\nOr is it my card that's\nlucky? Either way, you\nget this way-cool\n<<STR_FREE4>>!\nIsn't that great?\n"
+    },
+    {
+      "group": "mail",
+      "index": 974,
+      "label": "",
+      "original": "Aren't you a lucky duck?\nI can't believe you got that\n<<STR_FREE4>>...\nI think we were fated to\nmeet, <<STR_FREE5>>.\n\n",
+      "new": "Aren't you a lucky duck?\nI can't believe you got that\n<<STR_FREE4>>...\nI think we were fated to\nmeet, <<STR_FREE5>>.\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 975,
+      "label": "",
+      "original": "My, my! You won! This must\nbe because you've been so\nnice to me! Isn't it? Well,\njust remember, take care of\nmy card!\n\n",
+      "new": "My, my! You won! This must\nbe because you've been so\nnice to me! Isn't it? Well,\njust remember, take care of\nmy card!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 976,
+      "label": "",
+      "original": "You have to tell that\npassword you sent me\nto Tom Nook if you want\nto get your present.\nSorry I couldn't help.\n\n",
+      "new": "You have to tell that\npassword you sent me\nto Tom Nook if you want\nto get your present.\nSorry I couldn't help.\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 977,
+      "label": "",
+      "original": "I don't know that secret code\nyou sent me. Maybe you\ncan ask Tom Nook what he\nknows about it!\n\n\n",
+      "new": "I don't know that secret code\nyou sent me. Maybe you\ncan ask Tom Nook what he\nknows about it!\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 978,
+      "label": "",
+      "original": "Umm, about that letter you\nsent me... It confused me.\nI hear Nook knows a lot\nof secret codes. Try\ntalking to him.\n\n",
+      "new": "Umm, about that letter you\nsent me... It confused me.\nI hear Nook knows a lot\nof secret codes. Try\ntalking to him.\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 979,
+      "label": "",
+      "original": "Why are you always in such\na rush? Don't tell me your\nsecret code...tell the\nNookster!\n\n\n",
+      "new": "Why are you always in such\na rush? Don't tell me your\nsecret code...tell the\nNookster!\n\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 980,
+      "label": "",
+      "original": "What!?! Do you think I work\nfor Nook or something???\nGive me a break! Go tell\nyour secret codes to\nNook!\n\n",
+      "new": "What!?! Do you think I work\nfor Nook or something???\nGive me a break! Go tell\nyour secret codes to\nNook!\n\n"
+    },
+    {
+      "group": "mail",
+      "index": 981,
+      "label": "",
+      "original": "I hate to say this, but\nI can't help you with your\nsecret code. I think you're\nsupposed to tell it Tom\nNook. Get with the program!\n\n",
+      "new": "I hate to say this, but\nI can't help you with your\nsecret code. I think you're\nsupposed to tell it Tom\nNook. Get with the program!\n\n"
+    },
+    {
+      "group": "maila",
+      "index": 0,
+      "label": "",
+      "original": "Hello, <<STR_FREE0>>. Thanks\nfor the letter. It was nice.\n",
+      "new": "Hello, <<STR_FREE0>>. Thanks\nfor the letter. It was nice.\n"
+    },
+    {
+      "group": "maila",
+      "index": 1,
+      "label": "",
+      "original": "Hey there. How ya doin'?\nI guess I'm doing OK.\n",
+      "new": "Hey there. How ya doin'?\nI guess I'm doing OK.\n"
+    },
+    {
+      "group": "maila",
+      "index": 2,
+      "label": "",
+      "original": "What's new, <<STR_FREE0>>?\nI'm pretty sleepy, as usual...\n",
+      "new": "What's new, <<STR_FREE0>>?\nI'm pretty sleepy, as usual...\n"
+    },
+    {
+      "group": "maila",
+      "index": 3,
+      "label": "",
+      "original": "Hello. It's me, <<STR_FREE1>>.\nThanks for the letter.\n",
+      "new": "Hello. It's me, <<STR_FREE1>>.\nThanks for the letter.\n"
+    },
+    {
+      "group": "maila",
+      "index": 4,
+      "label": "",
+      "original": "Hey there, <<STR_FREE0>>.\nYou're so nice to me!\n",
+      "new": "Hey there, <<STR_FREE0>>.\nYou're so nice to me!\n"
+    },
+    {
+      "group": "maila",
+      "index": 5,
+      "label": "",
+      "original": "Thanks for your letter! It\nwas actually interesting!\n",
+      "new": "Thanks for your letter! It\nwas actually interesting!\n"
+    },
+    {
+      "group": "maila",
+      "index": 6,
+      "label": "",
+      "original": "Thanks for that letter you\nsent. It really made my day.\n",
+      "new": "Thanks for that letter you\nsent. It really made my day.\n"
+    },
+    {
+      "group": "maila",
+      "index": 7,
+      "label": "",
+      "original": "Hey, <<STR_FREE0>>. That\nwas a great letter. Really.\n",
+      "new": "Hey, <<STR_FREE0>>. That\nwas a great letter. Really.\n"
+    },
+    {
+      "group": "maila",
+      "index": 8,
+      "label": "",
+      "original": "You know, <<STR_FREE0>>...\nYou write interesting letters.\n",
+      "new": "You know, <<STR_FREE0>>...\nYou write interesting letters.\n"
+    },
+    {
+      "group": "maila",
+      "index": 9,
+      "label": "",
+      "original": "Yo, <<STR_FREE0>>! It's me,\n<<STR_FREE1>>. How are you?\n",
+      "new": "Yo, <<STR_FREE0>>! It's me,\n<<STR_FREE1>>. How are you?\n"
+    },
+    {
+      "group": "maila",
+      "index": 10,
+      "label": "",
+      "original": "Well, <<STR_FREE0>>... What's\ngoing on with you lately?\n",
+      "new": "Well, <<STR_FREE0>>... What's\ngoing on with you lately?\n"
+    },
+    {
+      "group": "maila",
+      "index": 11,
+      "label": "",
+      "original": "Thanks for the letter. Here's\nmy reply. Speedy, huh?\n",
+      "new": "Thanks for the letter. Here's\nmy reply. Speedy, huh?\n"
+    },
+    {
+      "group": "maila",
+      "index": 12,
+      "label": "",
+      "original": "Hi, <<STR_FREE0>>. Did\nyou sleep in today? I did.\n",
+      "new": "Hi, <<STR_FREE0>>. Did\nyou sleep in today? I did.\n"
+    },
+    {
+      "group": "maila",
+      "index": 13,
+      "label": "",
+      "original": "I read your letter. It was\n<<STR_FREE12>>.\n",
+      "new": "I read your letter. It was\n<<STR_FREE12>>.\n"
+    },
+    {
+      "group": "maila",
+      "index": 14,
+      "label": "",
+      "original": "Hello, <<STR_FREE0>>. Aren't\nnaps wonderful?\n",
+      "new": "Hello, <<STR_FREE0>>. Aren't\nnaps wonderful?\n"
+    },
+    {
+      "group": "maila",
+      "index": 15,
+      "label": "",
+      "original": "Hi, <<STR_FREE0>>,\nI'm sleepy again today.\n",
+      "new": "Hi, <<STR_FREE0>>,\nI'm sleepy again today.\n"
+    },
+    {
+      "group": "maila",
+      "index": 16,
+      "label": "",
+      "original": "Thanks for the letter\nfrom <<STR_FREE11>>.\n",
+      "new": "Thanks for the letter\nfrom <<STR_FREE11>>.\n"
+    },
+    {
+      "group": "maila",
+      "index": 17,
+      "label": "",
+      "original": "Hey, <<STR_FREE0>>. I always\nlike hearing from you.\n",
+      "new": "Hey, <<STR_FREE0>>. I always\nlike hearing from you.\n"
+    },
+    {
+      "group": "maila",
+      "index": 18,
+      "label": "",
+      "original": "Hey, it's me, <<STR_FREE1>>.\nAre you alive, <<STR_FREE0>>?\n",
+      "new": "Hey, it's me, <<STR_FREE1>>.\nAre you alive, <<STR_FREE0>>?\n"
+    },
+    {
+      "group": "maila",
+      "index": 19,
+      "label": "",
+      "original": "Maybe writing you'll take my\nmind off my rumbly tummy.\n",
+      "new": "Maybe writing you'll take my\nmind off my rumbly tummy.\n"
+    },
+    {
+      "group": "maila",
+      "index": 20,
+      "label": "",
+      "original": "Hi there! It's me, <<STR_FREE1>>.\nIt's nice hearing from you.\n",
+      "new": "Hi there! It's me, <<STR_FREE1>>.\nIt's nice hearing from you.\n"
+    },
+    {
+      "group": "maila",
+      "index": 21,
+      "label": "",
+      "original": "Howdy. I'm so hungry I can't\nthink straight. What a day.\n",
+      "new": "Howdy. I'm so hungry I can't\nthink straight. What a day.\n"
+    },
+    {
+      "group": "maila",
+      "index": 22,
+      "label": "",
+      "original": "I was bored silly until\nI got your letter. Thanks!\n",
+      "new": "I was bored silly until\nI got your letter. Thanks!\n"
+    },
+    {
+      "group": "maila",
+      "index": 23,
+      "label": "",
+      "original": "You know what? Your letters\nare always <<STR_FREE12>>!\n",
+      "new": "You know what? Your letters\nare always <<STR_FREE12>>!\n"
+    },
+    {
+      "group": "maila",
+      "index": 24,
+      "label": "",
+      "original": "Anything interesting going\non? I'm too excited to sleep.\n",
+      "new": "Anything interesting going\non? I'm too excited to sleep.\n"
+    },
+    {
+      "group": "maila",
+      "index": 25,
+      "label": "",
+      "original": "Thanks for the letter.\nIt's me, <<STR_FREE1>>.\n",
+      "new": "Thanks for the letter.\nIt's me, <<STR_FREE1>>.\n"
+    },
+    {
+      "group": "maila",
+      "index": 26,
+      "label": "",
+      "original": "<<STR_FREE0>>!\nHave you eaten lunch yet?\n",
+      "new": "<<STR_FREE0>>!\nHave you eaten lunch yet?\n"
+    },
+    {
+      "group": "maila",
+      "index": 27,
+      "label": "",
+      "original": "Thanks for always writing\nsuch <<STR_FREE11>> letters.\n",
+      "new": "Thanks for always writing\nsuch <<STR_FREE11>> letters.\n"
+    },
+    {
+      "group": "maila",
+      "index": 28,
+      "label": "",
+      "original": "It's me, <<STR_FREE1>>. You know,\nthe guy who hates pants.\n",
+      "new": "It's me, <<STR_FREE1>>. You know,\nthe guy who hates pants.\n"
+    },
+    {
+      "group": "maila",
+      "index": 29,
+      "label": "",
+      "original": "I thought I'd write to you\nbefore I ate lunch.\n",
+      "new": "I thought I'd write to you\nbefore I ate lunch.\n"
+    },
+    {
+      "group": "maila",
+      "index": 30,
+      "label": "",
+      "original": "Hey there. How's the hole\ndigging coming along?\n",
+      "new": "Hey there. How's the hole\ndigging coming along?\n"
+    },
+    {
+      "group": "maila",
+      "index": 31,
+      "label": "",
+      "original": "<<STR_FREE0>>! You ever dig\nup Gyroids after the rain?\n",
+      "new": "<<STR_FREE0>>! You ever dig\nup Gyroids after the rain?\n"
+    },
+    {
+      "group": "maila",
+      "index": 32,
+      "label": "",
+      "original": "Hello, <<STR_FREE0>>. How\nare you? I got your letter.\n",
+      "new": "Hello, <<STR_FREE0>>. How\nare you? I got your letter.\n"
+    },
+    {
+      "group": "maila",
+      "index": 33,
+      "label": "",
+      "original": "Hello. How are you?\nI am doing well.\n",
+      "new": "Hello. How are you?\nI am doing well.\n"
+    },
+    {
+      "group": "maila",
+      "index": 34,
+      "label": "",
+      "original": "Hello. Are you doing well?\nI'm as right as rain.\n",
+      "new": "Hello. Are you doing well?\nI'm as right as rain.\n"
+    },
+    {
+      "group": "maila",
+      "index": 35,
+      "label": "",
+      "original": "Hello! It's me, <<STR_FREE1>>.\nThanks for your letter.\n",
+      "new": "Hello! It's me, <<STR_FREE1>>.\nThanks for your letter.\n"
+    },
+    {
+      "group": "maila",
+      "index": 36,
+      "label": "",
+      "original": "Hello, <<STR_FREE0>>.\nThanks for writing.\n",
+      "new": "Hello, <<STR_FREE0>>.\nThanks for writing.\n"
+    },
+    {
+      "group": "maila",
+      "index": 37,
+      "label": "",
+      "original": "Thanks for that funny\nletter you sent me!\n",
+      "new": "Thanks for that funny\nletter you sent me!\n"
+    },
+    {
+      "group": "maila",
+      "index": 38,
+      "label": "",
+      "original": "Thanks for your letter\nof the other day.\n",
+      "new": "Thanks for your letter\nof the other day.\n"
+    },
+    {
+      "group": "maila",
+      "index": 39,
+      "label": "",
+      "original": "Hi, <<STR_FREE0>>. I\nI loved your letter. Thanks.\n",
+      "new": "Hi, <<STR_FREE0>>. I\nI loved your letter. Thanks.\n"
+    },
+    {
+      "group": "maila",
+      "index": 40,
+      "label": "",
+      "original": "Hi, <<STR_FREE0>>! I always\nlove hearing from you.\n",
+      "new": "Hi, <<STR_FREE0>>! I always\nlove hearing from you.\n"
+    },
+    {
+      "group": "maila",
+      "index": 41,
+      "label": "",
+      "original": "How are you? I myself have\nnothing to complain about.\n",
+      "new": "How are you? I myself have\nnothing to complain about.\n"
+    },
+    {
+      "group": "maila",
+      "index": 42,
+      "label": "",
+      "original": "How's it going? Did you do\nanything exciting today?\n",
+      "new": "How's it going? Did you do\nanything exciting today?\n"
+    },
+    {
+      "group": "maila",
+      "index": 43,
+      "label": "",
+      "original": "Is it odd to ask how you're\ndoing when I see you daily?\n",
+      "new": "Is it odd to ask how you're\ndoing when I see you daily?\n"
+    },
+    {
+      "group": "maila",
+      "index": 44,
+      "label": "",
+      "original": "Hello. I hope you're having\nan exciting day, today!\n",
+      "new": "Hello. I hope you're having\nan exciting day, today!\n"
+    },
+    {
+      "group": "maila",
+      "index": 45,
+      "label": "",
+      "original": "I read your last letter. It\nwas a joy, as always.\n",
+      "new": "I read your last letter. It\nwas a joy, as always.\n"
+    },
+    {
+      "group": "maila",
+      "index": 46,
+      "label": "",
+      "original": "Hello, <<STR_FREE0>>. Did\nyou sleep well last night?\n",
+      "new": "Hello, <<STR_FREE0>>. Did\nyou sleep well last night?\n"
+    },
+    {
+      "group": "maila",
+      "index": 47,
+      "label": "",
+      "original": "Good day, <<STR_FREE0>>.\nAre you eating properly?\n",
+      "new": "Good day, <<STR_FREE0>>.\nAre you eating properly?\n"
+    },
+    {
+      "group": "maila",
+      "index": 48,
+      "label": "",
+      "original": "Thanks for the letter. I was\nreally tickled to read it.\n",
+      "new": "Thanks for the letter. I was\nreally tickled to read it.\n"
+    },
+    {
+      "group": "maila",
+      "index": 49,
+      "label": "",
+      "original": "I had really been looking\nforward to your letter.\n",
+      "new": "I had really been looking\nforward to your letter.\n"
+    },
+    {
+      "group": "maila",
+      "index": 50,
+      "label": "",
+      "original": "Hi! It's me, <<STR_FREE1>>.\nHow are you these days?\n",
+      "new": "Hi! It's me, <<STR_FREE1>>.\nHow are you these days?\n"
+    },
+    {
+      "group": "maila",
+      "index": 51,
+      "label": "",
+      "original": "Hello. I think I've caught a\nbit of a cold. Have you?\n",
+      "new": "Hello. I think I've caught a\nbit of a cold. Have you?\n"
+    },
+    {
+      "group": "maila",
+      "index": 52,
+      "label": "",
+      "original": "Are you doing well? I have\na cold I just can't kick.\n",
+      "new": "Are you doing well? I have\na cold I just can't kick.\n"
+    },
+    {
+      "group": "maila",
+      "index": 53,
+      "label": "",
+      "original": "Hello! I'm full of unbridled\nenergy today! How are you?\n",
+      "new": "Hello! I'm full of unbridled\nenergy today! How are you?\n"
+    },
+    {
+      "group": "maila",
+      "index": 54,
+      "label": "",
+      "original": "I was a bit bored, so your\nletter was welcome relief.\n",
+      "new": "I was a bit bored, so your\nletter was welcome relief.\n"
+    },
+    {
+      "group": "maila",
+      "index": 55,
+      "label": "",
+      "original": "Hi! Did you know I just\nlove hearing from you?\n",
+      "new": "Hi! Did you know I just\nlove hearing from you?\n"
+    },
+    {
+      "group": "maila",
+      "index": 56,
+      "label": "",
+      "original": "Hi there! What's new with\nyou? You have to tell me!\n",
+      "new": "Hi there! What's new with\nyou? You have to tell me!\n"
+    },
+    {
+      "group": "maila",
+      "index": 57,
+      "label": "",
+      "original": "It's me, <<STR_FREE1>>.\nThanks for thinking of me.\n",
+      "new": "It's me, <<STR_FREE1>>.\nThanks for thinking of me.\n"
+    },
+    {
+      "group": "maila",
+      "index": 58,
+      "label": "",
+      "original": "Thank you so much for your\nletter. It was very sweet.\n",
+      "new": "Thank you so much for your\nletter. It was very sweet.\n"
+    },
+    {
+      "group": "maila",
+      "index": 59,
+      "label": "",
+      "original": "Your letters are always so\nmuch fun. Thanks a bundle!\n",
+      "new": "Your letters are always so\nmuch fun. Thanks a bundle!\n"
+    },
+    {
+      "group": "maila",
+      "index": 60,
+      "label": "",
+      "original": "I enjoy talking with you,\nbut letters are nice, too.\n",
+      "new": "I enjoy talking with you,\nbut letters are nice, too.\n"
+    },
+    {
+      "group": "maila",
+      "index": 61,
+      "label": "",
+      "original": "Hi. Did you know the early\nbird catches the worm?\n",
+      "new": "Hi. Did you know the early\nbird catches the worm?\n"
+    },
+    {
+      "group": "maila",
+      "index": 62,
+      "label": "",
+      "original": "Hello. Have you finished\npaying off your house?\n",
+      "new": "Hello. Have you finished\npaying off your house?\n"
+    },
+    {
+      "group": "maila",
+      "index": 63,
+      "label": "",
+      "original": "Hello, <<STR_FREE0>>. Tell\nme... How are things?\n",
+      "new": "Hello, <<STR_FREE0>>. Tell\nme... How are things?\n"
+    },
+    {
+      "group": "maila",
+      "index": 64,
+      "label": "",
+      "original": "Hi, <<STR_FREE0>>!!! Your\nletter was so cute!\n",
+      "new": "Hi, <<STR_FREE0>>!!! Your\nletter was so cute!\n"
+    },
+    {
+      "group": "maila",
+      "index": 65,
+      "label": "",
+      "original": "Hi! How are you? I'm\nspectacular, as usual!\n",
+      "new": "Hi! How are you? I'm\nspectacular, as usual!\n"
+    },
+    {
+      "group": "maila",
+      "index": 66,
+      "label": "",
+      "original": "Hey, <<STR_FREE0>>! How's it\ngoing? I'm just super!\n",
+      "new": "Hey, <<STR_FREE0>>! How's it\ngoing? I'm just super!\n"
+    },
+    {
+      "group": "maila",
+      "index": 67,
+      "label": "",
+      "original": "Hi, <<STR_FREE0>>!\nThanks for your little letter.\n",
+      "new": "Hi, <<STR_FREE0>>!\nThanks for your little letter.\n"
+    },
+    {
+      "group": "maila",
+      "index": 68,
+      "label": "",
+      "original": "Ciao, <<STR_FREE0>>. Thanks\nfor your letter!\n",
+      "new": "Ciao, <<STR_FREE0>>. Thanks\nfor your letter!\n"
+    },
+    {
+      "group": "maila",
+      "index": 69,
+      "label": "",
+      "original": "Thanks for your letter!\nIt was just fab!\n",
+      "new": "Thanks for your letter!\nIt was just fab!\n"
+    },
+    {
+      "group": "maila",
+      "index": 70,
+      "label": "",
+      "original": "Thanks so much for that\nletter you sent me!\n",
+      "new": "Thanks so much for that\nletter you sent me!\n"
+    },
+    {
+      "group": "maila",
+      "index": 71,
+      "label": "",
+      "original": "Howdy, <<STR_FREE0>>!\nThanks oodles for the note!\n",
+      "new": "Howdy, <<STR_FREE0>>!\nThanks oodles for the note!\n"
+    },
+    {
+      "group": "maila",
+      "index": 72,
+      "label": "",
+      "original": "Hey, <<STR_FREE0>>! I\njust love hearing from you!\n",
+      "new": "Hey, <<STR_FREE0>>! I\njust love hearing from you!\n"
+    },
+    {
+      "group": "maila",
+      "index": 73,
+      "label": "",
+      "original": "Hey, <<STR_FREE0>>!\nIt's me, <<STR_FREE1>>!\n",
+      "new": "Hey, <<STR_FREE0>>!\nIt's me, <<STR_FREE1>>!\n"
+    },
+    {
+      "group": "maila",
+      "index": 74,
+      "label": "",
+      "original": "Hey, <<STR_FREE0>>. What's\nup? Heard any new gossip?\n",
+      "new": "Hey, <<STR_FREE0>>. What's\nup? Heard any new gossip?\n"
+    },
+    {
+      "group": "maila",
+      "index": 75,
+      "label": "",
+      "original": "Thanks for writing! I had\nto write you right back!\n",
+      "new": "Thanks for writing! I had\nto write you right back!\n"
+    },
+    {
+      "group": "maila",
+      "index": 76,
+      "label": "",
+      "original": "Hi there, <<STR_FREE0>>.\nHave you been staying cool?\n",
+      "new": "Hi there, <<STR_FREE0>>.\nHave you been staying cool?\n"
+    },
+    {
+      "group": "maila",
+      "index": 77,
+      "label": "",
+      "original": "I read your letter... It was\n<<STR_FREE9>>!\n",
+      "new": "I read your letter... It was\n<<STR_FREE9>>!\n"
+    },
+    {
+      "group": "maila",
+      "index": 78,
+      "label": "",
+      "original": "What's up? Are you an early\nriser? I hate mornings!\n",
+      "new": "What's up? Are you an early\nriser? I hate mornings!\n"
+    },
+    {
+      "group": "maila",
+      "index": 79,
+      "label": "",
+      "original": "Hiya! When do you go to\nbed? I'm a night owl!\n",
+      "new": "Hiya! When do you go to\nbed? I'm a night owl!\n"
+    },
+    {
+      "group": "maila",
+      "index": 80,
+      "label": "",
+      "original": "Thanks for the crazy letter!\nIt had me in tears!\n",
+      "new": "Thanks for the crazy letter!\nIt had me in tears!\n"
+    },
+    {
+      "group": "maila",
+      "index": 81,
+      "label": "",
+      "original": "<<STR_FREE0>>, my friend! I\nreally enjoy your letters.\n",
+      "new": "<<STR_FREE0>>, my friend! I\nreally enjoy your letters.\n"
+    },
+    {
+      "group": "maila",
+      "index": 82,
+      "label": "",
+      "original": "Bonjour! (That's French!)\nIt's me, <<STR_FREE1>>!\n",
+      "new": "Bonjour! (That's French!)\nIt's me, <<STR_FREE1>>!\n"
+    },
+    {
+      "group": "maila",
+      "index": 83,
+      "label": "",
+      "original": "I'm a bit tired, but I'm\nputting on a happy face!\n",
+      "new": "I'm a bit tired, but I'm\nputting on a happy face!\n"
+    },
+    {
+      "group": "maila",
+      "index": 84,
+      "label": "",
+      "original": "Hi! It's me, <<STR_FREE1>>.\nThanks for the letter!\n",
+      "new": "Hi! It's me, <<STR_FREE1>>.\nThanks for the letter!\n"
+    },
+    {
+      "group": "maila",
+      "index": 85,
+      "label": "",
+      "original": "Hi. I'm a bit sleepy today. I\nneed to get to bed earlier.\n",
+      "new": "Hi. I'm a bit sleepy today. I\nneed to get to bed earlier.\n"
+    },
+    {
+      "group": "maila",
+      "index": 86,
+      "label": "",
+      "original": "Your letter saved me from\na horrendously boring day.\n",
+      "new": "Your letter saved me from\na horrendously boring day.\n"
+    },
+    {
+      "group": "maila",
+      "index": 87,
+      "label": "",
+      "original": "You know, <<STR_FREE0>>, you\nwrite fascinating letters!\n",
+      "new": "You know, <<STR_FREE0>>, you\nwrite fascinating letters!\n"
+    },
+    {
+      "group": "maila",
+      "index": 88,
+      "label": "",
+      "original": "Hey, how's tricks? Any\njuicy news to report?\n",
+      "new": "Hey, how's tricks? Any\njuicy news to report?\n"
+    },
+    {
+      "group": "maila",
+      "index": 89,
+      "label": "",
+      "original": "Thanks for the letter! If you\nhadn't guess, it's me!\n",
+      "new": "Thanks for the letter! If you\nhadn't guess, it's me!\n"
+    },
+    {
+      "group": "maila",
+      "index": 90,
+      "label": "",
+      "original": "<<STR_FREE0>>! What have\nyou been up to lately?\n",
+      "new": "<<STR_FREE0>>! What have\nyou been up to lately?\n"
+    },
+    {
+      "group": "maila",
+      "index": 91,
+      "label": "",
+      "original": "Your letters are alway so\ncool! Thanks oodles!\n",
+      "new": "Your letters are alway so\ncool! Thanks oodles!\n"
+    },
+    {
+      "group": "maila",
+      "index": 92,
+      "label": "",
+      "original": "Chatting is fun, but writing\nletters is a blast, too!\n",
+      "new": "Chatting is fun, but writing\nletters is a blast, too!\n"
+    },
+    {
+      "group": "maila",
+      "index": 93,
+      "label": "",
+      "original": "You're letters are always so\nweird! Thanks tons!\n",
+      "new": "You're letters are always so\nweird! Thanks tons!\n"
+    },
+    {
+      "group": "maila",
+      "index": 94,
+      "label": "",
+      "original": "Howdy. How's your interior\ndecorating coming along?\n",
+      "new": "Howdy. How's your interior\ndecorating coming along?\n"
+    },
+    {
+      "group": "maila",
+      "index": 95,
+      "label": "",
+      "original": "Hey, <<STR_FREE0>>!\nAnything new?\n",
+      "new": "Hey, <<STR_FREE0>>!\nAnything new?\n"
+    },
+    {
+      "group": "maila",
+      "index": 96,
+      "label": "",
+      "original": "Duuude! <<STR_FREE0>>!\nI got your letter.\n",
+      "new": "Duuude! <<STR_FREE0>>!\nI got your letter.\n"
+    },
+    {
+      "group": "maila",
+      "index": 97,
+      "label": "",
+      "original": "Hey! How you doing?\nI'm as fit as a fiddle!\n",
+      "new": "Hey! How you doing?\nI'm as fit as a fiddle!\n"
+    },
+    {
+      "group": "maila",
+      "index": 98,
+      "label": "",
+      "original": "Hey, <<STR_FREE0>>. Sup? I'm\nso happy I could burst!\n",
+      "new": "Hey, <<STR_FREE0>>. Sup? I'm\nso happy I could burst!\n"
+    },
+    {
+      "group": "maila",
+      "index": 99,
+      "label": "",
+      "original": "Hey, it's me, <<STR_FREE1>>!\nThanks for the letter.\n",
+      "new": "Hey, it's me, <<STR_FREE1>>!\nThanks for the letter.\n"
+    },
+    {
+      "group": "maila",
+      "index": 100,
+      "label": "",
+      "original": "Howdy, <<STR_FREE0>>! I'm\nlooking out for you. You dig?\n",
+      "new": "Howdy, <<STR_FREE0>>! I'm\nlooking out for you. You dig?\n"
+    },
+    {
+      "group": "maila",
+      "index": 101,
+      "label": "",
+      "original": "Heck of a letter you sent! It\ncracked me up! Ha ha ha!\n",
+      "new": "Heck of a letter you sent! It\ncracked me up! Ha ha ha!\n"
+    },
+    {
+      "group": "maila",
+      "index": 102,
+      "label": "",
+      "original": "Nice letter you sent me.\nYou made my day. Thanks.\n",
+      "new": "Nice letter you sent me.\nYou made my day. Thanks.\n"
+    },
+    {
+      "group": "maila",
+      "index": 103,
+      "label": "",
+      "original": "Hey there, <<STR_FREE0>>!\nI checked out your letter.\n",
+      "new": "Hey there, <<STR_FREE0>>!\nI checked out your letter.\n"
+    },
+    {
+      "group": "maila",
+      "index": 104,
+      "label": "",
+      "original": "Hey, <<STR_FREE0>>! It's not\nbad hearing from you.\n",
+      "new": "Hey, <<STR_FREE0>>! It's not\nbad hearing from you.\n"
+    },
+    {
+      "group": "maila",
+      "index": 105,
+      "label": "",
+      "original": "Yo, <<STR_FREE0>>!\nIt's me, <<STR_FREE1>>!\n",
+      "new": "Yo, <<STR_FREE0>>!\nIt's me, <<STR_FREE1>>!\n"
+    },
+    {
+      "group": "maila",
+      "index": 106,
+      "label": "",
+      "original": "So, <<STR_FREE0>>,\nanything new?\n",
+      "new": "So, <<STR_FREE0>>,\nanything new?\n"
+    },
+    {
+      "group": "maila",
+      "index": 107,
+      "label": "",
+      "original": "Thanks for the letter! I had\nto reply right away!\n",
+      "new": "Thanks for the letter! I had\nto reply right away!\n"
+    },
+    {
+      "group": "maila",
+      "index": 108,
+      "label": "",
+      "original": "What's up, <<STR_FREE0>>?\nYou enjoying yourself?\n",
+      "new": "What's up, <<STR_FREE0>>?\nYou enjoying yourself?\n"
+    },
+    {
+      "group": "maila",
+      "index": 109,
+      "label": "",
+      "original": "I read your letter, dude!\nWay <<STR_FREE9>>!\n",
+      "new": "I read your letter, dude!\nWay <<STR_FREE9>>!\n"
+    },
+    {
+      "group": "maila",
+      "index": 110,
+      "label": "",
+      "original": "How's it going? As always,\nyour writing's a mess.\n",
+      "new": "How's it going? As always,\nyour writing's a mess.\n"
+    },
+    {
+      "group": "maila",
+      "index": 111,
+      "label": "",
+      "original": "Top of the morning to you!\nI thought I'd reply to you.\n",
+      "new": "Top of the morning to you!\nI thought I'd reply to you.\n"
+    },
+    {
+      "group": "maila",
+      "index": 112,
+      "label": "",
+      "original": "Thanks for the letter. It was\n<<STR_FREE12>>.\n",
+      "new": "Thanks for the letter. It was\n<<STR_FREE12>>.\n"
+    },
+    {
+      "group": "maila",
+      "index": 113,
+      "label": "",
+      "original": "Your letters are a riot! I\nalways laugh my pants off!\n",
+      "new": "Your letters are a riot! I\nalways laugh my pants off!\n"
+    },
+    {
+      "group": "maila",
+      "index": 114,
+      "label": "",
+      "original": "Hey! It's me, <<STR_FREE1>>!\nDid you get my letter?\n",
+      "new": "Hey! It's me, <<STR_FREE1>>!\nDid you get my letter?\n"
+    },
+    {
+      "group": "maila",
+      "index": 115,
+      "label": "",
+      "original": "I'm totally tired, but I still\ntook the time to write!\n",
+      "new": "I'm totally tired, but I still\ntook the time to write!\n"
+    },
+    {
+      "group": "maila",
+      "index": 116,
+      "label": "",
+      "original": "How's it going, buddy? It's\nme, your pal <<STR_FREE1>>!\n",
+      "new": "How's it going, buddy? It's\nme, your pal <<STR_FREE1>>!\n"
+    },
+    {
+      "group": "maila",
+      "index": 117,
+      "label": "",
+      "original": "What's up, <<STR_FREE0>>?\nMaking any new friends?\n",
+      "new": "What's up, <<STR_FREE0>>?\nMaking any new friends?\n"
+    },
+    {
+      "group": "maila",
+      "index": 118,
+      "label": "",
+      "original": "I was having a lousy day,\nbut then I got your letter!\n",
+      "new": "I was having a lousy day,\nbut then I got your letter!\n"
+    },
+    {
+      "group": "maila",
+      "index": 119,
+      "label": "",
+      "original": "Your letters are always\nso <<STR_FREE13>>!\n",
+      "new": "Your letters are always\nso <<STR_FREE13>>!\n"
+    },
+    {
+      "group": "maila",
+      "index": 120,
+      "label": "",
+      "original": "Have you been exercising?\nBeing lazy makes you fat!\n",
+      "new": "Have you been exercising?\nBeing lazy makes you fat!\n"
+    },
+    {
+      "group": "maila",
+      "index": 121,
+      "label": "",
+      "original": "C'est moi, <<STR_FREE1>>.\nMy French is good, oui?\n",
+      "new": "C'est moi, <<STR_FREE1>>.\nMy French is good, oui?\n"
+    },
+    {
+      "group": "maila",
+      "index": 122,
+      "label": "",
+      "original": "Hey! Have you washed\nbehind your ears lately?\n",
+      "new": "Hey! Have you washed\nbehind your ears lately?\n"
+    },
+    {
+      "group": "maila",
+      "index": 123,
+      "label": "",
+      "original": "Thanks for the letter. It was\n<<STR_FREE9>>.\n",
+      "new": "Thanks for the letter. It was\n<<STR_FREE9>>.\n"
+    },
+    {
+      "group": "maila",
+      "index": 124,
+      "label": "",
+      "original": "Yo! It's me, <<STR_FREE1>>!\nThanks for writing.\n",
+      "new": "Yo! It's me, <<STR_FREE1>>!\nThanks for writing.\n"
+    },
+    {
+      "group": "maila",
+      "index": 125,
+      "label": "",
+      "original": "Howdy, <<STR_FREE0>>!\nTalk to you later! Heh heh!\n",
+      "new": "Howdy, <<STR_FREE0>>!\nTalk to you later! Heh heh!\n"
+    },
+    {
+      "group": "maila",
+      "index": 126,
+      "label": "",
+      "original": "Hey! How's the fishing? I'm\ncatching 'em like crazy!\n",
+      "new": "Hey! How's the fishing? I'm\ncatching 'em like crazy!\n"
+    },
+    {
+      "group": "maila",
+      "index": 127,
+      "label": "",
+      "original": "Yep, it's me, and I'm writing\nyou back! Aren't you lucky?\n",
+      "new": "Yep, it's me, and I'm writing\nyou back! Aren't you lucky?\n"
+    },
+    {
+      "group": "maila",
+      "index": 128,
+      "label": "",
+      "original": "Yeah, yeah, <<STR_FREE0>>,\nI got your letter. Great.\n",
+      "new": "Yeah, yeah, <<STR_FREE0>>,\nI got your letter. Great.\n"
+    },
+    {
+      "group": "maila",
+      "index": 129,
+      "label": "",
+      "original": "Hello. How are you?\nI'm OK, I guess.\n",
+      "new": "Hello. How are you?\nI'm OK, I guess.\n"
+    },
+    {
+      "group": "maila",
+      "index": 130,
+      "label": "",
+      "original": "Are you OK, <<STR_FREE0>>?\nI'm as good as I get.\n",
+      "new": "Are you OK, <<STR_FREE0>>?\nI'm as good as I get.\n"
+    },
+    {
+      "group": "maila",
+      "index": 131,
+      "label": "",
+      "original": "<<STR_FREE1>> here. Thanks\nfor the letter.\n",
+      "new": "<<STR_FREE1>> here. Thanks\nfor the letter.\n"
+    },
+    {
+      "group": "maila",
+      "index": 132,
+      "label": "",
+      "original": "Umm, hi. Thanks for always\nbeing so darn...nice.\n",
+      "new": "Umm, hi. Thanks for always\nbeing so darn...nice.\n"
+    },
+    {
+      "group": "maila",
+      "index": 133,
+      "label": "",
+      "original": "Nice letter. It cracked me\nup. Hurr hurr hurr.\n",
+      "new": "Nice letter. It cracked me\nup. Hurr hurr hurr.\n"
+    },
+    {
+      "group": "maila",
+      "index": 134,
+      "label": "",
+      "original": "It was a pleasure hearing\nfrom you the other day.\n",
+      "new": "It was a pleasure hearing\nfrom you the other day.\n"
+    },
+    {
+      "group": "maila",
+      "index": 135,
+      "label": "",
+      "original": "Say, <<STR_FREE0>>, I read\nyour letter.\n",
+      "new": "Say, <<STR_FREE0>>, I read\nyour letter.\n"
+    },
+    {
+      "group": "maila",
+      "index": 136,
+      "label": "",
+      "original": "It's strange, but I actually\nlook forward to your letters.\n",
+      "new": "It's strange, but I actually\nlook forward to your letters.\n"
+    },
+    {
+      "group": "maila",
+      "index": 137,
+      "label": "",
+      "original": "Well, hello, <<STR_FREE0>>!\nIt's ME! <<STR_FREE1>>!\n",
+      "new": "Well, hello, <<STR_FREE0>>!\nIt's ME! <<STR_FREE1>>!\n"
+    },
+    {
+      "group": "maila",
+      "index": 138,
+      "label": "",
+      "original": "What's new? Huh? Hey!\nI asked you a question!\n",
+      "new": "What's new? Huh? Hey!\nI asked you a question!\n"
+    },
+    {
+      "group": "maila",
+      "index": 139,
+      "label": "",
+      "original": "Geez, why'd you have to\nwrite me? I hate writing...\n",
+      "new": "Geez, why'd you have to\nwrite me? I hate writing...\n"
+    },
+    {
+      "group": "maila",
+      "index": 140,
+      "label": "",
+      "original": "Are you still with us? I\njust thought I'd check.\n",
+      "new": "Are you still with us? I\njust thought I'd check.\n"
+    },
+    {
+      "group": "maila",
+      "index": 141,
+      "label": "",
+      "original": "I read your letter. It was\n<<STR_FREE9>>.\n",
+      "new": "I read your letter. It was\n<<STR_FREE9>>.\n"
+    },
+    {
+      "group": "maila",
+      "index": 142,
+      "label": "",
+      "original": "Hey! Your letter rocked. Your\nwit is incredible!\n",
+      "new": "Hey! Your letter rocked. Your\nwit is incredible!\n"
+    },
+    {
+      "group": "maila",
+      "index": 143,
+      "label": "",
+      "original": "Stop writing to me. Letters\nare nothing but trouble!\n",
+      "new": "Stop writing to me. Letters\nare nothing but trouble!\n"
+    },
+    {
+      "group": "maila",
+      "index": 144,
+      "label": "",
+      "original": "Just to let you know, I save\nall the letters you send me.\n",
+      "new": "Just to let you know, I save\nall the letters you send me.\n"
+    },
+    {
+      "group": "maila",
+      "index": 145,
+      "label": "",
+      "original": "Your letters are funny, but\nare they supposed to be?\n",
+      "new": "Your letters are funny, but\nare they supposed to be?\n"
+    },
+    {
+      "group": "maila",
+      "index": 146,
+      "label": "",
+      "original": "It's <<STR_FREE1>>. You better\nread this, <<STR_FREE0>>!\n",
+      "new": "It's <<STR_FREE1>>. You better\nread this, <<STR_FREE0>>!\n"
+    },
+    {
+      "group": "maila",
+      "index": 147,
+      "label": "",
+      "original": "Hey! Why are you in such\na good mood all the time?\n",
+      "new": "Hey! Why are you in such\na good mood all the time?\n"
+    },
+    {
+      "group": "maila",
+      "index": 148,
+      "label": "",
+      "original": "Yo! <<STR_FREE0>>! What\nhave you been up to?\n",
+      "new": "Yo! <<STR_FREE0>>! What\nhave you been up to?\n"
+    },
+    {
+      "group": "maila",
+      "index": 149,
+      "label": "",
+      "original": "Hey! You should take the\ntrain out of town sometime.\n",
+      "new": "Hey! You should take the\ntrain out of town sometime.\n"
+    },
+    {
+      "group": "maila",
+      "index": 150,
+      "label": "",
+      "original": "The rules state that you\nmust reply to every letter.\n",
+      "new": "The rules state that you\nmust reply to every letter.\n"
+    },
+    {
+      "group": "maila",
+      "index": 151,
+      "label": "",
+      "original": "It's me. You were waiting\nto hear from me, eh?\n",
+      "new": "It's me. You were waiting\nto hear from me, eh?\n"
+    },
+    {
+      "group": "maila",
+      "index": 152,
+      "label": "",
+      "original": "I appreciated your letter. It\nsaved me from boredom.\n",
+      "new": "I appreciated your letter. It\nsaved me from boredom.\n"
+    },
+    {
+      "group": "maila",
+      "index": 153,
+      "label": "",
+      "original": "Sorry my reply's so late. I've\nbeen busy, you know?\n",
+      "new": "Sorry my reply's so late. I've\nbeen busy, you know?\n"
+    },
+    {
+      "group": "maila",
+      "index": 154,
+      "label": "",
+      "original": "What's going on? Have you\nbeen working a lot?\n",
+      "new": "What's going on? Have you\nbeen working a lot?\n"
+    },
+    {
+      "group": "maila",
+      "index": 155,
+      "label": "",
+      "original": "GREAT letter. It was a bit...\n<<STR_FREE9>>.\n",
+      "new": "GREAT letter. It was a bit...\n<<STR_FREE9>>.\n"
+    },
+    {
+      "group": "maila",
+      "index": 156,
+      "label": "",
+      "original": "What's new? Are you excited\nto hear from me? I hope so.\n",
+      "new": "What's new? Are you excited\nto hear from me? I hope so.\n"
+    },
+    {
+      "group": "maila",
+      "index": 157,
+      "label": "",
+      "original": "You keeping busy? Me, too.\nLife's rough, isn't it?\n",
+      "new": "You keeping busy? Me, too.\nLife's rough, isn't it?\n"
+    },
+    {
+      "group": "maila",
+      "index": 158,
+      "label": "",
+      "original": "Are you sleeping well? Who,\nme? Don't worry about me!\n",
+      "new": "Are you sleeping well? Who,\nme? Don't worry about me!\n"
+    },
+    {
+      "group": "maila",
+      "index": 159,
+      "label": "",
+      "original": "Getting a letter from me\nmust make your day, right?\n",
+      "new": "Getting a letter from me\nmust make your day, right?\n"
+    },
+    {
+      "group": "maila",
+      "index": 160,
+      "label": "",
+      "original": "Good day, <<STR_FREE0>>.\nI perused your letter.\n",
+      "new": "Good day, <<STR_FREE0>>.\nI perused your letter.\n"
+    },
+    {
+      "group": "maila",
+      "index": 161,
+      "label": "",
+      "original": "Greetings. How are you\ntoday? I'm as good as ever.\n",
+      "new": "Greetings. How are you\ntoday? I'm as good as ever.\n"
+    },
+    {
+      "group": "maila",
+      "index": 162,
+      "label": "",
+      "original": "How are you, <<STR_FREE0>>?\nI'm the same as always.\n",
+      "new": "How are you, <<STR_FREE0>>?\nI'm the same as always.\n"
+    },
+    {
+      "group": "maila",
+      "index": 163,
+      "label": "",
+      "original": "Hello. Thank you for that\nquaint little letter of yours.\n",
+      "new": "Hello. Thank you for that\nquaint little letter of yours.\n"
+    },
+    {
+      "group": "maila",
+      "index": 164,
+      "label": "",
+      "original": "I got your letter. It was\nactually almost humorous.\n",
+      "new": "I got your letter. It was\nactually almost humorous.\n"
+    },
+    {
+      "group": "maila",
+      "index": 165,
+      "label": "",
+      "original": "Your letter was amusing.\nThank you for the laughs.\n",
+      "new": "Your letter was amusing.\nThank you for the laughs.\n"
+    },
+    {
+      "group": "maila",
+      "index": 166,
+      "label": "",
+      "original": "I must thank you for that\nletter of the other day.\n",
+      "new": "I must thank you for that\nletter of the other day.\n"
+    },
+    {
+      "group": "maila",
+      "index": 167,
+      "label": "",
+      "original": "Your letter was laugh-out-\nloud funny. Thank you.\n",
+      "new": "Your letter was laugh-out-\nloud funny. Thank you.\n"
+    },
+    {
+      "group": "maila",
+      "index": 168,
+      "label": "",
+      "original": "Your letters are so... How\ndo I say this? ...Unique?\n",
+      "new": "Your letters are so... How\ndo I say this? ...Unique?\n"
+    },
+    {
+      "group": "maila",
+      "index": 169,
+      "label": "",
+      "original": "Good day, <<STR_FREE0>>.\nIt is I, <<STR_FREE1>>.\n",
+      "new": "Good day, <<STR_FREE0>>.\nIt is I, <<STR_FREE1>>.\n"
+    },
+    {
+      "group": "maila",
+      "index": 170,
+      "label": "",
+      "original": "So tell me, <<STR_FREE0>>...\nWhat's new with you?\n",
+      "new": "So tell me, <<STR_FREE0>>...\nWhat's new with you?\n"
+    },
+    {
+      "group": "maila",
+      "index": 171,
+      "label": "",
+      "original": "Thanks SO much for writing.\nI decided to reply right away.\n",
+      "new": "Thanks SO much for writing.\nI decided to reply right away.\n"
+    },
+    {
+      "group": "maila",
+      "index": 172,
+      "label": "",
+      "original": "Hello <<STR_FREE1>>. You're as\ncarefree as ever, I see.\n",
+      "new": "Hello <<STR_FREE1>>. You're as\ncarefree as ever, I see.\n"
+    },
+    {
+      "group": "maila",
+      "index": 173,
+      "label": "",
+      "original": "I read your latest missive.\nIt was quite <<STR_FREE9>>!\n",
+      "new": "I read your latest missive.\nIt was quite <<STR_FREE9>>!\n"
+    },
+    {
+      "group": "maila",
+      "index": 174,
+      "label": "",
+      "original": "Hello there, <<STR_FREE0>>.\nAre you dieting?\n",
+      "new": "Hello there, <<STR_FREE0>>.\nAre you dieting?\n"
+    },
+    {
+      "group": "maila",
+      "index": 175,
+      "label": "",
+      "original": "So tell me, <<STR_FREE0>>,\nhow have you been, my dear?\n",
+      "new": "So tell me, <<STR_FREE0>>,\nhow have you been, my dear?\n"
+    },
+    {
+      "group": "maila",
+      "index": 176,
+      "label": "",
+      "original": "Your witty letter had me in\nstitches. It rescued my day.\n",
+      "new": "Your witty letter had me in\nstitches. It rescued my day.\n"
+    },
+    {
+      "group": "maila",
+      "index": 177,
+      "label": "",
+      "original": "I must say, <<STR_FREE0>>,\neven YOUR letters thrill me.\n",
+      "new": "I must say, <<STR_FREE0>>,\neven YOUR letters thrill me.\n"
+    },
+    {
+      "group": "maila",
+      "index": 178,
+      "label": "",
+      "original": "'Tis I, <<STR_FREE1>>! Are you\ngetting enough fresh air?\n",
+      "new": "'Tis I, <<STR_FREE1>>! Are you\ngetting enough fresh air?\n"
+    },
+    {
+      "group": "maila",
+      "index": 179,
+      "label": "",
+      "original": "I've been a bit tired lately. I\nwonder if I'm too social.\n",
+      "new": "I've been a bit tired lately. I\nwonder if I'm too social.\n"
+    },
+    {
+      "group": "maila",
+      "index": 180,
+      "label": "",
+      "original": "Oh, <<STR_FREE0>>, I must\nsay, I find you QUITE naive.\n",
+      "new": "Oh, <<STR_FREE0>>, I must\nsay, I find you QUITE naive.\n"
+    },
+    {
+      "group": "maila",
+      "index": 181,
+      "label": "",
+      "original": "Hello. Today's weather is a\nbit odd, wouldn't you say?\n",
+      "new": "Hello. Today's weather is a\nbit odd, wouldn't you say?\n"
+    },
+    {
+      "group": "maila",
+      "index": 182,
+      "label": "",
+      "original": "Replying to letters is so\npedestrian. Oh, well...\n",
+      "new": "Replying to letters is so\npedestrian. Oh, well...\n"
+    },
+    {
+      "group": "maila",
+      "index": 183,
+      "label": "",
+      "original": "I receive so many letters\nthat replying wears me out.\n",
+      "new": "I receive so many letters\nthat replying wears me out.\n"
+    },
+    {
+      "group": "maila",
+      "index": 184,
+      "label": "",
+      "original": "Hello, <<STR_FREE0>>! You\nare such a bundle of energy.\n",
+      "new": "Hello, <<STR_FREE0>>! You\nare such a bundle of energy.\n"
+    },
+    {
+      "group": "maila",
+      "index": 185,
+      "label": "",
+      "original": "Thank you for writing. It's\nyour darling <<STR_FREE1>>.\n",
+      "new": "Thank you for writing. It's\nyour darling <<STR_FREE1>>.\n"
+    },
+    {
+      "group": "maila",
+      "index": 186,
+      "label": "",
+      "original": "Listen, keeping fun stuff all\nto yourself isn't nice!\n",
+      "new": "Listen, keeping fun stuff all\nto yourself isn't nice!\n"
+    },
+    {
+      "group": "maila",
+      "index": 187,
+      "label": "",
+      "original": "There's just something about\nyou that intrigues me.\n",
+      "new": "There's just something about\nyou that intrigues me.\n"
+    },
+    {
+      "group": "maila",
+      "index": 188,
+      "label": "",
+      "original": "Talking face-to-face is fun,\nbut letters are nice, too.\n",
+      "new": "Talking face-to-face is fun,\nbut letters are nice, too.\n"
+    },
+    {
+      "group": "maila",
+      "index": 189,
+      "label": "",
+      "original": "Thank you so much for all of\nthe interesting letters.\n",
+      "new": "Thank you so much for all of\nthe interesting letters.\n"
+    },
+    {
+      "group": "maila",
+      "index": 190,
+      "label": "",
+      "original": "Hello. Do you spend your days\ndigging ditches? Stop it!\n",
+      "new": "Hello. Do you spend your days\ndigging ditches? Stop it!\n"
+    },
+    {
+      "group": "maila",
+      "index": 191,
+      "label": "",
+      "original": "I'll give you creditーyou do\nthink of fascinating things.\n",
+      "new": "I'll give you creditーyou do\nthink of fascinating things.\n"
+    },
+    {
+      "group": "maila",
+      "index": 192,
+      "label": "",
+      "original": "I read that letter you sent.\nI needed a nap afterwards.\n",
+      "new": "I read that letter you sent.\nI needed a nap afterwards.\n"
+    },
+    {
+      "group": "maila",
+      "index": 193,
+      "label": "",
+      "original": "Hey there. How are things?\nThanks for the letter.\n",
+      "new": "Hey there. How are things?\nThanks for the letter.\n"
+    },
+    {
+      "group": "maila",
+      "index": 194,
+      "label": "",
+      "original": "It's me, <<STR_FREE1>>. Hi.\nYou wrote me. Thanks.\n",
+      "new": "It's me, <<STR_FREE1>>. Hi.\nYou wrote me. Thanks.\n"
+    },
+    {
+      "group": "maila",
+      "index": 195,
+      "label": "",
+      "original": "You came all that way AND\nyou wrote? You're energetic!\n",
+      "new": "You came all that way AND\nyou wrote? You're energetic!\n"
+    },
+    {
+      "group": "maila",
+      "index": 196,
+      "label": "",
+      "original": "That letter of yours really\nmade my day. Thanks!\n",
+      "new": "That letter of yours really\nmade my day. Thanks!\n"
+    },
+    {
+      "group": "maila",
+      "index": 197,
+      "label": "",
+      "original": "I really wanted to sleep, but\nI wrote you back instead!\n",
+      "new": "I really wanted to sleep, but\nI wrote you back instead!\n"
+    },
+    {
+      "group": "maila",
+      "index": 198,
+      "label": "",
+      "original": "Hey, thanks for the letter!\nI didn't expect you to write.\n",
+      "new": "Hey, thanks for the letter!\nI didn't expect you to write.\n"
+    },
+    {
+      "group": "maila",
+      "index": 199,
+      "label": "",
+      "original": "That was a <<STR_FREE12>>\nletter! It made my day.\n",
+      "new": "That was a <<STR_FREE12>>\nletter! It made my day.\n"
+    },
+    {
+      "group": "maila",
+      "index": 200,
+      "label": "",
+      "original": "It's great to get letters from\nsomeone visiting our town.\n",
+      "new": "It's great to get letters from\nsomeone visiting our town.\n"
+    },
+    {
+      "group": "maila",
+      "index": 201,
+      "label": "",
+      "original": "Your letters are much more\nexciting than anyone else's.\n",
+      "new": "Your letters are much more\nexciting than anyone else's.\n"
+    },
+    {
+      "group": "maila",
+      "index": 202,
+      "label": "",
+      "original": "Hi. I'm looking for eats. Got\nany? Hook me up, buddy.\n",
+      "new": "Hi. I'm looking for eats. Got\nany? Hook me up, buddy.\n"
+    },
+    {
+      "group": "maila",
+      "index": 203,
+      "label": "",
+      "original": "The weather's great. How\nare things in your town?\n",
+      "new": "The weather's great. How\nare things in your town?\n"
+    },
+    {
+      "group": "maila",
+      "index": 204,
+      "label": "",
+      "original": "How are you, <<STR_FREE0>>?\nI'm just hangin' out.\n",
+      "new": "How are you, <<STR_FREE0>>?\nI'm just hangin' out.\n"
+    },
+    {
+      "group": "maila",
+      "index": 205,
+      "label": "",
+      "original": "Hey there, <<STR_FREE0>>!\nThanks for coming to visit.\n",
+      "new": "Hey there, <<STR_FREE0>>!\nThanks for coming to visit.\n"
+    },
+    {
+      "group": "maila",
+      "index": 206,
+      "label": "",
+      "original": "Hey, <<STR_FREE0>>.\nDid you make it home OK?\n",
+      "new": "Hey, <<STR_FREE0>>.\nDid you make it home OK?\n"
+    },
+    {
+      "group": "maila",
+      "index": 207,
+      "label": "",
+      "original": "I thought maybe you'd stop\nby, so I stayed home today.\n",
+      "new": "I thought maybe you'd stop\nby, so I stayed home today.\n"
+    },
+    {
+      "group": "maila",
+      "index": 208,
+      "label": "",
+      "original": "Hey! <<STR_FREE0>>! It's me,\n<<STR_FREE1>>... Remember me?\n",
+      "new": "Hey! <<STR_FREE0>>! It's me,\n<<STR_FREE1>>... Remember me?\n"
+    },
+    {
+      "group": "maila",
+      "index": 209,
+      "label": "",
+      "original": "It was fun hanging out with\nyou, <<STR_FREE0>>.\n",
+      "new": "It was fun hanging out with\nyou, <<STR_FREE0>>.\n"
+    },
+    {
+      "group": "maila",
+      "index": 210,
+      "label": "",
+      "original": "<<STR_FREE0>>, did you get\nlost on your way home?\n",
+      "new": "<<STR_FREE0>>, did you get\nlost on your way home?\n"
+    },
+    {
+      "group": "maila",
+      "index": 211,
+      "label": "",
+      "original": "Did you miss your stop on\nthe train ride home?\n",
+      "new": "Did you miss your stop on\nthe train ride home?\n"
+    },
+    {
+      "group": "maila",
+      "index": 212,
+      "label": "",
+      "original": "Hi, <<STR_FREE0>>. Are you\ncoming over today, or what?\n",
+      "new": "Hi, <<STR_FREE0>>. Are you\ncoming over today, or what?\n"
+    },
+    {
+      "group": "maila",
+      "index": 213,
+      "label": "",
+      "original": "The other day was a blast!\nWasn't it, <<STR_FREE0>>?\n",
+      "new": "The other day was a blast!\nWasn't it, <<STR_FREE0>>?\n"
+    },
+    {
+      "group": "maila",
+      "index": 214,
+      "label": "",
+      "original": "It's me, <<STR_FREE1>>. Are\nyou home yet, or what?\n",
+      "new": "It's me, <<STR_FREE1>>. Are\nyou home yet, or what?\n"
+    },
+    {
+      "group": "maila",
+      "index": 215,
+      "label": "",
+      "original": "I hope you enjoyed your trip\nto <<STR_FREE14>>. I sure did.\n",
+      "new": "I hope you enjoyed your trip\nto <<STR_FREE14>>. I sure did.\n"
+    },
+    {
+      "group": "maila",
+      "index": 216,
+      "label": "",
+      "original": "Hi. Thanks for coming such\na long way to visit me.\n",
+      "new": "Hi. Thanks for coming such\na long way to visit me.\n"
+    },
+    {
+      "group": "maila",
+      "index": 217,
+      "label": "",
+      "original": "What time is it there? It's\nalmost bedtime here.\n",
+      "new": "What time is it there? It's\nalmost bedtime here.\n"
+    },
+    {
+      "group": "maila",
+      "index": 218,
+      "label": "",
+      "original": "So, I'm curious... What did\nyou think of <<STR_FREE14>>?\n",
+      "new": "So, I'm curious... What did\nyou think of <<STR_FREE14>>?\n"
+    },
+    {
+      "group": "maila",
+      "index": 219,
+      "label": "",
+      "original": "Do you remember me? My\nname's <<STR_FREE1>>...\n",
+      "new": "Do you remember me? My\nname's <<STR_FREE1>>...\n"
+    },
+    {
+      "group": "maila",
+      "index": 220,
+      "label": "",
+      "original": "It's nice meeting new folks,\nsince I don't get out much.\n",
+      "new": "It's nice meeting new folks,\nsince I don't get out much.\n"
+    },
+    {
+      "group": "maila",
+      "index": 221,
+      "label": "",
+      "original": "Did you try the food at\nthe station? How was it?\n",
+      "new": "Did you try the food at\nthe station? How was it?\n"
+    },
+    {
+      "group": "maila",
+      "index": 222,
+      "label": "",
+      "original": "The train whistle reminds\nme of you. Toot-toot!\n",
+      "new": "The train whistle reminds\nme of you. Toot-toot!\n"
+    },
+    {
+      "group": "maila",
+      "index": 223,
+      "label": "",
+      "original": "When are you coming by?\nI can't wait to see you?\n",
+      "new": "When are you coming by?\nI can't wait to see you?\n"
+    },
+    {
+      "group": "maila",
+      "index": 224,
+      "label": "",
+      "original": "Hello <<STR_FREE0>>. Thanks\nfor taking the time to write.\n",
+      "new": "Hello <<STR_FREE0>>. Thanks\nfor taking the time to write.\n"
+    },
+    {
+      "group": "maila",
+      "index": 225,
+      "label": "",
+      "original": "Thank you so much for your\nletter the other day.\n",
+      "new": "Thank you so much for your\nletter the other day.\n"
+    },
+    {
+      "group": "maila",
+      "index": 226,
+      "label": "",
+      "original": "Hi, it's me, <<STR_FREE1>>.\nYour letter was great.\n",
+      "new": "Hi, it's me, <<STR_FREE1>>.\nYour letter was great.\n"
+    },
+    {
+      "group": "maila",
+      "index": 227,
+      "label": "",
+      "original": "Hi. Thank you for the sweet\nletter. It was very nice.\n",
+      "new": "Hi. Thank you for the sweet\nletter. It was very nice.\n"
+    },
+    {
+      "group": "maila",
+      "index": 228,
+      "label": "",
+      "original": "Your visit made me so\nhappy! And you wrote, too!\n",
+      "new": "Your visit made me so\nhappy! And you wrote, too!\n"
+    },
+    {
+      "group": "maila",
+      "index": 229,
+      "label": "",
+      "original": "I read your letter. It was\ncharming, just like you!\n",
+      "new": "I read your letter. It was\ncharming, just like you!\n"
+    },
+    {
+      "group": "maila",
+      "index": 230,
+      "label": "",
+      "original": "Your letter was as funny as\nyou are, <<STR_FREE0>>.\n",
+      "new": "Your letter was as funny as\nyou are, <<STR_FREE0>>.\n"
+    },
+    {
+      "group": "maila",
+      "index": 231,
+      "label": "",
+      "original": "Hello, <<STR_FREE0>>. Thank\nyou for the delightful letter.\n",
+      "new": "Hello, <<STR_FREE0>>. Thank\nyou for the delightful letter.\n"
+    },
+    {
+      "group": "maila",
+      "index": 232,
+      "label": "",
+      "original": "Hello. How are you? I'm\nas right as rain.\n",
+      "new": "Hello. How are you? I'm\nas right as rain.\n"
+    },
+    {
+      "group": "maila",
+      "index": 233,
+      "label": "",
+      "original": "Thank you so much for\ntraveling so far to visit.\n",
+      "new": "Thank you so much for\ntraveling so far to visit.\n"
+    },
+    {
+      "group": "maila",
+      "index": 234,
+      "label": "",
+      "original": "Hello <<STR_FREE0>>. Thanks\nfor coming to visit me.\n",
+      "new": "Hello <<STR_FREE0>>. Thanks\nfor coming to visit me.\n"
+    },
+    {
+      "group": "maila",
+      "index": 235,
+      "label": "",
+      "original": "I was so pleased by your\nvisit, <<STR_FREE0>>.\n",
+      "new": "I was so pleased by your\nvisit, <<STR_FREE0>>.\n"
+    },
+    {
+      "group": "maila",
+      "index": 236,
+      "label": "",
+      "original": "How are you? I'm in high\nspirits, myself.\n",
+      "new": "How are you? I'm in high\nspirits, myself.\n"
+    },
+    {
+      "group": "maila",
+      "index": 237,
+      "label": "",
+      "original": "Hello. Thanks for taking the\ntime to come and visit.\n",
+      "new": "Hello. Thanks for taking the\ntime to come and visit.\n"
+    },
+    {
+      "group": "maila",
+      "index": 238,
+      "label": "",
+      "original": "I was happy to see you.\nThanks for dropping by.\n",
+      "new": "I was happy to see you.\nThanks for dropping by.\n"
+    },
+    {
+      "group": "maila",
+      "index": 239,
+      "label": "",
+      "original": "Hi there, <<STR_FREE0>>. I\nhope you're happy and stuff.\n",
+      "new": "Hi there, <<STR_FREE0>>. I\nhope you're happy and stuff.\n"
+    },
+    {
+      "group": "maila",
+      "index": 240,
+      "label": "",
+      "original": "It was so very nice to see\nyou the other day.\n",
+      "new": "It was so very nice to see\nyou the other day.\n"
+    },
+    {
+      "group": "maila",
+      "index": 241,
+      "label": "",
+      "original": "Hey, <<STR_FREE0>>. How's\nlife in your town? Good?\n",
+      "new": "Hey, <<STR_FREE0>>. How's\nlife in your town? Good?\n"
+    },
+    {
+      "group": "maila",
+      "index": 242,
+      "label": "",
+      "original": "You know, <<STR_FREE0>>, I\nwas a bit sad after you left.\n",
+      "new": "You know, <<STR_FREE0>>, I\nwas a bit sad after you left.\n"
+    },
+    {
+      "group": "maila",
+      "index": 243,
+      "label": "",
+      "original": "Greetings! It's just me.\nHow have you been?\n",
+      "new": "Greetings! It's just me.\nHow have you been?\n"
+    },
+    {
+      "group": "maila",
+      "index": 244,
+      "label": "",
+      "original": "Hi there! How was your\ntrip to <<STR_FREE14>>?\n",
+      "new": "Hi there! How was your\ntrip to <<STR_FREE14>>?\n"
+    },
+    {
+      "group": "maila",
+      "index": 245,
+      "label": "",
+      "original": "Hello. Did you make it home\nwithout any problems?\n",
+      "new": "Hello. Did you make it home\nwithout any problems?\n"
+    },
+    {
+      "group": "maila",
+      "index": 246,
+      "label": "",
+      "original": "Good day. I was so happy\nthat you came to visit.\n",
+      "new": "Good day. I was so happy\nthat you came to visit.\n"
+    },
+    {
+      "group": "maila",
+      "index": 247,
+      "label": "",
+      "original": "I wonder how your trip to\n<<STR_FREE14>> was. Good?\n",
+      "new": "I wonder how your trip to\n<<STR_FREE14>> was. Good?\n"
+    },
+    {
+      "group": "maila",
+      "index": 248,
+      "label": "",
+      "original": "I wonder what you thought\nof <<STR_FREE14>>. Like it?\n",
+      "new": "I wonder what you thought\nof <<STR_FREE14>>. Like it?\n"
+    },
+    {
+      "group": "maila",
+      "index": 249,
+      "label": "",
+      "original": "Hi. So tell me, do you enjoy\ntraveling by rail?\n",
+      "new": "Hi. So tell me, do you enjoy\ntraveling by rail?\n"
+    },
+    {
+      "group": "maila",
+      "index": 250,
+      "label": "",
+      "original": "This is <<STR_FREE1>>. Thanks\nfor thinking of me.\n",
+      "new": "This is <<STR_FREE1>>. Thanks\nfor thinking of me.\n"
+    },
+    {
+      "group": "maila",
+      "index": 251,
+      "label": "",
+      "original": "Thanks for coming all the\nway to <<STR_FREE14>>.\n",
+      "new": "Thanks for coming all the\nway to <<STR_FREE14>>.\n"
+    },
+    {
+      "group": "maila",
+      "index": 252,
+      "label": "",
+      "original": "I wonder if you'll be home\nwhen this letter arrives.\n",
+      "new": "I wonder if you'll be home\nwhen this letter arrives.\n"
+    },
+    {
+      "group": "maila",
+      "index": 253,
+      "label": "",
+      "original": "Hi, <<STR_FREE0>>. Did you\nmake it home safely?\n",
+      "new": "Hi, <<STR_FREE0>>. Did you\nmake it home safely?\n"
+    },
+    {
+      "group": "maila",
+      "index": 254,
+      "label": "",
+      "original": "I haven't forgotten you,\n<<STR_FREE0>>! I swear!\n",
+      "new": "I haven't forgotten you,\n<<STR_FREE0>>! I swear!\n"
+    },
+    {
+      "group": "maila",
+      "index": 255,
+      "label": "",
+      "original": "Hi there, <<STR_FREE0>>.\nHow have you been?\n",
+      "new": "Hi there, <<STR_FREE0>>.\nHow have you been?\n"
+    },
+    {
+      "group": "maila",
+      "index": 256,
+      "label": "",
+      "original": "Hi there! It was so sweet\nof you to write me!\n",
+      "new": "Hi there! It was so sweet\nof you to write me!\n"
+    },
+    {
+      "group": "maila",
+      "index": 257,
+      "label": "",
+      "original": "That super letter you sent\nme really pepped my pepper!\n",
+      "new": "That super letter you sent\nme really pepped my pepper!\n"
+    },
+    {
+      "group": "maila",
+      "index": 258,
+      "label": "",
+      "original": "Your letter was hysterical!\nI laughed myself to tears!\n",
+      "new": "Your letter was hysterical!\nI laughed myself to tears!\n"
+    },
+    {
+      "group": "maila",
+      "index": 259,
+      "label": "",
+      "original": "Hiya, <<STR_FREE0>>! Your\nletter was really cool!\n",
+      "new": "Hiya, <<STR_FREE0>>! Your\nletter was really cool!\n"
+    },
+    {
+      "group": "maila",
+      "index": 260,
+      "label": "",
+      "original": "Hey there! It's <<STR_FREE1>>.\nYour letter was a blast!\n",
+      "new": "Hey there! It's <<STR_FREE1>>.\nYour letter was a blast!\n"
+    },
+    {
+      "group": "maila",
+      "index": 261,
+      "label": "",
+      "original": "I never expected an outsider\nto send me a letter. Wow!\n",
+      "new": "I never expected an outsider\nto send me a letter. Wow!\n"
+    },
+    {
+      "group": "maila",
+      "index": 262,
+      "label": "",
+      "original": "You know, your letter really\ncracked me up! It was wacky!\n",
+      "new": "You know, your letter really\ncracked me up! It was wacky!\n"
+    },
+    {
+      "group": "maila",
+      "index": 263,
+      "label": "",
+      "original": "Such a long trip, and you\nstill took the time to write!\n",
+      "new": "Such a long trip, and you\nstill took the time to write!\n"
+    },
+    {
+      "group": "maila",
+      "index": 264,
+      "label": "",
+      "original": "Thanks for that totally\n<<STR_FREE12>> letter.\n",
+      "new": "Thanks for that totally\n<<STR_FREE12>> letter.\n"
+    },
+    {
+      "group": "maila",
+      "index": 265,
+      "label": "",
+      "original": "Hiya, <<STR_FREE0>>! It was\nSOOOO nice of you to write!\n",
+      "new": "Hiya, <<STR_FREE0>>! It was\nSOOOO nice of you to write!\n"
+    },
+    {
+      "group": "maila",
+      "index": 266,
+      "label": "",
+      "original": "Has anything new happened\nsince we last spoke?\n",
+      "new": "Has anything new happened\nsince we last spoke?\n"
+    },
+    {
+      "group": "maila",
+      "index": 267,
+      "label": "",
+      "original": "Howdy, <<STR_FREE0>>! How\nare you? I'm fit as a fiddle!\n",
+      "new": "Howdy, <<STR_FREE0>>! How\nare you? I'm fit as a fiddle!\n"
+    },
+    {
+      "group": "maila",
+      "index": 268,
+      "label": "",
+      "original": "It's just me! Thanks oodles\nfor everything the other day.\n",
+      "new": "It's just me! Thanks oodles\nfor everything the other day.\n"
+    },
+    {
+      "group": "maila",
+      "index": 269,
+      "label": "",
+      "original": "I was really happy you came\nall that way to visit me!\n",
+      "new": "I was really happy you came\nall that way to visit me!\n"
+    },
+    {
+      "group": "maila",
+      "index": 270,
+      "label": "",
+      "original": "Thanks for coming all that\nway just to see me.\n",
+      "new": "Thanks for coming all that\nway just to see me.\n"
+    },
+    {
+      "group": "maila",
+      "index": 271,
+      "label": "",
+      "original": "Yoo hoo! <<STR_FREE0>>! Did\nyou get home in one piece?\n",
+      "new": "Yoo hoo! <<STR_FREE0>>! Did\nyou get home in one piece?\n"
+    },
+    {
+      "group": "maila",
+      "index": 272,
+      "label": "",
+      "original": "Hey, <<STR_FREE0>>! It was a\ntotal blast having you visit!\n",
+      "new": "Hey, <<STR_FREE0>>! It was a\ntotal blast having you visit!\n"
+    },
+    {
+      "group": "maila",
+      "index": 273,
+      "label": "",
+      "original": "Hi there! Remember me? It's\n<<STR_FREE1>>! Remember??\n",
+      "new": "Hi there! Remember me? It's\n<<STR_FREE1>>! Remember??\n"
+    },
+    {
+      "group": "maila",
+      "index": 274,
+      "label": "",
+      "original": "Hey, hey, hey! You haven't\nforgotten me, have you?\n",
+      "new": "Hey, hey, hey! You haven't\nforgotten me, have you?\n"
+    },
+    {
+      "group": "maila",
+      "index": 275,
+      "label": "",
+      "original": "Greetings, <<STR_FREE0>>.\nAre you at home today?\n",
+      "new": "Greetings, <<STR_FREE0>>.\nAre you at home today?\n"
+    },
+    {
+      "group": "maila",
+      "index": 276,
+      "label": "",
+      "original": "It was really <<STR_FREE12>>\nthat you came out to visit.\n",
+      "new": "It was really <<STR_FREE12>>\nthat you came out to visit.\n"
+    },
+    {
+      "group": "maila",
+      "index": 277,
+      "label": "",
+      "original": "Hi, <<STR_FREE0>>. Boy, the\nother day sure was fun!\n",
+      "new": "Hi, <<STR_FREE0>>. Boy, the\nother day sure was fun!\n"
+    },
+    {
+      "group": "maila",
+      "index": 278,
+      "label": "",
+      "original": "Howdy, <<STR_FREE0>>. Will\nyou be dropping by today?\n",
+      "new": "Howdy, <<STR_FREE0>>. Will\nyou be dropping by today?\n"
+    },
+    {
+      "group": "maila",
+      "index": 279,
+      "label": "",
+      "original": "Halloo, <<STR_FREE0>>! It's\n<<STR_FREE1>>! How are you?\n",
+      "new": "Halloo, <<STR_FREE0>>! It's\n<<STR_FREE1>>! How are you?\n"
+    },
+    {
+      "group": "maila",
+      "index": 280,
+      "label": "",
+      "original": "Hey, <<STR_FREE1>>, did you\nforget about me?\n",
+      "new": "Hey, <<STR_FREE1>>, did you\nforget about me?\n"
+    },
+    {
+      "group": "maila",
+      "index": 281,
+      "label": "",
+      "original": "You know, <<STR_FREE0>>,\nI was sad after you left.\n",
+      "new": "You know, <<STR_FREE0>>,\nI was sad after you left.\n"
+    },
+    {
+      "group": "maila",
+      "index": 282,
+      "label": "",
+      "original": "How are things in your\nvillage? Anything new?\n",
+      "new": "How are things in your\nvillage? Anything new?\n"
+    },
+    {
+      "group": "maila",
+      "index": 283,
+      "label": "",
+      "original": "Thanks for the other day!\nIt's me, <<STR_FREE1>>.\n",
+      "new": "Thanks for the other day!\nIt's me, <<STR_FREE1>>.\n"
+    },
+    {
+      "group": "maila",
+      "index": 284,
+      "label": "",
+      "original": "Oh, <<STR_FREE0>>! It's\nmeeeee! <<STR_FREE1>>!\n",
+      "new": "Oh, <<STR_FREE0>>! It's\nmeeeee! <<STR_FREE1>>!\n"
+    },
+    {
+      "group": "maila",
+      "index": 285,
+      "label": "",
+      "original": "You live so far away, and I\nhardly ever get to see you.\n",
+      "new": "You live so far away, and I\nhardly ever get to see you.\n"
+    },
+    {
+      "group": "maila",
+      "index": 286,
+      "label": "",
+      "original": "Hi. Did you make it home\nsafely? I sure hope so!\n",
+      "new": "Hi. Did you make it home\nsafely? I sure hope so!\n"
+    },
+    {
+      "group": "maila",
+      "index": 287,
+      "label": "",
+      "original": "Hello hello, <<STR_FREE0>>.\n<<STR_FREE1>> here.\n",
+      "new": "Hello hello, <<STR_FREE0>>.\n<<STR_FREE1>> here.\n"
+    },
+    {
+      "group": "maila",
+      "index": 288,
+      "label": "",
+      "original": "Hey, thanks for the letter.\nThat was way cool of you.\n",
+      "new": "Hey, thanks for the letter.\nThat was way cool of you.\n"
+    },
+    {
+      "group": "maila",
+      "index": 289,
+      "label": "",
+      "original": "Hey, what's up? It was great\nseeing you the other day.\n",
+      "new": "Hey, what's up? It was great\nseeing you the other day.\n"
+    },
+    {
+      "group": "maila",
+      "index": 290,
+      "label": "",
+      "original": "How are things? This is\n<<STR_FREE1>>. Remember me?\n",
+      "new": "How are things? This is\n<<STR_FREE1>>. Remember me?\n"
+    },
+    {
+      "group": "maila",
+      "index": 291,
+      "label": "",
+      "original": "Hey! It's me, <<STR_FREE1>>!\nThanks for the letter.\n",
+      "new": "Hey! It's me, <<STR_FREE1>>!\nThanks for the letter.\n"
+    },
+    {
+      "group": "maila",
+      "index": 292,
+      "label": "",
+      "original": "How's tricks? Did you make\nit home in one piece?\n",
+      "new": "How's tricks? Did you make\nit home in one piece?\n"
+    },
+    {
+      "group": "maila",
+      "index": 293,
+      "label": "",
+      "original": "I liked your letter so much,\nI read the entire thing!\n",
+      "new": "I liked your letter so much,\nI read the entire thing!\n"
+    },
+    {
+      "group": "maila",
+      "index": 294,
+      "label": "",
+      "original": "So not only did you come to\nvisit, but you also wrote!\n",
+      "new": "So not only did you come to\nvisit, but you also wrote!\n"
+    },
+    {
+      "group": "maila",
+      "index": 295,
+      "label": "",
+      "original": "I wonder if this letter will\nreach you in <<STR_FREE15>>.\n",
+      "new": "I wonder if this letter will\nreach you in <<STR_FREE15>>.\n"
+    },
+    {
+      "group": "maila",
+      "index": 296,
+      "label": "",
+      "original": "Your letter was a gas!\nI guess I oughta reply.\n",
+      "new": "Your letter was a gas!\nI guess I oughta reply.\n"
+    },
+    {
+      "group": "maila",
+      "index": 297,
+      "label": "",
+      "original": "Yo! <<STR_FREE0>>! It's the\none and only <<STR_FREE1>>!\n",
+      "new": "Yo! <<STR_FREE0>>! It's the\none and only <<STR_FREE1>>!\n"
+    },
+    {
+      "group": "maila",
+      "index": 298,
+      "label": "",
+      "original": "Howdy. So, how was your\ntrip to <<STR_FREE14>>?\n",
+      "new": "Howdy. So, how was your\ntrip to <<STR_FREE14>>?\n"
+    },
+    {
+      "group": "maila",
+      "index": 299,
+      "label": "",
+      "original": "It was so awesome of you to\nwrite me when you visited.\n",
+      "new": "It was so awesome of you to\nwrite me when you visited.\n"
+    },
+    {
+      "group": "maila",
+      "index": 300,
+      "label": "",
+      "original": "I'm so pumped to receive\nmail from other towns!\n",
+      "new": "I'm so pumped to receive\nmail from other towns!\n"
+    },
+    {
+      "group": "maila",
+      "index": 301,
+      "label": "",
+      "original": "Thanks for sending me the\n<<STR_FREE12>> letter.\n",
+      "new": "Thanks for sending me the\n<<STR_FREE12>> letter.\n"
+    },
+    {
+      "group": "maila",
+      "index": 302,
+      "label": "",
+      "original": "Hey! I finally got through\nyour letter! Not bad, huh?\n",
+      "new": "Hey! I finally got through\nyour letter! Not bad, huh?\n"
+    },
+    {
+      "group": "maila",
+      "index": 303,
+      "label": "",
+      "original": "Hi, <<STR_FREE0>>. Check it\nout! I actually wrote you!\n",
+      "new": "Hi, <<STR_FREE0>>. Check it\nout! I actually wrote you!\n"
+    },
+    {
+      "group": "maila",
+      "index": 304,
+      "label": "",
+      "original": "Yo! Thanks for coming all\nthat way the other day.\n",
+      "new": "Yo! Thanks for coming all\nthat way the other day.\n"
+    },
+    {
+      "group": "maila",
+      "index": 305,
+      "label": "",
+      "original": "Did you like <<STR_FREE14>>?\nDid you get much exercise?\n",
+      "new": "Did you like <<STR_FREE14>>?\nDid you get much exercise?\n"
+    },
+    {
+      "group": "maila",
+      "index": 306,
+      "label": "",
+      "original": "Hey! How's the weather in\n<<STR_FREE15>>? Good?\n",
+      "new": "Hey! How's the weather in\n<<STR_FREE15>>? Good?\n"
+    },
+    {
+      "group": "maila",
+      "index": 307,
+      "label": "",
+      "original": "Howdy, <<STR_FREE0>>!\nHow was the trip home?\n",
+      "new": "Howdy, <<STR_FREE0>>!\nHow was the trip home?\n"
+    },
+    {
+      "group": "maila",
+      "index": 308,
+      "label": "",
+      "original": "Hey, you! Thanks for coming\nall that way to visit me!\n",
+      "new": "Hey, you! Thanks for coming\nall that way to visit me!\n"
+    },
+    {
+      "group": "maila",
+      "index": 309,
+      "label": "",
+      "original": "Hey! Do you get letters from\nanyone other than me?\n",
+      "new": "Hey! Do you get letters from\nanyone other than me?\n"
+    },
+    {
+      "group": "maila",
+      "index": 310,
+      "label": "",
+      "original": "Isn't traveling to another\ntown the ultimate adventure?\n",
+      "new": "Isn't traveling to another\ntown the ultimate adventure?\n"
+    },
+    {
+      "group": "maila",
+      "index": 311,
+      "label": "",
+      "original": "Your visit saved me from a\nreally boring day. Thanks!\n",
+      "new": "Your visit saved me from a\nreally boring day. Thanks!\n"
+    },
+    {
+      "group": "maila",
+      "index": 312,
+      "label": "",
+      "original": "It was pretty cool that you\ncame all that way to visit.\n",
+      "new": "It was pretty cool that you\ncame all that way to visit.\n"
+    },
+    {
+      "group": "maila",
+      "index": 313,
+      "label": "",
+      "original": "What's up? You didn't forget\nabout me, did you? No way!\n",
+      "new": "What's up? You didn't forget\nabout me, did you? No way!\n"
+    },
+    {
+      "group": "maila",
+      "index": 314,
+      "label": "",
+      "original": "Things are a bit dull now\nthat you've gone home.\n",
+      "new": "Things are a bit dull now\nthat you've gone home.\n"
+    },
+    {
+      "group": "maila",
+      "index": 315,
+      "label": "",
+      "original": "<<STR_FREE1>> here!\nHow was <<STR_FREE14>>?\n",
+      "new": "<<STR_FREE1>> here!\nHow was <<STR_FREE14>>?\n"
+    },
+    {
+      "group": "maila",
+      "index": 316,
+      "label": "",
+      "original": "Hi! This is <<STR_FREE1>>.\nDid you think I'd write?\n",
+      "new": "Hi! This is <<STR_FREE1>>.\nDid you think I'd write?\n"
+    },
+    {
+      "group": "maila",
+      "index": 317,
+      "label": "",
+      "original": "What's up, <<STR_FREE0>>?\nHow are you doing?\n",
+      "new": "What's up, <<STR_FREE0>>?\nHow are you doing?\n"
+    },
+    {
+      "group": "maila",
+      "index": 318,
+      "label": "",
+      "original": "Yahoo! It's me, <<STR_FREE1>>!\nI had a blast the other day!\n",
+      "new": "Yahoo! It's me, <<STR_FREE1>>!\nI had a blast the other day!\n"
+    },
+    {
+      "group": "maila",
+      "index": 319,
+      "label": "",
+      "original": "Oh, yeah! It's <<STR_FREE1>>!\nI want to ride the rail too!\n",
+      "new": "Oh, yeah! It's <<STR_FREE1>>!\nI want to ride the rail too!\n"
+    },
+    {
+      "group": "maila",
+      "index": 320,
+      "label": "",
+      "original": "For some strange reason,\nI read your wacky letter.\n",
+      "new": "For some strange reason,\nI read your wacky letter.\n"
+    },
+    {
+      "group": "maila",
+      "index": 321,
+      "label": "",
+      "original": "Hey, did you make it home?\nYou got lost, didn't you?\n",
+      "new": "Hey, did you make it home?\nYou got lost, didn't you?\n"
+    },
+    {
+      "group": "maila",
+      "index": 322,
+      "label": "",
+      "original": "What's new, <<STR_FREE0>>?\nDid you break any bones?\n",
+      "new": "What's new, <<STR_FREE0>>?\nDid you break any bones?\n"
+    },
+    {
+      "group": "maila",
+      "index": 323,
+      "label": "",
+      "original": "This is <<STR_FREE1>>. I\nmade myself read your letter.\n",
+      "new": "This is <<STR_FREE1>>. I\nmade myself read your letter.\n"
+    },
+    {
+      "group": "maila",
+      "index": 324,
+      "label": "",
+      "original": "Hey, there. Thanks for being\nnice and stuff the other day.\n",
+      "new": "Hey, there. Thanks for being\nnice and stuff the other day.\n"
+    },
+    {
+      "group": "maila",
+      "index": 325,
+      "label": "",
+      "original": "I appreciated your letter.\nLetters are pretty cool.\n",
+      "new": "I appreciated your letter.\nLetters are pretty cool.\n"
+    },
+    {
+      "group": "maila",
+      "index": 326,
+      "label": "",
+      "original": "Hey. Thanks for the letter. I\nfigured you wouldn't bother.\n",
+      "new": "Hey. Thanks for the letter. I\nfigured you wouldn't bother.\n"
+    },
+    {
+      "group": "maila",
+      "index": 327,
+      "label": "",
+      "original": "Who'd have thunk I'd ever\nget a letter from you?\n",
+      "new": "Who'd have thunk I'd ever\nget a letter from you?\n"
+    },
+    {
+      "group": "maila",
+      "index": 328,
+      "label": "",
+      "original": "I was a bit shocked that\nyou'd actually write me.\n",
+      "new": "I was a bit shocked that\nyou'd actually write me.\n"
+    },
+    {
+      "group": "maila",
+      "index": 329,
+      "label": "",
+      "original": "Hey! It's me, <<STR_FREE1>>.\nYou remember me, don't you?\n",
+      "new": "Hey! It's me, <<STR_FREE1>>.\nYou remember me, don't you?\n"
+    },
+    {
+      "group": "maila",
+      "index": 330,
+      "label": "",
+      "original": "<<STR_FREE0>>. You write a\nmean letter. I'm impressed.\n",
+      "new": "<<STR_FREE0>>. You write a\nmean letter. I'm impressed.\n"
+    },
+    {
+      "group": "maila",
+      "index": 331,
+      "label": "",
+      "original": "You had time to visit AND\nwrite? You must be bored.\n",
+      "new": "You had time to visit AND\nwrite? You must be bored.\n"
+    },
+    {
+      "group": "maila",
+      "index": 332,
+      "label": "",
+      "original": "What's up, <<STR_FREE0>>?\nSame as always, I bet.\n",
+      "new": "What's up, <<STR_FREE0>>?\nSame as always, I bet.\n"
+    },
+    {
+      "group": "maila",
+      "index": 333,
+      "label": "",
+      "original": "The letter you sent was sort\nof <<STR_FREE9>>. Heh heh!\n",
+      "new": "The letter you sent was sort\nof <<STR_FREE9>>. Heh heh!\n"
+    },
+    {
+      "group": "maila",
+      "index": 334,
+      "label": "",
+      "original": "Your letters are really weird,\n<<STR_FREE0>>, you know?\n",
+      "new": "Your letters are really weird,\n<<STR_FREE0>>, you know?\n"
+    },
+    {
+      "group": "maila",
+      "index": 335,
+      "label": "",
+      "original": "Don't bother replying to this.\nI'm tired of reading, OK?\n",
+      "new": "Don't bother replying to this.\nI'm tired of reading, OK?\n"
+    },
+    {
+      "group": "maila",
+      "index": 336,
+      "label": "",
+      "original": "You're an odd duck, traveling\nall the way to my village.\n",
+      "new": "You're an odd duck, traveling\nall the way to my village.\n"
+    },
+    {
+      "group": "maila",
+      "index": 337,
+      "label": "",
+      "original": "Hey, what's <<STR_FREE14>>\nlike? I bet it's a nice place.\n",
+      "new": "Hey, what's <<STR_FREE14>>\nlike? I bet it's a nice place.\n"
+    },
+    {
+      "group": "maila",
+      "index": 338,
+      "label": "",
+      "original": "You didn't forget me, did\nyou? It's me, <<STR_FREE1>>.\n",
+      "new": "You didn't forget me, did\nyou? It's me, <<STR_FREE1>>.\n"
+    },
+    {
+      "group": "maila",
+      "index": 339,
+      "label": "",
+      "original": "Tell me, <<STR_FREE0>>, are\nyou getting by all right? \n",
+      "new": "Tell me, <<STR_FREE0>>, are\nyou getting by all right? \n"
+    },
+    {
+      "group": "maila",
+      "index": 340,
+      "label": "",
+      "original": "<<STR_FREE0>>! How are you\nfilling your days, huh?\n",
+      "new": "<<STR_FREE0>>! How are you\nfilling your days, huh?\n"
+    },
+    {
+      "group": "maila",
+      "index": 341,
+      "label": "",
+      "original": "That long trip you took must\nhave tuckered you out.\n",
+      "new": "That long trip you took must\nhave tuckered you out.\n"
+    },
+    {
+      "group": "maila",
+      "index": 342,
+      "label": "",
+      "original": "I guess it wasn't so bad\nseeing you the other day.\n",
+      "new": "I guess it wasn't so bad\nseeing you the other day.\n"
+    },
+    {
+      "group": "maila",
+      "index": 343,
+      "label": "",
+      "original": "Howdy. I was worried my\nletter wouldn't get to you.\n",
+      "new": "Howdy. I was worried my\nletter wouldn't get to you.\n"
+    },
+    {
+      "group": "maila",
+      "index": 344,
+      "label": "",
+      "original": "Thanks for coming all that\nway to visit the other day.\n",
+      "new": "Thanks for coming all that\nway to visit the other day.\n"
+    },
+    {
+      "group": "maila",
+      "index": 345,
+      "label": "",
+      "original": "Hey! That train trip must\nhave been tiring. Thanks!\n",
+      "new": "Hey! That train trip must\nhave been tiring. Thanks!\n"
+    },
+    {
+      "group": "maila",
+      "index": 346,
+      "label": "",
+      "original": "So, did you make it back to\n<<STR_FREE15>> in one piece?\n",
+      "new": "So, did you make it back to\n<<STR_FREE15>> in one piece?\n"
+    },
+    {
+      "group": "maila",
+      "index": 347,
+      "label": "",
+      "original": "I wonder, how far is it from\nhere to <<STR_FREE14>>?\n",
+      "new": "I wonder, how far is it from\nhere to <<STR_FREE14>>?\n"
+    },
+    {
+      "group": "maila",
+      "index": 348,
+      "label": "",
+      "original": "Hi again! How is everything\nback home? No troubles?\n",
+      "new": "Hi again! How is everything\nback home? No troubles?\n"
+    },
+    {
+      "group": "maila",
+      "index": 349,
+      "label": "",
+      "original": "So, did you enjoy your little\ntrip to <<STR_FREE14>>?\n",
+      "new": "So, did you enjoy your little\ntrip to <<STR_FREE14>>?\n"
+    },
+    {
+      "group": "maila",
+      "index": 350,
+      "label": "",
+      "original": "Did you leave <<STR_FREE14>>\nwith some good memories?\n",
+      "new": "Did you leave <<STR_FREE14>>\nwith some good memories?\n"
+    },
+    {
+      "group": "maila",
+      "index": 351,
+      "label": "",
+      "original": "After you left, things quieted\ndown. So...thanks for leaving.\n",
+      "new": "After you left, things quieted\ndown. So...thanks for leaving.\n"
+    },
+    {
+      "group": "maila",
+      "index": 352,
+      "label": "",
+      "original": "I took the time to read your\nletter. It was...\"interesting.\"\n",
+      "new": "I took the time to read your\nletter. It was...\"interesting.\"\n"
+    },
+    {
+      "group": "maila",
+      "index": 353,
+      "label": "",
+      "original": "How are you my dear? Feeling\nat all <<STR_FREE12>>?\n",
+      "new": "How are you my dear? Feeling\nat all <<STR_FREE12>>?\n"
+    },
+    {
+      "group": "maila",
+      "index": 354,
+      "label": "",
+      "original": "How are you, <<STR_FREE0>>?\nI hope that you are well.\n",
+      "new": "How are you, <<STR_FREE0>>?\nI hope that you are well.\n"
+    },
+    {
+      "group": "maila",
+      "index": 355,
+      "label": "",
+      "original": "Hi. I wanted to thank you\nfor your delightful letter.\n",
+      "new": "Hi. I wanted to thank you\nfor your delightful letter.\n"
+    },
+    {
+      "group": "maila",
+      "index": 356,
+      "label": "",
+      "original": "Thank you for your quaint\nlittle letter, <<STR_FREE0>>.\n",
+      "new": "Thank you for your quaint\nlittle letter, <<STR_FREE0>>.\n"
+    },
+    {
+      "group": "maila",
+      "index": 357,
+      "label": "",
+      "original": "I was both surprised and\npleased to hear from you.\n",
+      "new": "I was both surprised and\npleased to hear from you.\n"
+    },
+    {
+      "group": "maila",
+      "index": 358,
+      "label": "",
+      "original": "A letter was not necessary\nto keep you in my thoughts.\n",
+      "new": "A letter was not necessary\nto keep you in my thoughts.\n"
+    },
+    {
+      "group": "maila",
+      "index": 359,
+      "label": "",
+      "original": "Oh, <<STR_FREE0>>! Your letter\nwas as droll as you are.\n",
+      "new": "Oh, <<STR_FREE0>>! Your letter\nwas as droll as you are.\n"
+    },
+    {
+      "group": "maila",
+      "index": 360,
+      "label": "",
+      "original": "Good day. You had time to\nvisit and write? Hmmm...\n",
+      "new": "Good day. You had time to\nvisit and write? Hmmm...\n"
+    },
+    {
+      "group": "maila",
+      "index": 361,
+      "label": "",
+      "original": "It's me, <<STR_FREE1>>. You\nremember me, of course.\n",
+      "new": "It's me, <<STR_FREE1>>. You\nremember me, of course.\n"
+    },
+    {
+      "group": "maila",
+      "index": 362,
+      "label": "",
+      "original": "Bon jour, <<STR_FREE0>>. How\nare you feeling these days?\n",
+      "new": "Bon jour, <<STR_FREE0>>. How\nare you feeling these days?\n"
+    },
+    {
+      "group": "maila",
+      "index": 363,
+      "label": "",
+      "original": "So...did you make it safely\nback to <<STR_FREE15>>?\n",
+      "new": "So...did you make it safely\nback to <<STR_FREE15>>?\n"
+    },
+    {
+      "group": "maila",
+      "index": 364,
+      "label": "",
+      "original": "It was marvelous visiting\nwith you, <<STR_FREE0>>.\n",
+      "new": "It was marvelous visiting\nwith you, <<STR_FREE0>>.\n"
+    },
+    {
+      "group": "maila",
+      "index": 365,
+      "label": "",
+      "original": "Thank you for coming from\nyour distant hamlet to visit.\n",
+      "new": "Thank you for coming from\nyour distant hamlet to visit.\n"
+    },
+    {
+      "group": "maila",
+      "index": 366,
+      "label": "",
+      "original": "I trust you remember me from\nyour trip to <<STR_FREE14>>.\n",
+      "new": "I trust you remember me from\nyour trip to <<STR_FREE14>>.\n"
+    },
+    {
+      "group": "maila",
+      "index": 367,
+      "label": "",
+      "original": "Despite my busy schedule, I\nfound time to reply to you.\n",
+      "new": "Despite my busy schedule, I\nfound time to reply to you.\n"
+    },
+    {
+      "group": "maila",
+      "index": 368,
+      "label": "",
+      "original": "You must be exhausted after\nyour trip to <<STR_FREE14>>.\n",
+      "new": "You must be exhausted after\nyour trip to <<STR_FREE14>>.\n"
+    },
+    {
+      "group": "maila",
+      "index": 369,
+      "label": "",
+      "original": "Greetings. I trust you are\nwell. It's me, <<STR_FREE1>>.\n",
+      "new": "Greetings. I trust you are\nwell. It's me, <<STR_FREE1>>.\n"
+    },
+    {
+      "group": "maila",
+      "index": 370,
+      "label": "",
+      "original": "<<STR_FREE1>> here! I KNOW\nyou haven't forgotten me!\n",
+      "new": "<<STR_FREE1>> here! I KNOW\nyou haven't forgotten me!\n"
+    },
+    {
+      "group": "maila",
+      "index": 371,
+      "label": "",
+      "original": "You rode the train just to\nsee me? How flattering!\n",
+      "new": "You rode the train just to\nsee me? How flattering!\n"
+    },
+    {
+      "group": "maila",
+      "index": 372,
+      "label": "",
+      "original": "Your visit the other day was\nquite delightful. Thank you.\n",
+      "new": "Your visit the other day was\nquite delightful. Thank you.\n"
+    },
+    {
+      "group": "maila",
+      "index": 373,
+      "label": "",
+      "original": "'Tis I, <<STR_FREE1>>. Thank\nyou for coming to visit me.\n",
+      "new": "'Tis I, <<STR_FREE1>>. Thank\nyou for coming to visit me.\n"
+    },
+    {
+      "group": "maila",
+      "index": 374,
+      "label": "",
+      "original": "Hello, darling. How are you?\nI'm as spectacular as ever.\n",
+      "new": "Hello, darling. How are you?\nI'm as spectacular as ever.\n"
+    },
+    {
+      "group": "maila",
+      "index": 375,
+      "label": "",
+      "original": "Good day. The next time you\nvisit, please write, as well.\n",
+      "new": "Good day. The next time you\nvisit, please write, as well.\n"
+    },
+    {
+      "group": "maila",
+      "index": 376,
+      "label": "",
+      "original": "Buenos dias! Thank you for\ntraveling so far to visit me!\n",
+      "new": "Buenos dias! Thank you for\ntraveling so far to visit me!\n"
+    },
+    {
+      "group": "maila",
+      "index": 377,
+      "label": "",
+      "original": "It's I, <<STR_FREE1>>. From\n<<STR_FREE14>>? Remember me?\n",
+      "new": "It's I, <<STR_FREE1>>. From\n<<STR_FREE14>>? Remember me?\n"
+    },
+    {
+      "group": "maila",
+      "index": 378,
+      "label": "",
+      "original": "Did your long trip tire you\nout? I certainly hope not.\n",
+      "new": "Did your long trip tire you\nout? I certainly hope not.\n"
+    },
+    {
+      "group": "maila",
+      "index": 379,
+      "label": "",
+      "original": "How are you, <<STR_FREE0>>?\nSeeing you was such fun.\n",
+      "new": "How are you, <<STR_FREE0>>?\nSeeing you was such fun.\n"
+    },
+    {
+      "group": "maila",
+      "index": 380,
+      "label": "",
+      "original": "It would seem that you made\nit home safely. How...nice.\n",
+      "new": "It would seem that you made\nit home safely. How...nice.\n"
+    },
+    {
+      "group": "maila",
+      "index": 381,
+      "label": "",
+      "original": "Did you go directly home\nafter our visit? I wonder...\n",
+      "new": "Did you go directly home\nafter our visit? I wonder...\n"
+    },
+    {
+      "group": "maila",
+      "index": 382,
+      "label": "",
+      "original": "Hello. So, how are things in\nyour village? Anything new?\n",
+      "new": "Hello. So, how are things in\nyour village? Anything new?\n"
+    },
+    {
+      "group": "maila",
+      "index": 383,
+      "label": "",
+      "original": "Thank you for coming to\nvisit. Are you busy today?\n",
+      "new": "Thank you for coming to\nvisit. Are you busy today?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 0,
+      "label": "",
+      "original": "Somebody dumped this in\nfront of my house. I don't\nknow why. Here, you take it.\n",
+      "new": "Somebody dumped this in\nfront of my house. I don't\nknow why. Here, you take it.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 1,
+      "label": "",
+      "original": "A friend got me this as a\nsouvenir, but I already have\none. So you can have it.\n",
+      "new": "A friend got me this as a\nsouvenir, but I already have\none. So you can have it.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 2,
+      "label": "",
+      "original": "I'm such a dork. I bought\nthis, but it turns out I\nalready had one. Want it?\n",
+      "new": "I'm such a dork. I bought\nthis, but it turns out I\nalready had one. Want it?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 3,
+      "label": "",
+      "original": "I found this out in the\ngarbage dump, and I thought\nit might be yours, so here.\n",
+      "new": "I found this out in the\ngarbage dump, and I thought\nit might be yours, so here.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 4,
+      "label": "",
+      "original": "I went to this other town,\nand some Gyroid had stuff\nfor free. So...this is for you.\n",
+      "new": "I went to this other town,\nand some Gyroid had stuff\nfor free. So...this is for you.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 5,
+      "label": "",
+      "original": "I wanted to give this\nto <<STR_FREE2>>, but...\nAnyway, it's yours now.\n",
+      "new": "I wanted to give this\nto <<STR_FREE2>>, but...\nAnyway, it's yours now.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 6,
+      "label": "",
+      "original": "I dreamt that if I gave this\naway, I'd have good luck.\nI'll tell you if it happens.\n",
+      "new": "I dreamt that if I gave this\naway, I'd have good luck.\nI'll tell you if it happens.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 7,
+      "label": "",
+      "original": "I dug this up with my new\nshovel. Did you bury it?\n",
+      "new": "I dug this up with my new\nshovel. Did you bury it?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 8,
+      "label": "",
+      "original": "A friend of mine gave this\nto me, but I think it suits\nyou better, so it's yours.\n",
+      "new": "A friend of mine gave this\nto me, but I think it suits\nyou better, so it's yours.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 9,
+      "label": "",
+      "original": "You asked for one of these,\nright, <<STR_FREE0>>? No?\nWell, keep itーI don't want it.\n",
+      "new": "You asked for one of these,\nright, <<STR_FREE0>>? No?\nWell, keep itーI don't want it.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 10,
+      "label": "",
+      "original": "It seemed like too much\ntrouble to take this home,\nso I'm sending it to you.\n",
+      "new": "It seemed like too much\ntrouble to take this home,\nso I'm sending it to you.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 11,
+      "label": "",
+      "original": "Don't you think this is\n<<STR_FREE12>>?\nWell, it's too good for me.\n",
+      "new": "Don't you think this is\n<<STR_FREE12>>?\nWell, it's too good for me.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 12,
+      "label": "",
+      "original": "There's always free stuff at\nthe Police Box, so I grabbed\nthis for you. Enjoy!\n",
+      "new": "There's always free stuff at\nthe Police Box, so I grabbed\nthis for you. Enjoy!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 13,
+      "label": "",
+      "original": "Um, <<STR_FREE0>>, when's\nyour birthday? I forgot. I\nhope this present isn't late.\n",
+      "new": "Um, <<STR_FREE0>>, when's\nyour birthday? I forgot. I\nhope this present isn't late.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 14,
+      "label": "",
+      "original": "I went shopping in the next\ntown over. I picked this up\nfor you. Nice, huh?\n",
+      "new": "I went shopping in the next\ntown over. I picked this up\nfor you. Nice, huh?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 15,
+      "label": "",
+      "original": "This turned up when I was\ncleaning. I just don't have\nroom for it, so you take it.\n",
+      "new": "This turned up when I was\ncleaning. I just don't have\nroom for it, so you take it.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 16,
+      "label": "",
+      "original": "Yesterday, <<STR_FREE2>>\nand I played\n<<STR_FREE5>>!\n",
+      "new": "Yesterday, <<STR_FREE2>>\nand I played\n<<STR_FREE5>>!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 17,
+      "label": "",
+      "original": "Did you know <<STR_FREE2>>\nmakes a mean\n<<STR_FREE3>>?\n",
+      "new": "Did you know <<STR_FREE2>>\nmakes a mean\n<<STR_FREE3>>?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 18,
+      "label": "",
+      "original": "I heard <<STR_FREE2>>'s\n<<STR_FREE3>>\ntastes <<STR_FREE11>>!\n",
+      "new": "I heard <<STR_FREE2>>'s\n<<STR_FREE3>>\ntastes <<STR_FREE11>>!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 19,
+      "label": "",
+      "original": "<<CAPTIALIZE>><<STR_FREE3>> is\n<<STR_FREE8>>, don't\nyou think? I sure do.\n",
+      "new": "<<CAPTIALIZE>><<STR_FREE3>> is\n<<STR_FREE8>>, don't\nyou think? I sure do.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 20,
+      "label": "",
+      "original": "Yo! Did you get a load of\n<<STR_FREE2>>'s new outfit?\nIsn't it kind of tight?\n",
+      "new": "Yo! Did you get a load of\n<<STR_FREE2>>'s new outfit?\nIsn't it kind of tight?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 21,
+      "label": "",
+      "original": "The clothes you had on\nyesterday were too tight.\nAnd <<STR_FREE9>>!\n",
+      "new": "The clothes you had on\nyesterday were too tight.\nAnd <<STR_FREE9>>!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 22,
+      "label": "",
+      "original": "I played <<STR_FREE4>>\nwith <<STR_FREE2>>. You\nshould join us next time!\n",
+      "new": "I played <<STR_FREE4>>\nwith <<STR_FREE2>>. You\nshould join us next time!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 23,
+      "label": "",
+      "original": "<<STR_FREE2>> made me\nsome <<STR_FREE3>>\nthat was so <<STR_FREE8>>!\n",
+      "new": "<<STR_FREE2>> made me\nsome <<STR_FREE3>>\nthat was so <<STR_FREE8>>!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 24,
+      "label": "",
+      "original": "So, <<STR_FREE0>>, what\nkind of music do you like? I\nlike <<STR_FREE10>>.\n",
+      "new": "So, <<STR_FREE0>>, what\nkind of music do you like? I\nlike <<STR_FREE10>>.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 25,
+      "label": "",
+      "original": "Did you compose the new\ntown tune? It's totally\n<<STR_FREE12>>!\n",
+      "new": "Did you compose the new\ntown tune? It's totally\n<<STR_FREE12>>!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 26,
+      "label": "",
+      "original": "Lunch isn't lunch without\n<<STR_FREE3>>, you know?\nOr is that just me?\n",
+      "new": "Lunch isn't lunch without\n<<STR_FREE3>>, you know?\nOr is that just me?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 27,
+      "label": "",
+      "original": "Do you know how to play\n<<STR_FREE4>>? Can you\nteach me? Please!\n",
+      "new": "Do you know how to play\n<<STR_FREE4>>? Can you\nteach me? Please!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 28,
+      "label": "",
+      "original": "If someone doesn't pull all\nthose weeds soon, they'll\ntake over the entire village!\n",
+      "new": "If someone doesn't pull all\nthose weeds soon, they'll\ntake over the entire village!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 29,
+      "label": "",
+      "original": "So, <<STR_FREE0>>, do you go\nto town festivals? I'm pretty\nlazy, but I never miss them!\n",
+      "new": "So, <<STR_FREE0>>, do you go\nto town festivals? I'm pretty\nlazy, but I never miss them!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 30,
+      "label": "",
+      "original": "I took a ride on the train\nthe other day. It was pretty\n<<STR_FREE9>>!\n",
+      "new": "I took a ride on the train\nthe other day. It was pretty\n<<STR_FREE9>>!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 31,
+      "label": "",
+      "original": "I haven't seen any flowers\nlately. Hmmm... Hang on!\nDid you eat them all?\n",
+      "new": "I haven't seen any flowers\nlately. Hmmm... Hang on!\nDid you eat them all?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 32,
+      "label": "",
+      "original": "I got this cool thing the\nother day. You can have\nit if you want it.\n",
+      "new": "I got this cool thing the\nother day. You can have\nit if you want it.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 33,
+      "label": "",
+      "original": "I went on a trip, and I got\nthis souvenir for you. It's\nnothing special, but...\n",
+      "new": "I went on a trip, and I got\nthis souvenir for you. It's\nnothing special, but...\n"
+    },
+    {
+      "group": "mailb",
+      "index": 34,
+      "label": "",
+      "original": "I went on a total shopping\nbinge the other day, and I\njust wanted to give you this.\n",
+      "new": "I went on a total shopping\nbinge the other day, and I\njust wanted to give you this.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 35,
+      "label": "",
+      "original": "I found this when I was out\non a little stroll and\nthought of you. Here you go!\n",
+      "new": "I found this when I was out\non a little stroll and\nthought of you. Here you go!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 36,
+      "label": "",
+      "original": "Can you believe the things\npeople will throw away?\nYou really should take this.\n",
+      "new": "Can you believe the things\npeople will throw away?\nYou really should take this.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 37,
+      "label": "",
+      "original": "I got this for you because\nyou're just SO nice to me!\nPlease, accept my thanks.\n",
+      "new": "I got this for you because\nyou're just SO nice to me!\nPlease, accept my thanks.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 38,
+      "label": "",
+      "original": "I found this under my couch\nwhen I was cleaning. It's a\nlittle dusty, but..here.\n",
+      "new": "I found this under my couch\nwhen I was cleaning. It's a\nlittle dusty, but..here.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 39,
+      "label": "",
+      "original": "I was out shopping in\nanother town, and I got this\nfor you. I hope you like it.\n",
+      "new": "I was out shopping in\nanother town, and I got this\nfor you. I hope you like it.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 40,
+      "label": "",
+      "original": "This was at the police box,\nand I just knew you had\nto have it, <<STR_FREE0>>.\n",
+      "new": "This was at the police box,\nand I just knew you had\nto have it, <<STR_FREE0>>.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 41,
+      "label": "",
+      "original": "I no longer need this, so I'd\nlike you to have it. You did\nsay you wanted it, right?\n",
+      "new": "I no longer need this, so I'd\nlike you to have it. You did\nsay you wanted it, right?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 42,
+      "label": "",
+      "original": "<<STR_FREE2>> gave this to\nme. but I'd like you to have\nit. OK, <<STR_FREE0>>?\n",
+      "new": "<<STR_FREE2>> gave this to\nme. but I'd like you to have\nit. OK, <<STR_FREE0>>?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 43,
+      "label": "",
+      "original": "I bought this in another\ntown, but I don't really\nneed it, so you can have it.\n",
+      "new": "I bought this in another\ntown, but I don't really\nneed it, so you can have it.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 44,
+      "label": "",
+      "original": "I saw <<STR_FREE2>> toss\nthis out, and I said, \"what\na waste!\" Here, you take it.\n",
+      "new": "I saw <<STR_FREE2>> toss\nthis out, and I said, \"what\na waste!\" Here, you take it.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 45,
+      "label": "",
+      "original": "I bought this the other day,\nand then realized I don't\nit. I'd like you to have it.\n",
+      "new": "I bought this the other day,\nand then realized I don't\nit. I'd like you to have it.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 46,
+      "label": "",
+      "original": "I dug this up in my yard...\nI don't think I've ever seen\nanything like it before.\n",
+      "new": "I dug this up in my yard...\nI don't think I've ever seen\nanything like it before.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 47,
+      "label": "",
+      "original": "I bought this off of some\nstranger, but it's really\ncreeping me out. You take it.\n",
+      "new": "I bought this off of some\nstranger, but it's really\ncreeping me out. You take it.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 48,
+      "label": "",
+      "original": "I stayed up too late last\nnight and didn't get enough\nsleep. I need to go to bed.\n",
+      "new": "I stayed up too late last\nnight and didn't get enough\nsleep. I need to go to bed.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 49,
+      "label": "",
+      "original": "You've got to cover up when\nyou're sleeping! You may\nfreeze to death otherwise.\n",
+      "new": "You've got to cover up when\nyou're sleeping! You may\nfreeze to death otherwise.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 50,
+      "label": "",
+      "original": "I love taking walks. There's\nno telling what you might\nfind along the riverside.\n",
+      "new": "I love taking walks. There's\nno telling what you might\nfind along the riverside.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 51,
+      "label": "",
+      "original": "The other day, I tried to\nmake <<STR_FREE3>>, but \nI blew it. It tasted awful!\n",
+      "new": "The other day, I tried to\nmake <<STR_FREE3>>, but \nI blew it. It tasted awful!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 52,
+      "label": "",
+      "original": "I whipped up some\n<<STR_FREE3>> yesterday.\nOh my, it was heavenly!\n",
+      "new": "I whipped up some\n<<STR_FREE3>> yesterday.\nOh my, it was heavenly!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 53,
+      "label": "",
+      "original": "Would you tell me how to\nmake <<STR_FREE3>>? I\ncan never get it right.\n",
+      "new": "Would you tell me how to\nmake <<STR_FREE3>>? I\ncan never get it right.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 54,
+      "label": "",
+      "original": "In a few days, I'm going to\nwatch <<STR_FREE4>>.\nI'm so looking forward to it.\n\n",
+      "new": "In a few days, I'm going to\nwatch <<STR_FREE4>>.\nI'm so looking forward to it.\n\n"
+    },
+    {
+      "group": "mailb",
+      "index": 55,
+      "label": "",
+      "original": "I broke my unlucky streak\nthe other day. I caught this\nhuge <<STR_FREE6>>!\n",
+      "new": "I broke my unlucky streak\nthe other day. I caught this\nhuge <<STR_FREE6>>!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 56,
+      "label": "",
+      "original": "The other day, I caught the\ncutest <<STR_FREE7>>. I\nfelt bad, so I set it free.\n",
+      "new": "The other day, I caught the\ncutest <<STR_FREE7>>. I\nfelt bad, so I set it free.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 57,
+      "label": "",
+      "original": "I got into an argument with\n<<STR_FREE2>>... I hope we\ncan make up and be friends.\n",
+      "new": "I got into an argument with\n<<STR_FREE2>>... I hope we\ncan make up and be friends.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 58,
+      "label": "",
+      "original": "<<STR_FREE2>> gave me some\nnew furniture yesterday.\nIt was <<STR_FREE9>>.\n",
+      "new": "<<STR_FREE2>> gave me some\nnew furniture yesterday.\nIt was <<STR_FREE9>>.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 59,
+      "label": "",
+      "original": "I went for a brisk walk this\nmorning, and I feel great!\nGive it a try, <<STR_FREE0>>.\n",
+      "new": "I went for a brisk walk this\nmorning, and I feel great!\nGive it a try, <<STR_FREE0>>.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 60,
+      "label": "",
+      "original": "I saw this <<STR_FREE9>>\nTV show, <<STR_FREE0>>.\nDid you catch it?\n",
+      "new": "I saw this <<STR_FREE9>>\nTV show, <<STR_FREE0>>.\nDid you catch it?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 61,
+      "label": "",
+      "original": "The <<STR_FREE3>> I made\ntoday was <<STR_FREE8>>.\nI hope it's better next time.\n",
+      "new": "The <<STR_FREE3>> I made\ntoday was <<STR_FREE8>>.\nI hope it's better next time.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 62,
+      "label": "",
+      "original": "I am really hooked on\n<<STR_FREE10>>. I've been\nlistening to it all the time.\n",
+      "new": "I am really hooked on\n<<STR_FREE10>>. I've been\nlistening to it all the time.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 63,
+      "label": "",
+      "original": "I'm thinking that the next\nconcert I see will have\nto be <<STR_FREE10>>.\n",
+      "new": "I'm thinking that the next\nconcert I see will have\nto be <<STR_FREE10>>.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 64,
+      "label": "",
+      "original": "I got something totally hip.\nHere's yours! Now we match!\n",
+      "new": "I got something totally hip.\nHere's yours! Now we match!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 65,
+      "label": "",
+      "original": "Here's a souvenir from my\ntrip. Don't be shy, just\ntake it!\n",
+      "new": "Here's a souvenir from my\ntrip. Don't be shy, just\ntake it!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 66,
+      "label": "",
+      "original": "Shopping can be dangerous!\nI accidentally bought two of\nthese! You can have one.\n",
+      "new": "Shopping can be dangerous!\nI accidentally bought two of\nthese! You can have one.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 67,
+      "label": "",
+      "original": "I saw this in the police\nbox, and I just had to have\nit. Now I'm giving it to you.\n",
+      "new": "I saw this in the police\nbox, and I just had to have\nit. Now I'm giving it to you.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 68,
+      "label": "",
+      "original": "I found this over in another\nvillage. You like this sort of\nthing, right? Here you go!\n",
+      "new": "I found this over in another\nvillage. You like this sort of\nthing, right? Here you go!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 69,
+      "label": "",
+      "original": "<<STR_FREE2>> gave this to\nme, but it clashes with my\nthings. Here, you take it.\n",
+      "new": "<<STR_FREE2>> gave this to\nme, but it clashes with my\nthings. Here, you take it.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 70,
+      "label": "",
+      "original": "I'm redecorating my house,\nand I have all this stuff to\nget rid of. Please take this.\n",
+      "new": "I'm redecorating my house,\nand I have all this stuff to\nget rid of. Please take this.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 71,
+      "label": "",
+      "original": "The dump is full of funky\nstuff. I got this for you.\n",
+      "new": "The dump is full of funky\nstuff. I got this for you.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 72,
+      "label": "",
+      "original": "I bought too much down at\nthe local department store.\nMaybe you can use this...\n",
+      "new": "I bought too much down at\nthe local department store.\nMaybe you can use this...\n"
+    },
+    {
+      "group": "mailb",
+      "index": 73,
+      "label": "",
+      "original": "Say, <<STR_FREE0>>.\nThis looks like something\nyou'd like. Well, it's yours!\n",
+      "new": "Say, <<STR_FREE0>>.\nThis looks like something\nyou'd like. Well, it's yours!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 74,
+      "label": "",
+      "original": "I was going to give this to\n<<STR_FREE2>>, but we're\nfighting, so now I'm not.\n",
+      "new": "I was going to give this to\n<<STR_FREE2>>, but we're\nfighting, so now I'm not.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 75,
+      "label": "",
+      "original": "I got this in a grab bag.\nIt's a bit <<STR_FREE9>>.\nI think it suits you better.\n",
+      "new": "I got this in a grab bag.\nIt's a bit <<STR_FREE9>>.\nI think it suits you better.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 76,
+      "label": "",
+      "original": "I can't believe anyone would\nthrow something like this\naway! I saved it! HA!\n",
+      "new": "I can't believe anyone would\nthrow something like this\naway! I saved it! HA!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 77,
+      "label": "",
+      "original": "I bought this before I \nrealized I already had\none. You can have it.\n",
+      "new": "I bought this before I \nrealized I already had\none. You can have it.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 78,
+      "label": "",
+      "original": "I can't believe the things\npeople bury around here!\nHold onto this for me, OK?\n",
+      "new": "I can't believe the things\npeople bury around here!\nHold onto this for me, OK?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 79,
+      "label": "",
+      "original": "<<STR_FREE2>> made me\nbuy this, but it's\nnot really me...\n",
+      "new": "<<STR_FREE2>> made me\nbuy this, but it's\nnot really me...\n"
+    },
+    {
+      "group": "mailb",
+      "index": 80,
+      "label": "",
+      "original": "I played <<STR_FREE5>>\nwith <<STR_FREE2>> yesterday.\nWe should play sometime.\n",
+      "new": "I played <<STR_FREE5>>\nwith <<STR_FREE2>> yesterday.\nWe should play sometime.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 81,
+      "label": "",
+      "original": "Did you hear <<STR_FREE2>>'s \ntaking a trip? I wish I\ncould go along!\n",
+      "new": "Did you hear <<STR_FREE2>>'s \ntaking a trip? I wish I\ncould go along!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 82,
+      "label": "",
+      "original": "Did you hear that\n<<STR_FREE2>>'s into\n<<STR_FREE10>>? Freaky, huh?\n",
+      "new": "Did you hear that\n<<STR_FREE2>>'s into\n<<STR_FREE10>>? Freaky, huh?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 83,
+      "label": "",
+      "original": "Do you like <<STR_FREE3>>?\nIt's so <<STR_FREE8>>!\nI'm totally hooked!\n",
+      "new": "Do you like <<STR_FREE3>>?\nIt's so <<STR_FREE8>>!\nI'm totally hooked!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 84,
+      "label": "",
+      "original": "Did you see <<STR_FREE2>>'s\noutfit? I can't believe how\n<<STR_FREE9>> it was!\n",
+      "new": "Did you see <<STR_FREE2>>'s\noutfit? I can't believe how\n<<STR_FREE9>> it was!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 85,
+      "label": "",
+      "original": "I need to talk to you about\nthose clothes you're wearing.\nWay <<STR_FREE9>>! OK?\n",
+      "new": "I need to talk to you about\nthose clothes you're wearing.\nWay <<STR_FREE9>>! OK?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 86,
+      "label": "",
+      "original": "I'm so in to\n<<STR_FREE3>>! Well, not\ncooking it, but eating it!\n",
+      "new": "I'm so in to\n<<STR_FREE3>>! Well, not\ncooking it, but eating it!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 87,
+      "label": "",
+      "original": "<<STR_FREE2>> made some\n<<STR_FREE3>>. It was\nSOOO <<STR_FREE8>>! Ha!\n",
+      "new": "<<STR_FREE2>> made some\n<<STR_FREE3>>. It was\nSOOO <<STR_FREE8>>! Ha!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 88,
+      "label": "",
+      "original": "I'm going out tomorrow to\ncatch a <<STR_FREE6>>. I\nthink it'll make a great pet.\n",
+      "new": "I'm going out tomorrow to\ncatch a <<STR_FREE6>>. I\nthink it'll make a great pet.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 89,
+      "label": "",
+      "original": "<<STR_FREE0>>, did you write\nthe village melody?\n<<CAPTIALIZE>><<STR_FREE12>>!\n",
+      "new": "<<STR_FREE0>>, did you write\nthe village melody?\n<<CAPTIALIZE>><<STR_FREE12>>!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 90,
+      "label": "",
+      "original": "I'm going to a <<STR_FREE4>>\nexhibition! It's going to\nbe so much fun!\n",
+      "new": "I'm going to a <<STR_FREE4>>\nexhibition! It's going to\nbe so much fun!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 91,
+      "label": "",
+      "original": "Has <<STR_FREE2>> ever made\n<<STR_FREE3>> for you?\nIt's so <<STR_FREE11>>!\n",
+      "new": "Has <<STR_FREE2>> ever made\n<<STR_FREE3>> for you?\nIt's so <<STR_FREE11>>!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 92,
+      "label": "",
+      "original": "AAAH! I found cockroaches\nin my house today! Have you\nseen any in your house?\n",
+      "new": "AAAH! I found cockroaches\nin my house today! Have you\nseen any in your house?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 93,
+      "label": "",
+      "original": "Hey, <<STR_FREE0>>! Can you\nplay <<STR_FREE5>>? \nTeach me sometime. OK?!\n",
+      "new": "Hey, <<STR_FREE0>>! Can you\nplay <<STR_FREE5>>? \nTeach me sometime. OK?!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 94,
+      "label": "",
+      "original": "I only ever listen to \n<<STR_FREE10>> at home. It's\n<<STR_FREE12>>!\n",
+      "new": "I only ever listen to \n<<STR_FREE10>> at home. It's\n<<STR_FREE12>>!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 95,
+      "label": "",
+      "original": "Is it just me, or are there\nfewer trees around here?\nWho's cutting them down?\n",
+      "new": "Is it just me, or are there\nfewer trees around here?\nWho's cutting them down?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 96,
+      "label": "",
+      "original": "By the way, here's a gift for\nyou. No special reason.\n",
+      "new": "By the way, here's a gift for\nyou. No special reason.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 97,
+      "label": "",
+      "original": "I was chillin' in a nearby\nvillage, and I got you this\nsouvenir. You like it?\n",
+      "new": "I was chillin' in a nearby\nvillage, and I got you this\nsouvenir. You like it?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 98,
+      "label": "",
+      "original": "Hey, I got two of these \n<<STR_FREE12>> things, and\nI'd like you to have one.\n",
+      "new": "Hey, I got two of these \n<<STR_FREE12>> things, and\nI'd like you to have one.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 99,
+      "label": "",
+      "original": "I don't known why this was\nin the dumpーit's still good!\nI grabbed it for you.\n",
+      "new": "I don't known why this was\nin the dumpーit's still good!\nI grabbed it for you.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 100,
+      "label": "",
+      "original": "I did some shopping while I\nwas out of town. Hey, I even\ngot something for you!\n",
+      "new": "I did some shopping while I\nwas out of town. Hey, I even\ngot something for you!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 101,
+      "label": "",
+      "original": "I was going to give this to\n<<STR_FREE2>>, but heard you\ncollect 'em. Is that true?\n",
+      "new": "I was going to give this to\n<<STR_FREE2>>, but heard you\ncollect 'em. Is that true?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 102,
+      "label": "",
+      "original": "This is for always being\nnice to me. Don't give me a\nhard time. Just take it.\n",
+      "new": "This is for always being\nnice to me. Don't give me a\nhard time. Just take it.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 103,
+      "label": "",
+      "original": "I was digging holes, and\nfound this. You take it. It's\ntoo <<STR_FREE9>> for me.\n",
+      "new": "I was digging holes, and\nfound this. You take it. It's\ntoo <<STR_FREE9>> for me.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 104,
+      "label": "",
+      "original": "This is a bit <<STR_FREE13>>,\nbut I'd rather give it to you\nthan sell it to Tom. \n",
+      "new": "This is a bit <<STR_FREE13>>,\nbut I'd rather give it to you\nthan sell it to Tom. \n"
+    },
+    {
+      "group": "mailb",
+      "index": 105,
+      "label": "",
+      "original": "I found a Lucky Bag of\n<<STR_FREE9>> stuff in\nmy bureau. Let's split it!\n",
+      "new": "I found a Lucky Bag of\n<<STR_FREE9>> stuff in\nmy bureau. Let's split it!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 106,
+      "label": "",
+      "original": "My room's been such a mess\nlately. It's <<STR_FREE13>>!\nTake this off my hands, OK?\n",
+      "new": "My room's been such a mess\nlately. It's <<STR_FREE13>>!\nTake this off my hands, OK?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 107,
+      "label": "",
+      "original": "Sometimes, even your\n<<STR_FREE12>> things get in\nthe way. Do you want this?\n",
+      "new": "Sometimes, even your\n<<STR_FREE12>> things get in\nthe way. Do you want this?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 108,
+      "label": "",
+      "original": "<<STR_FREE2>> gave this to\nme, but it's just not me.\nMaybe you can use it.\n",
+      "new": "<<STR_FREE2>> gave this to\nme, but it's just not me.\nMaybe you can use it.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 109,
+      "label": "",
+      "original": "Oh, <<STR_FREE2>> made me\ntake this even after I said\nno. Here, it's all yours.\n",
+      "new": "Oh, <<STR_FREE2>> made me\ntake this even after I said\nno. Here, it's all yours.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 110,
+      "label": "",
+      "original": "This was on sale. Why can't\nI resist buying things on\nsale!? Isn' it <<STR_FREE13>>?\n",
+      "new": "This was on sale. Why can't\nI resist buying things on\nsale!? Isn' it <<STR_FREE13>>?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 111,
+      "label": "",
+      "original": "For some reason, I bought\nanother one of these. Here,\nyou take my old one.\n",
+      "new": "For some reason, I bought\nanother one of these. Here,\nyou take my old one.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 112,
+      "label": "",
+      "original": "You play <<STR_FREE5>>,\ndon't you? Let's get together\nand give it a shot!\n",
+      "new": "You play <<STR_FREE5>>,\ndon't you? Let's get together\nand give it a shot!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 113,
+      "label": "",
+      "original": "Yesterday, <<STR_FREE2>> and\nI played <<STR_FREE5>>. It\nwas just <<STR_FREE9>>.\n",
+      "new": "Yesterday, <<STR_FREE2>> and\nI played <<STR_FREE5>>. It\nwas just <<STR_FREE9>>.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 114,
+      "label": "",
+      "original": "I watched <<STR_FREE4>>\nyesterday. I really wish\nI could've played!\n",
+      "new": "I watched <<STR_FREE4>>\nyesterday. I really wish\nI could've played!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 115,
+      "label": "",
+      "original": "Hey, hey! <<STR_FREE3>> is\n<<STR_FREE8>>, right? I haven't\nhad any in quite a while.\n",
+      "new": "Hey, hey! <<STR_FREE3>> is\n<<STR_FREE8>>, right? I haven't\nhad any in quite a while.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 116,
+      "label": "",
+      "original": "Have you ever seen\n<<STR_FREE2>>'s place?\nIt's a bit <<STR_FREE9>>.\n",
+      "new": "Have you ever seen\n<<STR_FREE2>>'s place?\nIt's a bit <<STR_FREE9>>.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 117,
+      "label": "",
+      "original": "Tell me, what do you think\nof the name <<STR_FREE1>>?\nIs it too <<STR_FREE12>>?\n",
+      "new": "Tell me, what do you think\nof the name <<STR_FREE1>>?\nIs it too <<STR_FREE12>>?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 118,
+      "label": "",
+      "original": "I saw this guitarist in front\nof the station Saturday\nnight. <<CAPTIALIZE>><<STR_FREE12>>!\n",
+      "new": "I saw this guitarist in front\nof the station Saturday\nnight. <<CAPTIALIZE>><<STR_FREE12>>!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 119,
+      "label": "",
+      "original": "Oh, yeah, I caught a huge\n<<STR_FREE6>> the other\nday! Ha ha! It was a cinch!\n",
+      "new": "Oh, yeah, I caught a huge\n<<STR_FREE6>> the other\nday! Ha ha! It was a cinch!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 120,
+      "label": "",
+      "original": "Do you like <<STR_FREE10>>?\nI love it! It's totally\n<<STR_FREE12>> to rock to!\n",
+      "new": "Do you like <<STR_FREE10>>?\nI love it! It's totally\n<<STR_FREE12>> to rock to!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 121,
+      "label": "",
+      "original": "Have you ever tried making a\nnew village melody? Mine\nare always <<STR_FREE13>>.\n",
+      "new": "Have you ever tried making a\nnew village melody? Mine\nare always <<STR_FREE13>>.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 122,
+      "label": "",
+      "original": "I collect bugs, but I can't\ncatch even one tiny\n<<STR_FREE7>>! I it!\n",
+      "new": "I collect bugs, but I can't\ncatch even one tiny\n<<STR_FREE7>>! I it!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 123,
+      "label": "",
+      "original": "<<STR_FREE2>> doesn't know\nthe rules to <<STR_FREE4>>!\nCompletely <<STR_FREE13>>!\n",
+      "new": "<<STR_FREE2>> doesn't know\nthe rules to <<STR_FREE4>>!\nCompletely <<STR_FREE13>>!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 124,
+      "label": "",
+      "original": "Listen to this! I was out\nshaking trees, and a piece of\nfurniture dropped on me!\n",
+      "new": "Listen to this! I was out\nshaking trees, and a piece of\nfurniture dropped on me!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 125,
+      "label": "",
+      "original": "I heard that if you plant a\nbag of bells in a certain\nspot, a tree will grow!\n",
+      "new": "I heard that if you plant a\nbag of bells in a certain\nspot, a tree will grow!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 126,
+      "label": "",
+      "original": "Boy, am I hungry. I wonder\nif anyone would cook me up\nsome <<STR_FREE3>>.\n",
+      "new": "Boy, am I hungry. I wonder\nif anyone would cook me up\nsome <<STR_FREE3>>.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 127,
+      "label": "",
+      "original": "I was out digging, and I\nfound a funky fossil! Why\ndon't you try finding one?\n",
+      "new": "I was out digging, and I\nfound a funky fossil! Why\ndon't you try finding one?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 128,
+      "label": "",
+      "original": "I don't know why, and I don't\nwant to, but my niece asked\nme to give this to you.\n",
+      "new": "I don't know why, and I don't\nwant to, but my niece asked\nme to give this to you.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 129,
+      "label": "",
+      "original": "I went to this village out in\nthe sticks, and, well...I\ngot this for you.\n",
+      "new": "I went to this village out in\nthe sticks, and, well...I\ngot this for you.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 130,
+      "label": "",
+      "original": "Why don't you to cook up\nsome <<STR_FREE3>> for me?\nI'll even pay for it!\n",
+      "new": "Why don't you to cook up\nsome <<STR_FREE3>> for me?\nI'll even pay for it!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 131,
+      "label": "",
+      "original": "You threw this away, didn't\nyou? Don't lie to me! You\nhorrible, horrible person!\n",
+      "new": "You threw this away, didn't\nyou? Don't lie to me! You\nhorrible, horrible person!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 132,
+      "label": "",
+      "original": "Did you drop this? No?\nI could have sworn I saw\nyou trying to hide it. Hm....\n",
+      "new": "Did you drop this? No?\nI could have sworn I saw\nyou trying to hide it. Hm....\n"
+    },
+    {
+      "group": "mailb",
+      "index": 133,
+      "label": "",
+      "original": "<<STR_FREE2>> told me to give\nthis to you. Why? It's not\nlike I don't have stuff to do.\n",
+      "new": "<<STR_FREE2>> told me to give\nthis to you. Why? It's not\nlike I don't have stuff to do.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 134,
+      "label": "",
+      "original": "This is my way of saying\nthanks. Don't get all weepy\nabout it or anything.\n",
+      "new": "This is my way of saying\nthanks. Don't get all weepy\nabout it or anything.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 135,
+      "label": "",
+      "original": "I figured I'd forget to give\nthis to you in person, so\nI'll send it to you instead.\n",
+      "new": "I figured I'd forget to give\nthis to you in person, so\nI'll send it to you instead.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 136,
+      "label": "",
+      "original": "Look, I'm in a hurry. Could\nyou throw this away for me?\nYou're not busy, are you?\n",
+      "new": "Look, I'm in a hurry. Could\nyou throw this away for me?\nYou're not busy, are you?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 137,
+      "label": "",
+      "original": "You like the thrill of\nopening presents, don't ya?\nWell, this thrills on me!\n",
+      "new": "You like the thrill of\nopening presents, don't ya?\nWell, this thrills on me!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 138,
+      "label": "",
+      "original": "I must have been crazy to\nbuy this <<STR_FREE13>> thing.\nWell, it's yours now.\n",
+      "new": "I must have been crazy to\nbuy this <<STR_FREE13>> thing.\nWell, it's yours now.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 139,
+      "label": "",
+      "original": "This is <<STR_FREE12>>, so I'm\nletting you have it. Why?\n'Cuz I'm generous! OK!?\n",
+      "new": "This is <<STR_FREE12>>, so I'm\nletting you have it. Why?\n'Cuz I'm generous! OK!?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 140,
+      "label": "",
+      "original": "I won this at <<STR_FREE4>>,\nbut I don't need it.\nIt's all yours if you want it.\n",
+      "new": "I won this at <<STR_FREE4>>,\nbut I don't need it.\nIt's all yours if you want it.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 141,
+      "label": "",
+      "original": "When's your birthday again?\nI didn't want to forget it,\nso I'm sending you this now.\n",
+      "new": "When's your birthday again?\nI didn't want to forget it,\nso I'm sending you this now.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 142,
+      "label": "",
+      "original": "They were selling all kinds of\n<<STR_FREE12>> stuff in a\nvillage nearby. Check it out!\n",
+      "new": "They were selling all kinds of\n<<STR_FREE12>> stuff in a\nvillage nearby. Check it out!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 143,
+      "label": "",
+      "original": "I guess it would be rude to\nthrow something away if I\nthought you could use it.\n",
+      "new": "I guess it would be rude to\nthrow something away if I\nthought you could use it.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 144,
+      "label": "",
+      "original": "I patrol my village every\nnight, and I'm telling you,\nthere are no weirdos here!\n",
+      "new": "I patrol my village every\nnight, and I'm telling you,\nthere are no weirdos here!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 145,
+      "label": "",
+      "original": "What time do you go to bed?\nYou stay up late, don't you!\nMe? Why should I tell you?\n",
+      "new": "What time do you go to bed?\nYou stay up late, don't you!\nMe? Why should I tell you?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 146,
+      "label": "",
+      "original": "Yo, you like sports, right?\nI'm taking a special training\ncourse in <<STR_FREE4>>!\n",
+      "new": "Yo, you like sports, right?\nI'm taking a special training\ncourse in <<STR_FREE4>>!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 147,
+      "label": "",
+      "original": "Hey! I checked out your pad\nthe other day, and...whoa! It\nwas way <<STR_FREE9>>!\n",
+      "new": "Hey! I checked out your pad\nthe other day, and...whoa! It\nwas way <<STR_FREE9>>!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 148,
+      "label": "",
+      "original": "Do you check your mail\nevery day? If so, send me an\nanswer RIGHT AWAY!\n",
+      "new": "Do you check your mail\nevery day? If so, send me an\nanswer RIGHT AWAY!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 149,
+      "label": "",
+      "original": "Tomorrow is supposed to be\n<<STR_FREE12>>. I really want\nto get out of the house.\n",
+      "new": "Tomorrow is supposed to be\n<<STR_FREE12>>. I really want\nto get out of the house.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 150,
+      "label": "",
+      "original": "This furniture Mr. Nook sold\nme was <<STR_FREE9>>!\nHe's got all kinds of stuff.\n",
+      "new": "This furniture Mr. Nook sold\nme was <<STR_FREE9>>!\nHe's got all kinds of stuff.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 151,
+      "label": "",
+      "original": "Ugh! I made <<STR_FREE3>>\nyesterday. <<CAPTIALIZE>><<STR_FREE8>>! It\nwas a complete failure!\n",
+      "new": "Ugh! I made <<STR_FREE3>>\nyesterday. <<CAPTIALIZE>><<STR_FREE8>>! It\nwas a complete failure!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 152,
+      "label": "",
+      "original": "When it comes to music, it's\ngotta be <<STR_FREE10>>!\nReal men dig <<STR_FREE10>>!\n",
+      "new": "When it comes to music, it's\ngotta be <<STR_FREE10>>!\nReal men dig <<STR_FREE10>>!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 153,
+      "label": "",
+      "original": "We have to hear that village\ntheme every time we talk.\nIt should be more catchy.\n",
+      "new": "We have to hear that village\ntheme every time we talk.\nIt should be more catchy.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 154,
+      "label": "",
+      "original": "I heard <<STR_FREE2>> saying\nyou were <<STR_FREE12>>! Are\nyou best friends or what?\n",
+      "new": "I heard <<STR_FREE2>> saying\nyou were <<STR_FREE12>>! Are\nyou best friends or what?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 155,
+      "label": "",
+      "original": "You should take the train\nout of town once in a while.\nTravel does a body good!\n",
+      "new": "You should take the train\nout of town once in a while.\nTravel does a body good!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 156,
+      "label": "",
+      "original": "It's <<STR_FREE12>> when\nsomeone completes another\ndisplay set at the museum.\n",
+      "new": "It's <<STR_FREE12>> when\nsomeone completes another\ndisplay set at the museum.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 157,
+      "label": "",
+      "original": "Post-rain mushrooms are\ngreat, but what the heck is\na post-rain Gyroid?\n",
+      "new": "Post-rain mushrooms are\ngreat, but what the heck is\na post-rain Gyroid?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 158,
+      "label": "",
+      "original": "My niece got me to join in\nsome <<STR_FREE5>> the\nother day. <<CAPTIALIZE>><<STR_FREE9>>.\n",
+      "new": "My niece got me to join in\nsome <<STR_FREE5>> the\nother day. <<CAPTIALIZE>><<STR_FREE9>>.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 159,
+      "label": "",
+      "original": "My most <<STR_FREE9>>\nmemory isーwait a minute!\nI won't share that with you!\n",
+      "new": "My most <<STR_FREE9>>\nmemory isーwait a minute!\nI won't share that with you!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 160,
+      "label": "",
+      "original": "I acquired this recently and\ndecided to send it to you.\nYou'll accept it, of course.\n",
+      "new": "I acquired this recently and\ndecided to send it to you.\nYou'll accept it, of course.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 161,
+      "label": "",
+      "original": "I got this souvenir for you\non a recent trip. It's a bit\nwasted on you, but....\n",
+      "new": "I got this souvenir for you\non a recent trip. It's a bit\nwasted on you, but....\n"
+    },
+    {
+      "group": "mailb",
+      "index": 162,
+      "label": "",
+      "original": "This sort of thing just suits\nyou better than it does me.\nYou may thank me later.\n",
+      "new": "This sort of thing just suits\nyou better than it does me.\nYou may thank me later.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 163,
+      "label": "",
+      "original": "I'd like to know who had\nthe nerve to throw this out!\nI trust you'll treat it better.\n",
+      "new": "I'd like to know who had\nthe nerve to throw this out!\nI trust you'll treat it better.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 164,
+      "label": "",
+      "original": "I found this in the dirt\nand thought you deserved it.\nNo, please don't thank me.\n",
+      "new": "I found this in the dirt\nand thought you deserved it.\nNo, please don't thank me.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 165,
+      "label": "",
+      "original": "It's not that I felt obligated\nor anything. I just thought\nyou'd like a little gift.\n",
+      "new": "It's not that I felt obligated\nor anything. I just thought\nyou'd like a little gift.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 166,
+      "label": "",
+      "original": "This popped up while I was\ncleaning. You may have it\nif you'd like.\n",
+      "new": "This popped up while I was\ncleaning. You may have it\nif you'd like.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 167,
+      "label": "",
+      "original": "I visited a distant hamlet\nand found this little trinket.\nI bought it for you. Here.\n",
+      "new": "I visited a distant hamlet\nand found this little trinket.\nI bought it for you. Here.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 168,
+      "label": "",
+      "original": "This was in the police box.\nIt is yours, isn't it? Well,\ndon't worry if it isn't.\n",
+      "new": "This was in the police box.\nIt is yours, isn't it? Well,\ndon't worry if it isn't.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 169,
+      "label": "",
+      "original": "I no longer need this, and I\nknow you always wanted it...\nThat was you, wasn't it?\n",
+      "new": "I no longer need this, and I\nknow you always wanted it...\nThat was you, wasn't it?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 170,
+      "label": "",
+      "original": "This is a reward for that\nwitty letter of yours. I'm\npositive you could use it.\n",
+      "new": "This is a reward for that\nwitty letter of yours. I'm\npositive you could use it.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 171,
+      "label": "",
+      "original": "While I was abroad, I\npicked something up for you.\nI trust you'll appreciate it.\n",
+      "new": "While I was abroad, I\npicked something up for you.\nI trust you'll appreciate it.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 172,
+      "label": "",
+      "original": "You said you need this, so\nhere you are. I certainly\ndon't want it back.\n",
+      "new": "You said you need this, so\nhere you are. I certainly\ndon't want it back.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 173,
+      "label": "",
+      "original": "I must say, I do pick up the\nmost useless things. Look at\nthis! You should take it.\n",
+      "new": "I must say, I do pick up the\nmost useless things. Look at\nthis! You should take it.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 174,
+      "label": "",
+      "original": "Oh, and I know you buried\nthis in front of my house.\nQuit! You're such a creep!\n",
+      "new": "Oh, and I know you buried\nthis in front of my house.\nQuit! You're such a creep!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 175,
+      "label": "",
+      "original": "I made a fortune on the\nturnip market! This gift is\njust to share my happiness!\n",
+      "new": "I made a fortune on the\nturnip market! This gift is\njust to share my happiness!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 176,
+      "label": "",
+      "original": "My skin is so dry and red.\nI just haven't been sleeping\nenough! I'm not getting old!\n",
+      "new": "My skin is so dry and red.\nI just haven't been sleeping\nenough! I'm not getting old!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 177,
+      "label": "",
+      "original": "Buying turnips isn't difficult,\nbut I do so hate checking\nthe prices every day.\n",
+      "new": "Buying turnips isn't difficult,\nbut I do so hate checking\nthe prices every day.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 178,
+      "label": "",
+      "original": "Every single day, the same\nfaces and the same topics. I\nam so bored! Do something!\n",
+      "new": "Every single day, the same\nfaces and the same topics. I\nam so bored! Do something!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 179,
+      "label": "",
+      "original": "I visited <<STR_FREE2>>'s pad\nrecently, and it was more\n<<STR_FREE12>> than yours.\n",
+      "new": "I visited <<STR_FREE2>>'s pad\nrecently, and it was more\n<<STR_FREE12>> than yours.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 180,
+      "label": "",
+      "original": "What will you take part in\nat the next Sports Fair?\nI live for <<STR_FREE4>>!\n",
+      "new": "What will you take part in\nat the next Sports Fair?\nI live for <<STR_FREE4>>!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 181,
+      "label": "",
+      "original": "<<STR_FREE2>> asked me to\nplay <<STR_FREE5>>. How\njuvenile! I mean, really!\n",
+      "new": "<<STR_FREE2>> asked me to\nplay <<STR_FREE5>>. How\njuvenile! I mean, really!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 182,
+      "label": "",
+      "original": "The <<STR_FREE3>> I made\nlast night was screamingly\n<<STR_FREE11>>!\n",
+      "new": "The <<STR_FREE3>> I made\nlast night was screamingly\n<<STR_FREE11>>!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 183,
+      "label": "",
+      "original": "My boyfriend made\n<<STR_FREE3>> a few days\nago. It was <<STR_FREE8>>! Tsk!\n",
+      "new": "My boyfriend made\n<<STR_FREE3>> a few days\nago. It was <<STR_FREE8>>! Tsk!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 184,
+      "label": "",
+      "original": "I spent the night battling\ncockroaches. In MY house!\nThe nerve of them!\n",
+      "new": "I spent the night battling\ncockroaches. In MY house!\nThe nerve of them!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 185,
+      "label": "",
+      "original": "<<STR_FREE2>> said my home\nwas <<STR_FREE12>>. As if it\ncould be anything less!\n",
+      "new": "<<STR_FREE2>> said my home\nwas <<STR_FREE12>>. As if it\ncould be anything less!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 186,
+      "label": "",
+      "original": "I just adore <<STR_FREE10>>\nmusic. It's so soothing, it\njust carries me away.\n",
+      "new": "I just adore <<STR_FREE10>>\nmusic. It's so soothing, it\njust carries me away.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 187,
+      "label": "",
+      "original": "<<STR_FREE2>>'s <<STR_FREE3>>?\n<<CAPTIALIZE>><<STR_FREE11>>!\nI've been bested!\n",
+      "new": "<<STR_FREE2>>'s <<STR_FREE3>>?\n<<CAPTIALIZE>><<STR_FREE11>>!\nI've been bested!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 188,
+      "label": "",
+      "original": "If I venture from my house\nat different times, I always\ndiscover something new.\n",
+      "new": "If I venture from my house\nat different times, I always\ndiscover something new.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 189,
+      "label": "",
+      "original": "My boyfriend and I are going\n<<STR_FREE6>> fishing.\nI'm so excited! Tee hee hee!\n",
+      "new": "My boyfriend and I are going\n<<STR_FREE6>> fishing.\nI'm so excited! Tee hee hee!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 190,
+      "label": "",
+      "original": "Rumors of money trees has\nme burying bags of bells. I\nwonder if location matters?\n",
+      "new": "Rumors of money trees has\nme burying bags of bells. I\nwonder if location matters?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 191,
+      "label": "",
+      "original": "Crazy Redd duped me! I paid\na ridiculous amount, and for\nwhat? Trash! The nerve!\n",
+      "new": "Crazy Redd duped me! I paid\na ridiculous amount, and for\nwhat? Trash! The nerve!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 192,
+      "label": "",
+      "original": "I found this in front of my\nplace after you left. I think\nyou dropped it.\n",
+      "new": "I found this in front of my\nplace after you left. I think\nyou dropped it.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 193,
+      "label": "",
+      "original": "Did you buy any souvenirs\nwhile you were here? Here's\na gift for you, just in case.\n",
+      "new": "Did you buy any souvenirs\nwhile you were here? Here's\na gift for you, just in case.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 194,
+      "label": "",
+      "original": "It's nice when friends come\nto visit. This is my way of\nsaying thanks.\n",
+      "new": "It's nice when friends come\nto visit. This is my way of\nsaying thanks.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 195,
+      "label": "",
+      "original": "Sorry you came to visit and\nwent home empty-handed. I\nthought you might like this.\n",
+      "new": "Sorry you came to visit and\nwent home empty-handed. I\nthought you might like this.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 196,
+      "label": "",
+      "original": "I don't have many friends\nfrom other villages. Thanks\nfor visiting. Here's a gift.\n",
+      "new": "I don't have many friends\nfrom other villages. Thanks\nfor visiting. Here's a gift.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 197,
+      "label": "",
+      "original": "It was really great of you to\ncome so far just to visit.\nThis is just to say thanks.\n",
+      "new": "It was really great of you to\ncome so far just to visit.\nThis is just to say thanks.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 198,
+      "label": "",
+      "original": "It was a lot of fun having\nyou around, <<STR_FREE0>>.\nHope you come back soon.\n",
+      "new": "It was a lot of fun having\nyou around, <<STR_FREE0>>.\nHope you come back soon.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 199,
+      "label": "",
+      "original": "I'm really happy to have\nmore friends from outside\nmy village.\n",
+      "new": "I'm really happy to have\nmore friends from outside\nmy village.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 200,
+      "label": "",
+      "original": "You were so nice to me.\nI hope you'll accept this as\na token of my friendship.\n",
+      "new": "You were so nice to me.\nI hope you'll accept this as\na token of my friendship.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 201,
+      "label": "",
+      "original": "Uhm, <<STR_FREE0>>, did\nyou bury this in our town?\nNo? Well, either way, here.\n",
+      "new": "Uhm, <<STR_FREE0>>, did\nyou bury this in our town?\nNo? Well, either way, here.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 202,
+      "label": "",
+      "original": "Do you have these in\n<<STR_FREE15>>? Well, I'm\ngiving it to you anyway, OK?\n",
+      "new": "Do you have these in\n<<STR_FREE15>>? Well, I'm\ngiving it to you anyway, OK?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 203,
+      "label": "",
+      "original": "This is really <<STR_FREE12>>.\nI thought it suited you, so\nI'm sending it your way.\n",
+      "new": "This is really <<STR_FREE12>>.\nI thought it suited you, so\nI'm sending it your way.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 204,
+      "label": "",
+      "original": "<<STR_FREE14>>'s police box\nhas some cool stuff. You\nshould come check it out.\n",
+      "new": "<<STR_FREE14>>'s police box\nhas some cool stuff. You\nshould come check it out.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 205,
+      "label": "",
+      "original": "I'm sending you something\nthis time, so now it's your\nturn to send me something.\n",
+      "new": "I'm sending you something\nthis time, so now it's your\nturn to send me something.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 206,
+      "label": "",
+      "original": "I haven't forgotten you,\nso don't you forget me.\nConsider this a bribe, OK?\n",
+      "new": "I haven't forgotten you,\nso don't you forget me.\nConsider this a bribe, OK?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 207,
+      "label": "",
+      "original": "I'm sending you one of my\nprized possessions, but I\nreally want you to have it.\n",
+      "new": "I'm sending you one of my\nprized possessions, but I\nreally want you to have it.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 208,
+      "label": "",
+      "original": "You know, <<STR_FREE0>>,\nafter you went home, I felt\n<<STR_FREE13>>. It stunk.\n",
+      "new": "You know, <<STR_FREE0>>,\nafter you went home, I felt\n<<STR_FREE13>>. It stunk.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 209,
+      "label": "",
+      "original": "I have a friend who lives in\n<<STR_FREE15>>. Have you\never met <<STR_FREE2>>?\n",
+      "new": "I have a friend who lives in\n<<STR_FREE15>>. Have you\never met <<STR_FREE2>>?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 210,
+      "label": "",
+      "original": "The next time you come to\nvisit, could you bring some\n<<STR_FREE3>>? Please?\n",
+      "new": "The next time you come to\nvisit, could you bring some\n<<STR_FREE3>>? Please?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 211,
+      "label": "",
+      "original": "The next time you're by, we\noughta play <<STR_FREE5>>!\nI could use the exercise.\n",
+      "new": "The next time you're by, we\noughta play <<STR_FREE5>>!\nI could use the exercise.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 212,
+      "label": "",
+      "original": "I'm thinking of joining the\n<<STR_FREE4>> club, but\nit seems like a lot of work.\n",
+      "new": "I'm thinking of joining the\n<<STR_FREE4>> club, but\nit seems like a lot of work.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 213,
+      "label": "",
+      "original": "Do they sell any tasty snacks\nin your village? Bring\nsome next time you visit.\n",
+      "new": "Do they sell any tasty snacks\nin your village? Bring\nsome next time you visit.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 214,
+      "label": "",
+      "original": "How was the train ride? Was\nit like a big cradle, rocking\nyou into a safe, deep sleep?\n",
+      "new": "How was the train ride? Was\nit like a big cradle, rocking\nyou into a safe, deep sleep?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 215,
+      "label": "",
+      "original": "Hey, what kind of fruit do\nyou have in your village?\nBring some next time, OK?\n",
+      "new": "Hey, what kind of fruit do\nyou have in your village?\nBring some next time, OK?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 216,
+      "label": "",
+      "original": "Do you have any friends in\n<<STR_FREE15>>? Tell them to\ncome visit us someday.\n",
+      "new": "Do you have any friends in\n<<STR_FREE15>>? Tell them to\ncome visit us someday.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 217,
+      "label": "",
+      "original": "Did you mess with our\nvillage melody? Someone did\nand it's all <<STR_FREE13>>.\n",
+      "new": "Did you mess with our\nvillage melody? Someone did\nand it's all <<STR_FREE13>>.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 218,
+      "label": "",
+      "original": "Ever since you came, I've\nwanted to pack a lunch and\nvisit another town for a day.\n",
+      "new": "Ever since you came, I've\nwanted to pack a lunch and\nvisit another town for a day.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 219,
+      "label": "",
+      "original": "Keep it under your hat, but\nthe price of turnips differs\nfrom village to village!\n",
+      "new": "Keep it under your hat, but\nthe price of turnips differs\nfrom village to village!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 220,
+      "label": "",
+      "original": "The last village I visited\nwas <<STR_FREE9>>. Yep.\nWhat's <<STR_FREE15>> like?\n",
+      "new": "The last village I visited\nwas <<STR_FREE9>>. Yep.\nWhat's <<STR_FREE15>> like?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 221,
+      "label": "",
+      "original": "What color is your roof,\n<<STR_FREE0>>? I hope it's\nmulticolored, like a rainbow.\n",
+      "new": "What color is your roof,\n<<STR_FREE0>>? I hope it's\nmulticolored, like a rainbow.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 222,
+      "label": "",
+      "original": "I waited down at the station\nyesterday, in case you came\nby. What a waste of time.\n",
+      "new": "I waited down at the station\nyesterday, in case you came\nby. What a waste of time.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 223,
+      "label": "",
+      "original": "Did you take some fruit\nfrom our village? I'd been\nwaiting for that to ripen!\n",
+      "new": "Did you take some fruit\nfrom our village? I'd been\nwaiting for that to ripen!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 224,
+      "label": "",
+      "original": "This is to say thank you for\ncoming so far to visit. It\nwas nice to see you.\n",
+      "new": "This is to say thank you for\ncoming so far to visit. It\nwas nice to see you.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 225,
+      "label": "",
+      "original": "I wanted to give you a gift\nfor visiting <<STR_FREE14>>.\nSorry it's so late!\n",
+      "new": "I wanted to give you a gift\nfor visiting <<STR_FREE14>>.\nSorry it's so late!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 226,
+      "label": "",
+      "original": "You came so far to visit,\nand I didn't get to say\nthanks. Take this, please.\n",
+      "new": "You came so far to visit,\nand I didn't get to say\nthanks. Take this, please.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 227,
+      "label": "",
+      "original": "Please accept this small\ntoken of gratitude for\nspending time with me.\n",
+      "new": "Please accept this small\ntoken of gratitude for\nspending time with me.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 228,
+      "label": "",
+      "original": "It's so thrilling to make\nfriends with someone from\nanother village!\n",
+      "new": "It's so thrilling to make\nfriends with someone from\nanother village!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 229,
+      "label": "",
+      "original": "It was nice of you to come\nso far to visit us. Here's a\nlittle gift for being so kind.\n",
+      "new": "It was nice of you to come\nso far to visit us. Here's a\nlittle gift for being so kind.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 230,
+      "label": "",
+      "original": "<<STR_FREE0>>, you made my\nday with your visit. I hope\nyou can come again soon.\n",
+      "new": "<<STR_FREE0>>, you made my\nday with your visit. I hope\nyou can come again soon.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 231,
+      "label": "",
+      "original": "It's strange, but getting to\nmeet people you don't see\nevery day is such a thrill!\n",
+      "new": "It's strange, but getting to\nmeet people you don't see\nevery day is such a thrill!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 232,
+      "label": "",
+      "original": "It's not much, but here's\na little something for\ncoming so far to see me.\n",
+      "new": "It's not much, but here's\na little something for\ncoming so far to see me.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 233,
+      "label": "",
+      "original": "I really goofed by letting you\nreturn home empty-handed.\nWhat was I thinking? Here!\n",
+      "new": "I really goofed by letting you\nreturn home empty-handed.\nWhat was I thinking? Here!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 234,
+      "label": "",
+      "original": "We have lots of these in my\nvillage, but I thought maybe\nyou'd like one for yourself.\n",
+      "new": "We have lots of these in my\nvillage, but I thought maybe\nyou'd like one for yourself.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 235,
+      "label": "",
+      "original": "Did you leave this here by\naccident? I was worried, so\nI decided to send it to you.\n",
+      "new": "Did you leave this here by\naccident? I was worried, so\nI decided to send it to you.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 236,
+      "label": "",
+      "original": "I bought this after you went\nhome. I thought you might\nlike to have it as a present.\n",
+      "new": "I bought this after you went\nhome. I thought you might\nlike to have it as a present.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 237,
+      "label": "",
+      "original": "Someone found this in front\nof the station after you left.\nDid you drop it?\n",
+      "new": "Someone found this in front\nof the station after you left.\nDid you drop it?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 238,
+      "label": "",
+      "original": "Here's a gift to say thanks\nfor visiting. It would be\nnice to see you again.\n",
+      "new": "Here's a gift to say thanks\nfor visiting. It would be\nnice to see you again.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 239,
+      "label": "",
+      "original": "I had such a nice time with\nyou that I decided to give\nyou this! Stay in touch!\n",
+      "new": "I had such a nice time with\nyou that I decided to give\nyou this! Stay in touch!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 240,
+      "label": "",
+      "original": "I'm sure all that travel\ntuckered you out, but I\nhope you'll visit again.\n",
+      "new": "I'm sure all that travel\ntuckered you out, but I\nhope you'll visit again.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 241,
+      "label": "",
+      "original": "Did you make it home\nwithout any trouble? I have\nmy doubts about that train.\n",
+      "new": "Did you make it home\nwithout any trouble? I have\nmy doubts about that train.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 242,
+      "label": "",
+      "original": "So what did you think\nof your visit to our\nquaint little village?\n",
+      "new": "So what did you think\nof your visit to our\nquaint little village?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 243,
+      "label": "",
+      "original": "I only wish that, someday,\nI could visit your village.\nAh, someday...\n",
+      "new": "I only wish that, someday,\nI could visit your village.\nAh, someday...\n"
+    },
+    {
+      "group": "mailb",
+      "index": 244,
+      "label": "",
+      "original": "Did you go shopping while\nyou were here? Did you\nfind anything interesting?\n",
+      "new": "Did you go shopping while\nyou were here? Did you\nfind anything interesting?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 245,
+      "label": "",
+      "original": "I'd love to visit your village\nand see what I could find\nfor sale there.\n",
+      "new": "I'd love to visit your village\nand see what I could find\nfor sale there.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 246,
+      "label": "",
+      "original": "I like <<STR_FREE14>>, but to\nsee new places and new\nfaces... Oh, I want to move!\n",
+      "new": "I like <<STR_FREE14>>, but to\nsee new places and new\nfaces... Oh, I want to move!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 247,
+      "label": "",
+      "original": "Do you have lots of friends\nin your village? I'd like to\ntravel there some time.\n",
+      "new": "Do you have lots of friends\nin your village? I'd like to\ntravel there some time.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 248,
+      "label": "",
+      "original": "I'm starting to feel like\nmaybe it's time for me to\nmove to a new village.\n",
+      "new": "I'm starting to feel like\nmaybe it's time for me to\nmove to a new village.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 249,
+      "label": "",
+      "original": "It seems like only yesterday\nthat you visited. You must\ncome again, <<STR_FREE0>>.\n",
+      "new": "It seems like only yesterday\nthat you visited. You must\ncome again, <<STR_FREE0>>.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 250,
+      "label": "",
+      "original": "The next time you visit,\nplease bring <<STR_FREE2>>.\nWe're such good friends.\n",
+      "new": "The next time you visit,\nplease bring <<STR_FREE2>>.\nWe're such good friends.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 251,
+      "label": "",
+      "original": "Please come see me again\nbefore I decide to move off\nto another village. \n",
+      "new": "Please come see me again\nbefore I decide to move off\nto another village. \n"
+    },
+    {
+      "group": "mailb",
+      "index": 252,
+      "label": "",
+      "original": "How's the weather in your\ntown? It's <<STR_FREE9>>\nhere. No big deal, though.\n",
+      "new": "How's the weather in your\ntown? It's <<STR_FREE9>>\nhere. No big deal, though.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 253,
+      "label": "",
+      "original": "I wonder what your place is\nlike, <<STR_FREE0>>. I bet\nit's <<STR_FREE12>>.\n",
+      "new": "I wonder what your place is\nlike, <<STR_FREE0>>. I bet\nit's <<STR_FREE12>>.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 254,
+      "label": "",
+      "original": "I had a feeling you might\nvisit. I spent the whole\nday waiting to see you.\n",
+      "new": "I had a feeling you might\nvisit. I spent the whole\nday waiting to see you.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 255,
+      "label": "",
+      "original": "What kind of music do you\nlisten to in your village?\nIt's all <<STR_FREE10>> here.\n",
+      "new": "What kind of music do you\nlisten to in your village?\nIt's all <<STR_FREE10>> here.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 256,
+      "label": "",
+      "original": "It was so super of you to\nvisit me. Here's a special\npresent from me to you!\n",
+      "new": "It was so super of you to\nvisit me. Here's a special\npresent from me to you!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 257,
+      "label": "",
+      "original": "I decided to send you this\nsince we got along so well.\nI think it's super cool!\n",
+      "new": "I decided to send you this\nsince we got along so well.\nI think it's super cool!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 258,
+      "label": "",
+      "original": "I thought of you while\nI was shopping, so I\npicked this up as a gift.\n",
+      "new": "I thought of you while\nI was shopping, so I\npicked this up as a gift.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 259,
+      "label": "",
+      "original": "Since we're such good pals\nnow, I figured I'd better\nsend a gift with this letter.\n",
+      "new": "Since we're such good pals\nnow, I figured I'd better\nsend a gift with this letter.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 260,
+      "label": "",
+      "original": "I went shopping and I got\ntoo much and I thought you\nmight want this, so here.\n",
+      "new": "I went shopping and I got\ntoo much and I thought you\nmight want this, so here.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 261,
+      "label": "",
+      "original": "My village is famous for\nthis. Next time you visit,\nbring something for me!\n",
+      "new": "My village is famous for\nthis. Next time you visit,\nbring something for me!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 262,
+      "label": "",
+      "original": "This was on sale for almost\nnothing, so I thought I'd\nbuy it, <<STR_FREE0>>.\n",
+      "new": "This was on sale for almost\nnothing, so I thought I'd\nbuy it, <<STR_FREE0>>.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 263,
+      "label": "",
+      "original": "Sending you a present when\nit's not your birthday isn't\nweird or anything, is it?\n",
+      "new": "Sending you a present when\nit's not your birthday isn't\nweird or anything, is it?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 264,
+      "label": "",
+      "original": "I know you live far away,\nbut please don't forget me!\nTake this as a reminder.\n",
+      "new": "I know you live far away,\nbut please don't forget me!\nTake this as a reminder.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 265,
+      "label": "",
+      "original": "When you look at this gift,\nthink of me and all the fun\nwe had together!\n",
+      "new": "When you look at this gift,\nthink of me and all the fun\nwe had together!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 266,
+      "label": "",
+      "original": "<<STR_FREE0>>, you live too\nfar away. I never get to see\nyou! Remember me with this!\n",
+      "new": "<<STR_FREE0>>, you live too\nfar away. I never get to see\nyou! Remember me with this!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 267,
+      "label": "",
+      "original": "Hey, <<STR_FREE0>>! Did you\nforget this when you were\nhere? I'm sure it's yours.\n",
+      "new": "Hey, <<STR_FREE0>>! Did you\nforget this when you were\nhere? I'm sure it's yours.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 268,
+      "label": "",
+      "original": "I purchased this especially\nfor you, <<STR_FREE0>>.\nYes, I know you love me.\n",
+      "new": "I purchased this especially\nfor you, <<STR_FREE0>>.\nYes, I know you love me.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 269,
+      "label": "",
+      "original": "I had so much fun with you\nthat I got you this. I don't\nknow if you'll like it, but...\n",
+      "new": "I had so much fun with you\nthat I got you this. I don't\nknow if you'll like it, but...\n"
+    },
+    {
+      "group": "mailb",
+      "index": 270,
+      "label": "",
+      "original": "I dug this up and thought\nyou should see it. I wonder\nwho buried it...\n",
+      "new": "I dug this up and thought\nyou should see it. I wonder\nwho buried it...\n"
+    },
+    {
+      "group": "mailb",
+      "index": 271,
+      "label": "",
+      "original": "I'm sending you this gift\nin the hopes that maybe\nyou'll come see me again!\n",
+      "new": "I'm sending you this gift\nin the hopes that maybe\nyou'll come see me again!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 272,
+      "label": "",
+      "original": "I hope your train trip\ndidn't tire you out. Please\nrest up!\n",
+      "new": "I hope your train trip\ndidn't tire you out. Please\nrest up!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 273,
+      "label": "",
+      "original": "How was the train ride? I\nhaven't been on a train\nsince I was a little girl!\n",
+      "new": "How was the train ride? I\nhaven't been on a train\nsince I was a little girl!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 274,
+      "label": "",
+      "original": "I think it's my turn to visit\nyour village. I'd really like\nto, but I'm always so busy...\n",
+      "new": "I think it's my turn to visit\nyour village. I'd really like\nto, but I'm always so busy...\n"
+    },
+    {
+      "group": "mailb",
+      "index": 275,
+      "label": "",
+      "original": "I'm so jealous of your pals\nat home, because they get\nto see you all the time!\n",
+      "new": "I'm so jealous of your pals\nat home, because they get\nto see you all the time!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 276,
+      "label": "",
+      "original": "Traveling to new villages\nand meeting new people is\ntotally <<STR_FREE12>>!\n",
+      "new": "Traveling to new villages\nand meeting new people is\ntotally <<STR_FREE12>>!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 277,
+      "label": "",
+      "original": "We live so far apart that we\nrarely see each other, but\nplease don't forget about me.\n",
+      "new": "We live so far apart that we\nrarely see each other, but\nplease don't forget about me.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 278,
+      "label": "",
+      "original": "The next time you visit,\nI'll treat you to some\n<<STR_FREE3>>!\n",
+      "new": "The next time you visit,\nI'll treat you to some\n<<STR_FREE3>>!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 279,
+      "label": "",
+      "original": "Living in the same place for\ntoo long is so <<STR_FREE13>>!\nI want to go someplace new!\n",
+      "new": "Living in the same place for\ntoo long is so <<STR_FREE13>>!\nI want to go someplace new!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 280,
+      "label": "",
+      "original": "So, <<STR_FREE0>>, what's\n<<STR_FREE15>> like, anyway?\nI'm really curious.\n",
+      "new": "So, <<STR_FREE0>>, what's\n<<STR_FREE15>> like, anyway?\nI'm really curious.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 281,
+      "label": "",
+      "original": "Do you remember the town\ntune in <<STR_FREE14>>? Come\nvisit us so you don't forget.\n",
+      "new": "Do you remember the town\ntune in <<STR_FREE14>>? Come\nvisit us so you don't forget.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 282,
+      "label": "",
+      "original": "Did you write anything on\nour bulletin board? Maybe I\nshould just go and look.\n",
+      "new": "Did you write anything on\nour bulletin board? Maybe I\nshould just go and look.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 283,
+      "label": "",
+      "original": "I'd love to go and see you\nevery day, but it's so far. I\nguess I'll just wait for you.\n",
+      "new": "I'd love to go and see you\nevery day, but it's so far. I\nguess I'll just wait for you.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 284,
+      "label": "",
+      "original": "By the way, please say hi\nto <<STR_FREE2>> for me.\nWe're the best of friends!\n",
+      "new": "By the way, please say hi\nto <<STR_FREE2>> for me.\nWe're the best of friends!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 285,
+      "label": "",
+      "original": "I'd love it if our villages\nhad a <<STR_FREE4>>\ncontest. We're pretty good!\n",
+      "new": "I'd love it if our villages\nhad a <<STR_FREE4>>\ncontest. We're pretty good!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 286,
+      "label": "",
+      "original": "<<STR_FREE0>>, you can't just\ngo around chopping down\ntrees in other villages!\n",
+      "new": "<<STR_FREE0>>, you can't just\ngo around chopping down\ntrees in other villages!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 287,
+      "label": "",
+      "original": "How's life in <<STR_FREE15>>?\nI was thinking about\ncoming for a visit sometime.\n",
+      "new": "How's life in <<STR_FREE15>>?\nI was thinking about\ncoming for a visit sometime.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 288,
+      "label": "",
+      "original": "By the way, here's a little\ngift in appreciation for your\ncoming to visit. Thanks!\n",
+      "new": "By the way, here's a little\ngift in appreciation for your\ncoming to visit. Thanks!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 289,
+      "label": "",
+      "original": "I forgot to give you a\nsouvenir for braving the\ntrain to come visit us!\n",
+      "new": "I forgot to give you a\nsouvenir for braving the\ntrain to come visit us!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 290,
+      "label": "",
+      "original": "I can't believe I let such a\ngood friend go home\nempty-handed! I'm so sorry!\n",
+      "new": "I can't believe I let such a\ngood friend go home\nempty-handed! I'm so sorry!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 291,
+      "label": "",
+      "original": "I was psyched that you came\nto visit. This gift is a bit\nlate, but here you go.\n",
+      "new": "I was psyched that you came\nto visit. This gift is a bit\nlate, but here you go.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 292,
+      "label": "",
+      "original": "I had planned on giving this\nbefore you left, but I forgot.\n",
+      "new": "I had planned on giving this\nbefore you left, but I forgot.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 293,
+      "label": "",
+      "original": "My village prides itself on\nquality goods like this!\nDon't be shy, just take it!\n",
+      "new": "My village prides itself on\nquality goods like this!\nDon't be shy, just take it!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 294,
+      "label": "",
+      "original": "Just take this, OK? It's\nsomething to remember your\nvisit to <<STR_FREE14>> by.\n",
+      "new": "Just take this, OK? It's\nsomething to remember your\nvisit to <<STR_FREE14>> by.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 295,
+      "label": "",
+      "original": "If you come visit again, I'll\ngive you something even\nbetter than this! I promise!\n",
+      "new": "If you come visit again, I'll\ngive you something even\nbetter than this! I promise!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 296,
+      "label": "",
+      "original": "Did you drop this in front\nof my house? I don't know\nfor sure, but here it is.\n",
+      "new": "Did you drop this in front\nof my house? I don't know\nfor sure, but here it is.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 297,
+      "label": "",
+      "original": "We don't get to see each\nother often, so here's a gift\nto remember me by.\n",
+      "new": "We don't get to see each\nother often, so here's a gift\nto remember me by.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 298,
+      "label": "",
+      "original": "Even though we don't hang\nout all that often, we're\nstill friends, right?\n",
+      "new": "Even though we don't hang\nout all that often, we're\nstill friends, right?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 299,
+      "label": "",
+      "original": "I have one JUST like this....\nIf it's not too freaky, keep\nit. All right? ALL RIGHT!?\n",
+      "new": "I have one JUST like this....\nIf it's not too freaky, keep\nit. All right? ALL RIGHT!?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 300,
+      "label": "",
+      "original": "I found this at the store\nand thought it was made\nfor you. Anyway, here it is.\n",
+      "new": "I found this at the store\nand thought it was made\nfor you. Anyway, here it is.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 301,
+      "label": "",
+      "original": "Can you buy these in\n<<STR_FREE15>>? No? You're\nlucky I got one for you.\n",
+      "new": "Can you buy these in\n<<STR_FREE15>>? No? You're\nlucky I got one for you.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 302,
+      "label": "",
+      "original": "This here's a personal\ntreasure, <<STR_FREE0>>, but\nI want you to have it, pal.\n",
+      "new": "This here's a personal\ntreasure, <<STR_FREE0>>, but\nI want you to have it, pal.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 303,
+      "label": "",
+      "original": "Thanks for coming so far to\nhang out. This is for you.\nYou're coming again, right?\n",
+      "new": "Thanks for coming so far to\nhang out. This is for you.\nYou're coming again, right?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 304,
+      "label": "",
+      "original": "Next time you're in town,\nlet's try our luck catching\nsome <<CUTARTICLE>><<STR_FREE6>>!\n",
+      "new": "Next time you're in town,\nlet's try our luck catching\nsome <<CUTARTICLE>><<STR_FREE6>>!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 305,
+      "label": "",
+      "original": "Catching <<CUTARTICLE>><<STR_FREE7>>\nis all the rage in my\nvillage. How about yours?\n",
+      "new": "Catching <<CUTARTICLE>><<STR_FREE7>>\nis all the rage in my\nvillage. How about yours?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 306,
+      "label": "",
+      "original": "When you decide to come by\nagain, bring some of your\nlocal fruit with you!\n",
+      "new": "When you decide to come by\nagain, bring some of your\nlocal fruit with you!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 307,
+      "label": "",
+      "original": "I'd love to get out and see\nother villages. It sounds\nlike such a great adventure!\n",
+      "new": "I'd love to get out and see\nother villages. It sounds\nlike such a great adventure!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 308,
+      "label": "",
+      "original": "What sports are popular in\nyour hometown? We're all\nabout <<STR_FREE4>> here.\n",
+      "new": "What sports are popular in\nyour hometown? We're all\nabout <<STR_FREE4>> here.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 309,
+      "label": "",
+      "original": "Are you good at composing\nmusic? Next time you visit,\nfix our town tune, please!\n",
+      "new": "Are you good at composing\nmusic? Next time you visit,\nfix our town tune, please!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 310,
+      "label": "",
+      "original": "Does this traveling musician\nnamed Totakeke visit your\ntown, too? He's <<STR_FREE12>>!\n",
+      "new": "Does this traveling musician\nnamed Totakeke visit your\ntown, too? He's <<STR_FREE12>>!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 311,
+      "label": "",
+      "original": "Maybe if someone from my\nvillage goes to visit yours, I\nmight be able to move there!\n",
+      "new": "Maybe if someone from my\nvillage goes to visit yours, I\nmight be able to move there!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 312,
+      "label": "",
+      "original": "It must be cool to travel so\nfreely! I would love to get\nout and see the world.\n",
+      "new": "It must be cool to travel so\nfreely! I would love to get\nout and see the world.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 313,
+      "label": "",
+      "original": "If I ever move, I think I'd\nlike to live in <<STR_FREE15>>\nwith you, <<STR_FREE0>>.\n",
+      "new": "If I ever move, I think I'd\nlike to live in <<STR_FREE15>>\nwith you, <<STR_FREE0>>.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 314,
+      "label": "",
+      "original": "Yo! Did you leave a message\non our bulletin board? Write\nsomething next time, OK?\n",
+      "new": "Yo! Did you leave a message\non our bulletin board? Write\nsomething next time, OK?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 315,
+      "label": "",
+      "original": "I've been to your village\nbefore, <<STR_FREE2>>. It was\nquite a while ago, though.\n",
+      "new": "I've been to your village\nbefore, <<STR_FREE2>>. It was\nquite a while ago, though.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 316,
+      "label": "",
+      "original": "Listen to this! A while back,\nI shook a tree, and a bee\nhive fell out! What a pain!\n",
+      "new": "Listen to this! A while back,\nI shook a tree, and a bee\nhive fell out! What a pain!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 317,
+      "label": "",
+      "original": "Did you bury a pit trap\nbefore leaving? AAARRRGH!\nWho did it? WHO!?\n",
+      "new": "Did you bury a pit trap\nbefore leaving? AAARRRGH!\nWho did it? WHO!?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 318,
+      "label": "",
+      "original": "Other villages often have\nitems that you just can't\nfind in your own village.\n",
+      "new": "Other villages often have\nitems that you just can't\nfind in your own village.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 319,
+      "label": "",
+      "original": "I am STARVING! Do\nme a favor and bring\nme <<STR_FREE3>>!\n",
+      "new": "I am STARVING! Do\nme a favor and bring\nme <<STR_FREE3>>!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 320,
+      "label": "",
+      "original": "My niece asked me to\nsend this to you.\nHow do you know her?\n",
+      "new": "My niece asked me to\nsend this to you.\nHow do you know her?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 321,
+      "label": "",
+      "original": "I snagged this from the\npolice box, and I thought\nI'd share it with you.\n",
+      "new": "I snagged this from the\npolice box, and I thought\nI'd share it with you.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 322,
+      "label": "",
+      "original": "You forgot this, didn't you?\nYou left it laying in front of\nmy house! Well, take it!\n",
+      "new": "You forgot this, didn't you?\nYou left it laying in front of\nmy house! Well, take it!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 323,
+      "label": "",
+      "original": "You tossed this away in my\nvillage, didn't you? Don't\never do that again! Got it!?\n",
+      "new": "You tossed this away in my\nvillage, didn't you? Don't\never do that again! Got it!?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 324,
+      "label": "",
+      "original": "These are really popular in\nmy village. You can't find\n'em in your town, can you?\n",
+      "new": "These are really popular in\nmy village. You can't find\n'em in your town, can you?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 325,
+      "label": "",
+      "original": "This is for coming so far to\nhang with me. It's a gift,\nso take it already.\n",
+      "new": "This is for coming so far to\nhang with me. It's a gift,\nso take it already.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 326,
+      "label": "",
+      "original": "I figured you weren't strong\nenough to carry this home,\nso I'm mailing it to you.\n",
+      "new": "I figured you weren't strong\nenough to carry this home,\nso I'm mailing it to you.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 327,
+      "label": "",
+      "original": "Here's a gift for you. It was\nfor someone else, but I'm\nmad at him. Bwah ha ha!\n",
+      "new": "Here's a gift for you. It was\nfor someone else, but I'm\nmad at him. Bwah ha ha!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 328,
+      "label": "",
+      "original": "Why'd you leave behind the\ngift I gave you? Hm? Why!?\nI did give it to you, right?\n",
+      "new": "Why'd you leave behind the\ngift I gave you? Hm? Why!?\nI did give it to you, right?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 329,
+      "label": "",
+      "original": "Look out! The box I sent is\nrigged with a spring-loaded\ncream pie. Bwah ha ha!\n",
+      "new": "Look out! The box I sent is\nrigged with a spring-loaded\ncream pie. Bwah ha ha!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 330,
+      "label": "",
+      "original": "Oh, by the way, I forgot to\ngive this to you before you\nleft. Now I have to mail it.\n",
+      "new": "Oh, by the way, I forgot to\ngive this to you before you\nleft. Now I have to mail it.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 331,
+      "label": "",
+      "original": "This is for coming so far to\nvisit. Maybe you can hock it\nfor train fare next time.\n",
+      "new": "This is for coming so far to\nvisit. Maybe you can hock it\nfor train fare next time.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 332,
+      "label": "",
+      "original": "Thanks for visiting. Here's a\nlittle treat for you. Come\nagain. You crack me up!\n",
+      "new": "Thanks for visiting. Here's a\nlittle treat for you. Come\nagain. You crack me up!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 333,
+      "label": "",
+      "original": "Maybe these are common in\nyour town, but I want you to\nhave this. So take it!\n",
+      "new": "Maybe these are common in\nyour town, but I want you to\nhave this. So take it!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 334,
+      "label": "",
+      "original": "I have no clue what type of\nstuff you like, but here!\nNo complaining!\n",
+      "new": "I have no clue what type of\nstuff you like, but here!\nNo complaining!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 335,
+      "label": "",
+      "original": "I was picking up some grub\nwhen I saw this and thought\nof you. So I bought it.\n",
+      "new": "I was picking up some grub\nwhen I saw this and thought\nof you. So I bought it.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 336,
+      "label": "",
+      "original": "I guess each village has its\nown unique stuff for sale, so\ntraveling is where it's at.\n",
+      "new": "I guess each village has its\nown unique stuff for sale, so\ntraveling is where it's at.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 337,
+      "label": "",
+      "original": "Look in the police box from\ntime to time. You can find\ncool stuff! And it's free!\n",
+      "new": "Look in the police box from\ntime to time. You can find\ncool stuff! And it's free!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 338,
+      "label": "",
+      "original": "Hey! What kind of tunes do\nyou like? <<CAPTIALIZE>><<STR_FREE10>> is\nfully hip in <<STR_FREE14>>.\n",
+      "new": "Hey! What kind of tunes do\nyou like? <<CAPTIALIZE>><<STR_FREE10>> is\nfully hip in <<STR_FREE14>>.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 339,
+      "label": "",
+      "original": "Tell those wimps in your\ntown that we challenge them\nto a <<STR_FREE4>> contest!\n",
+      "new": "Tell those wimps in your\ntown that we challenge them\nto a <<STR_FREE4>> contest!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 340,
+      "label": "",
+      "original": "Plant some flowers, will ya?\n<<STR_FREE15>> is an eyesore.\nYou need some nice scenery.\n",
+      "new": "Plant some flowers, will ya?\n<<STR_FREE15>> is an eyesore.\nYou need some nice scenery.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 341,
+      "label": "",
+      "original": "There are times when I just\nwant to get on the train and\nget out of town, too.\n",
+      "new": "There are times when I just\nwant to get on the train and\nget out of town, too.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 342,
+      "label": "",
+      "original": "The same scenery day after\nday gets old! I need to get\nout and see new sights!\n",
+      "new": "The same scenery day after\nday gets old! I need to get\nout and see new sights!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 343,
+      "label": "",
+      "original": "Be careful the next time you\nvisit... I buried a pitfall\nsomewhere! HA HA!\n",
+      "new": "Be careful the next time you\nvisit... I buried a pitfall\nsomewhere! HA HA!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 344,
+      "label": "",
+      "original": "Everyone in <<STR_FREE14>>\nis crazy about <<STR_FREE10>>\nthese days. I wonder why.\n",
+      "new": "Everyone in <<STR_FREE14>>\nis crazy about <<STR_FREE10>>\nthese days. I wonder why.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 345,
+      "label": "",
+      "original": "<<STR_FREE14>>'s town tune\nsounds just <<STR_FREE13>>.\nFix it, or I'll thump you!\n",
+      "new": "<<STR_FREE14>>'s town tune\nsounds just <<STR_FREE13>>.\nFix it, or I'll thump you!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 346,
+      "label": "",
+      "original": "I found a shiny spot in the\nground yesterday! I'm not\ngonna tell you what I found!\n",
+      "new": "I found a shiny spot in the\nground yesterday! I'm not\ngonna tell you what I found!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 347,
+      "label": "",
+      "original": "So you enrolled in the Happy\nRoom Academy, huh? Have\nyou got 10,000 points yet?\n",
+      "new": "So you enrolled in the Happy\nRoom Academy, huh? Have\nyou got 10,000 points yet?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 348,
+      "label": "",
+      "original": "<<CAPTIALIZE>><<STR_FREE15>> used to be\nway too <<STR_FREE9>>.\nHas it changed any?\n",
+      "new": "<<CAPTIALIZE>><<STR_FREE15>> used to be\nway too <<STR_FREE9>>.\nHas it changed any?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 349,
+      "label": "",
+      "original": "Hey! You come into my town,\nand you cut down my trees?\nI loved those trees!!!\n",
+      "new": "Hey! You come into my town,\nand you cut down my trees?\nI loved those trees!!!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 350,
+      "label": "",
+      "original": "The folks in your town are so\nlucky! Every time you travel\nthey have a chance to move!\n",
+      "new": "The folks in your town are so\nlucky! Every time you travel\nthey have a chance to move!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 351,
+      "label": "",
+      "original": "Are there <<STR_FREE6>>\nin your village? Come by\nand fish here sometime.\n",
+      "new": "Are there <<STR_FREE6>>\nin your village? Come by\nand fish here sometime.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 352,
+      "label": "",
+      "original": "I forgot to give you this\ntrinket on your last visit.\nDon't let it go to your head.\n",
+      "new": "I forgot to give you this\ntrinket on your last visit.\nDon't let it go to your head.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 353,
+      "label": "",
+      "original": "I hate to be rude, so I'm\nsending this gift I forgot to\ngive you when you visited.\n",
+      "new": "I hate to be rude, so I'm\nsending this gift I forgot to\ngive you when you visited.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 354,
+      "label": "",
+      "original": "I've been told I'm a bit too\nprim, but it's just not so.\nYou do see that, don't you?\n",
+      "new": "I've been told I'm a bit too\nprim, but it's just not so.\nYou do see that, don't you?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 355,
+      "label": "",
+      "original": "You went and forgot this,\ndidn't you? Yes, you did.\nI'll hear no more of it.\n",
+      "new": "You went and forgot this,\ndidn't you? Yes, you did.\nI'll hear no more of it.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 356,
+      "label": "",
+      "original": "I value all of my friends,\neven those in distant villas.\nSee? I've sent you a present.\n",
+      "new": "I value all of my friends,\neven those in distant villas.\nSee? I've sent you a present.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 357,
+      "label": "",
+      "original": "This is in appreciation of\nyour friendship. Don't be\nshy. Take it and be grateful.\n",
+      "new": "This is in appreciation of\nyour friendship. Don't be\nshy. Take it and be grateful.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 358,
+      "label": "",
+      "original": "I realize your travels were\ntiring, but maybe this gift\nwill everything better.\n",
+      "new": "I realize your travels were\ntiring, but maybe this gift\nwill everything better.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 359,
+      "label": "",
+      "original": "I do love a sale, but this\njust isn't very attractive.\nIt suits you MUCH better.\n",
+      "new": "I do love a sale, but this\njust isn't very attractive.\nIt suits you MUCH better.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 360,
+      "label": "",
+      "original": "Did you bury this in front\nof my home? Unacceptable!\nTake your trash back!\n",
+      "new": "Did you bury this in front\nof my home? Unacceptable!\nTake your trash back!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 361,
+      "label": "",
+      "original": "This is gift from me to you.\nI wanted to make your day a\ntad brighter, that's all.\n",
+      "new": "This is gift from me to you.\nI wanted to make your day a\ntad brighter, that's all.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 362,
+      "label": "",
+      "original": "It's hardly worth making a\nfuss over, but I bought this\nto say thanks for your visit.\n",
+      "new": "It's hardly worth making a\nfuss over, but I bought this\nto say thanks for your visit.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 363,
+      "label": "",
+      "original": "I wanted you to see the type\nof item I value. Now you can\nsend me appropriate gifts.\n",
+      "new": "I wanted you to see the type\nof item I value. Now you can\nsend me appropriate gifts.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 364,
+      "label": "",
+      "original": "Is this not the perfect gift\nfor you? I can sense these\nthings. It's amazing!\n",
+      "new": "Is this not the perfect gift\nfor you? I can sense these\nthings. It's amazing!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 365,
+      "label": "",
+      "original": "I was saving this for your\nnext visit, but I just\ncouldn't wait. Enjoy!\n",
+      "new": "I was saving this for your\nnext visit, but I just\ncouldn't wait. Enjoy!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 366,
+      "label": "",
+      "original": "I was cleaning, and I found\nthis dusty old thing. I want\nyou to have it.\n",
+      "new": "I was cleaning, and I found\nthis dusty old thing. I want\nyou to have it.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 367,
+      "label": "",
+      "original": "I'm so generous. I know you\ncan't afford anything like\nthis, so it's free. Take it.\n",
+      "new": "I'm so generous. I know you\ncan't afford anything like\nthis, so it's free. Take it.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 368,
+      "label": "",
+      "original": "Oh, my complexion is a mess.\nI need more rest. I must be\nradiant for your next visit.\n",
+      "new": "Oh, my complexion is a mess.\nI need more rest. I must be\nradiant for your next visit.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 369,
+      "label": "",
+      "original": "I wonder, is your village\nstore adequately stocked?\nI need a wide selection.\n",
+      "new": "I wonder, is your village\nstore adequately stocked?\nI need a wide selection.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 370,
+      "label": "",
+      "original": "Are there <<STR_FREE7>>\nin your town? Perhaps I'll\ntry to capture one myself!\n",
+      "new": "Are there <<STR_FREE7>>\nin your town? Perhaps I'll\ntry to capture one myself!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 371,
+      "label": "",
+      "original": "I've a mind to try growing\nexotic fruit. Are you doing\nanything challenging?\n",
+      "new": "I've a mind to try growing\nexotic fruit. Are you doing\nanything challenging?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 372,
+      "label": "",
+      "original": "I've heard there are amazing\nfish in <<STR_FREE15>>! Have\nyou ever caught a fish?\n",
+      "new": "I've heard there are amazing\nfish in <<STR_FREE15>>! Have\nyou ever caught a fish?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 373,
+      "label": "",
+      "original": "The next time you visit,\nwe must play <<STR_FREE4>>!\nYou do know how, don't you?\n",
+      "new": "The next time you visit,\nwe must play <<STR_FREE4>>!\nYou do know how, don't you?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 374,
+      "label": "",
+      "original": "When you next visit, bring\nme some <<STR_FREE3>>.\nWe are friends, after all.\n",
+      "new": "When you next visit, bring\nme some <<STR_FREE3>>.\nWe are friends, after all.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 375,
+      "label": "",
+      "original": "It's best to travel and see\nas much as possible while\nyou're young. Don't forget!\n",
+      "new": "It's best to travel and see\nas much as possible while\nyou're young. Don't forget!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 376,
+      "label": "",
+      "original": "Did you tour my glorious\nhome when you visited?\nIt's a must-see, you know.\n",
+      "new": "Did you tour my glorious\nhome when you visited?\nIt's a must-see, you know.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 377,
+      "label": "",
+      "original": "You failed to write anything\non the bulletin board, didn't\nyou! Such a waste! Honestly!\n",
+      "new": "You failed to write anything\non the bulletin board, didn't\nyou! Such a waste! Honestly!\n"
+    },
+    {
+      "group": "mailb",
+      "index": 378,
+      "label": "",
+      "original": "<<CAPTIALIZE>><<STR_FREE10>> is wildly\npopular here. Everyone is\ncompletely <<STR_FREE12>>.\n",
+      "new": "<<CAPTIALIZE>><<STR_FREE10>> is wildly\npopular here. Everyone is\ncompletely <<STR_FREE12>>.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 379,
+      "label": "",
+      "original": "I've always been quite\ncharmed with <<STR_FREE14>>.\nIt's so <<STR_FREE12>>.\n",
+      "new": "I've always been quite\ncharmed with <<STR_FREE14>>.\nIt's so <<STR_FREE12>>.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 380,
+      "label": "",
+      "original": "So what did you think of\n<<STR_FREE14>>? I trust you\nfound it worth the visit.\n",
+      "new": "So what did you think of\n<<STR_FREE14>>? I trust you\nfound it worth the visit.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 381,
+      "label": "",
+      "original": "You'll be stifled if you stick\nto the same old haunts.\nTravel is the only cure.\n",
+      "new": "You'll be stifled if you stick\nto the same old haunts.\nTravel is the only cure.\n"
+    },
+    {
+      "group": "mailb",
+      "index": 382,
+      "label": "",
+      "original": "Are no new villagers moving\ninto <<STR_FREE15>>? Could it\nbe poor living conditions?\n",
+      "new": "Are no new villagers moving\ninto <<STR_FREE15>>? Could it\nbe poor living conditions?\n"
+    },
+    {
+      "group": "mailb",
+      "index": 383,
+      "label": "",
+      "original": "We should compose a village\nsong together. Are your\nmusical skills up to it?\n",
+      "new": "We should compose a village\nsong together. Are your\nmusical skills up to it?\n"
+    },
+    {
+      "group": "mailc",
+      "index": 0,
+      "label": "",
+      "original": "That's all for me...\n",
+      "new": "That's all for me...\n"
+    },
+    {
+      "group": "mailc",
+      "index": 1,
+      "label": "",
+      "original": "Well, it's time to eat.\n",
+      "new": "Well, it's time to eat.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 2,
+      "label": "",
+      "original": "I could sure use a nap.\n",
+      "new": "I could sure use a nap.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 3,
+      "label": "",
+      "original": "Catch ya later, pal.\n",
+      "new": "Catch ya later, pal.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 4,
+      "label": "",
+      "original": "Let's get together soon.\n",
+      "new": "Let's get together soon.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 5,
+      "label": "",
+      "original": "Write again, all right?\n",
+      "new": "Write again, all right?\n"
+    },
+    {
+      "group": "mailc",
+      "index": 6,
+      "label": "",
+      "original": "I'll write soon, maybe!\n",
+      "new": "I'll write soon, maybe!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 7,
+      "label": "",
+      "original": "Until next time, g'bye!\n",
+      "new": "Until next time, g'bye!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 8,
+      "label": "",
+      "original": "Come visit anytime!\n",
+      "new": "Come visit anytime!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 9,
+      "label": "",
+      "original": "Let's chew the fat soon!\n",
+      "new": "Let's chew the fat soon!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 10,
+      "label": "",
+      "original": "Talk to you later. Buh-bye!\n",
+      "new": "Talk to you later. Buh-bye!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 11,
+      "label": "",
+      "original": "So that's it. See you later.\n",
+      "new": "So that's it. See you later.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 12,
+      "label": "",
+      "original": "All right, then. Goodbye.\n",
+      "new": "All right, then. Goodbye.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 13,
+      "label": "",
+      "original": "I'll talk to you later, OK?\n",
+      "new": "I'll talk to you later, OK?\n"
+    },
+    {
+      "group": "mailc",
+      "index": 14,
+      "label": "",
+      "original": "Write if you get time.\n",
+      "new": "Write if you get time.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 15,
+      "label": "",
+      "original": "That's all for now.\n",
+      "new": "That's all for now.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 16,
+      "label": "",
+      "original": "I need a walk.\n",
+      "new": "I need a walk.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 17,
+      "label": "",
+      "original": "I'm getting really hungry.\n",
+      "new": "I'm getting really hungry.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 18,
+      "label": "",
+      "original": "What did I just write?\n",
+      "new": "What did I just write?\n"
+    },
+    {
+      "group": "mailc",
+      "index": 19,
+      "label": "",
+      "original": "I guess I'll see you later!\n",
+      "new": "I guess I'll see you later!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 20,
+      "label": "",
+      "original": "Until next time, bye.\n",
+      "new": "Until next time, bye.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 21,
+      "label": "",
+      "original": "That's it for now. So long.\n",
+      "new": "That's it for now. So long.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 22,
+      "label": "",
+      "original": "Ah, whatever. It's all good.\n",
+      "new": "Ah, whatever. It's all good.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 23,
+      "label": "",
+      "original": "Don't fret, I'll write again!\n",
+      "new": "Don't fret, I'll write again!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 24,
+      "label": "",
+      "original": "Let's talk again tomorrow.\n",
+      "new": "Let's talk again tomorrow.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 25,
+      "label": "",
+      "original": "Bye for now.\n",
+      "new": "Bye for now.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 26,
+      "label": "",
+      "original": "Catch you on the flip-side.\n",
+      "new": "Catch you on the flip-side.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 27,
+      "label": "",
+      "original": "And that's all I had to say.\n",
+      "new": "And that's all I had to say.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 28,
+      "label": "",
+      "original": "I ran out of things to write.\n",
+      "new": "I ran out of things to write.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 29,
+      "label": "",
+      "original": "So, um...yeah...bye.\n",
+      "new": "So, um...yeah...bye.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 30,
+      "label": "",
+      "original": "That's all for now. See you!\n",
+      "new": "That's all for now. See you!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 31,
+      "label": "",
+      "original": "I'll have some jobs for you!\n",
+      "new": "I'll have some jobs for you!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 32,
+      "label": "",
+      "original": "I'm sure I'll see you soon.\n",
+      "new": "I'm sure I'll see you soon.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 33,
+      "label": "",
+      "original": "Bye. Take care!\n",
+      "new": "Bye. Take care!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 34,
+      "label": "",
+      "original": "Take care of yourself.\n",
+      "new": "Take care of yourself.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 35,
+      "label": "",
+      "original": "Come see me more often!\n",
+      "new": "Come see me more often!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 36,
+      "label": "",
+      "original": "Let's chat again soon.\n",
+      "new": "Let's chat again soon.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 37,
+      "label": "",
+      "original": "Please write again.\n",
+      "new": "Please write again.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 38,
+      "label": "",
+      "original": "I'll write to you soon.\n",
+      "new": "I'll write to you soon.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 39,
+      "label": "",
+      "original": "Let's hang out soon.\n",
+      "new": "Let's hang out soon.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 40,
+      "label": "",
+      "original": "Please visit me anytime.\n",
+      "new": "Please visit me anytime.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 41,
+      "label": "",
+      "original": "Let's chat again, OK?\n",
+      "new": "Let's chat again, OK?\n"
+    },
+    {
+      "group": "mailc",
+      "index": 42,
+      "label": "",
+      "original": "Well, that's all for today.\n",
+      "new": "Well, that's all for today.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 43,
+      "label": "",
+      "original": "We'll talk if you're around.\n",
+      "new": "We'll talk if you're around.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 44,
+      "label": "",
+      "original": "Until I see you again, then!\n",
+      "new": "Until I see you again, then!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 45,
+      "label": "",
+      "original": "I look forward to your help.\n",
+      "new": "I look forward to your help.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 46,
+      "label": "",
+      "original": "I do hope to see you soon.\n",
+      "new": "I do hope to see you soon.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 47,
+      "label": "",
+      "original": "I hope to see you again.\n",
+      "new": "I hope to see you again.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 48,
+      "label": "",
+      "original": "I hope you have a good day.\n",
+      "new": "I hope you have a good day.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 49,
+      "label": "",
+      "original": "That's it until next time.\n",
+      "new": "That's it until next time.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 50,
+      "label": "",
+      "original": "Write soon, OK?\n",
+      "new": "Write soon, OK?\n"
+    },
+    {
+      "group": "mailc",
+      "index": 51,
+      "label": "",
+      "original": "Write when you can.\n",
+      "new": "Write when you can.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 52,
+      "label": "",
+      "original": "Keep in touch.\n",
+      "new": "Keep in touch.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 53,
+      "label": "",
+      "original": "I'm going for a walk now.\n",
+      "new": "I'm going for a walk now.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 54,
+      "label": "",
+      "original": "Send me another fun letter!\n",
+      "new": "Send me another fun letter!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 55,
+      "label": "",
+      "original": "Catch you soon. Take care.\n",
+      "new": "Catch you soon. Take care.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 56,
+      "label": "",
+      "original": "Let's get together soon, OK?\n",
+      "new": "Let's get together soon, OK?\n"
+    },
+    {
+      "group": "mailc",
+      "index": 57,
+      "label": "",
+      "original": "Sorry about my handwriting.\n",
+      "new": "Sorry about my handwriting.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 58,
+      "label": "",
+      "original": "Please come and visit again.\n",
+      "new": "Please come and visit again.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 59,
+      "label": "",
+      "original": "That's all for today.\n",
+      "new": "That's all for today.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 60,
+      "label": "",
+      "original": "What an odd letter. Sheesh.\n",
+      "new": "What an odd letter. Sheesh.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 61,
+      "label": "",
+      "original": "Come by and help me again.\n",
+      "new": "Come by and help me again.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 62,
+      "label": "",
+      "original": "Goodbye for now.\n",
+      "new": "Goodbye for now.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 63,
+      "label": "",
+      "original": "That's all for now. Bye.\n",
+      "new": "That's all for now. Bye.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 64,
+      "label": "",
+      "original": "Bye-bye!\n",
+      "new": "Bye-bye!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 65,
+      "label": "",
+      "original": "See you! Take care!\n",
+      "new": "See you! Take care!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 66,
+      "label": "",
+      "original": "I'll miss you! See you soon!\n",
+      "new": "I'll miss you! See you soon!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 67,
+      "label": "",
+      "original": "Well, I guess that's it. Bye!\n",
+      "new": "Well, I guess that's it. Bye!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 68,
+      "label": "",
+      "original": "Come see me soon, mmkay?\n",
+      "new": "Come see me soon, mmkay?\n"
+    },
+    {
+      "group": "mailc",
+      "index": 69,
+      "label": "",
+      "original": "Write me again, OK?\n",
+      "new": "Write me again, OK?\n"
+    },
+    {
+      "group": "mailc",
+      "index": 70,
+      "label": "",
+      "original": "I'll write you soon, I swear!\n",
+      "new": "I'll write you soon, I swear!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 71,
+      "label": "",
+      "original": "Let's get together again!\n",
+      "new": "Let's get together again!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 72,
+      "label": "",
+      "original": "Come visit ANYtime!\n",
+      "new": "Come visit ANYtime!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 73,
+      "label": "",
+      "original": "Let's chat again soon!\n",
+      "new": "Let's chat again soon!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 74,
+      "label": "",
+      "original": "Bye for now! See you soon!\n",
+      "new": "Bye for now! See you soon!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 75,
+      "label": "",
+      "original": "All right then. Adios!\n",
+      "new": "All right then. Adios!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 76,
+      "label": "",
+      "original": "Let's hang out. OK?\n",
+      "new": "Let's hang out. OK?\n"
+    },
+    {
+      "group": "mailc",
+      "index": 77,
+      "label": "",
+      "original": "Until next time! C-ya!\n",
+      "new": "Until next time! C-ya!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 78,
+      "label": "",
+      "original": "Write me soon, or I'll cry!\n",
+      "new": "Write me soon, or I'll cry!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 79,
+      "label": "",
+      "original": "That's all for today. Ciao!\n",
+      "new": "That's all for today. Ciao!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 80,
+      "label": "",
+      "original": "I'll see you, right? Right?\n",
+      "new": "I'll see you, right? Right?\n"
+    },
+    {
+      "group": "mailc",
+      "index": 81,
+      "label": "",
+      "original": "Well...goodbye.\n",
+      "new": "Well...goodbye.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 82,
+      "label": "",
+      "original": "Write me. OK? Bye-eee!\n",
+      "new": "Write me. OK? Bye-eee!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 83,
+      "label": "",
+      "original": "Let's get together soon!\n",
+      "new": "Let's get together soon!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 84,
+      "label": "",
+      "original": "Stay cool! Come by soon!\n",
+      "new": "Stay cool! Come by soon!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 85,
+      "label": "",
+      "original": "Hope you can help me again!\n",
+      "new": "Hope you can help me again!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 86,
+      "label": "",
+      "original": "That's all for today.\n",
+      "new": "That's all for today.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 87,
+      "label": "",
+      "original": "Take care of yourself. Bye!\n",
+      "new": "Take care of yourself. Bye!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 88,
+      "label": "",
+      "original": "Let's hang out tomorrow.\n",
+      "new": "Let's hang out tomorrow.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 89,
+      "label": "",
+      "original": "Sorry for the weird letter.\n",
+      "new": "Sorry for the weird letter.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 90,
+      "label": "",
+      "original": "I'll write again. Aloha!\n",
+      "new": "I'll write again. Aloha!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 91,
+      "label": "",
+      "original": "Bye! Ciao! Adios! Adieu!\n",
+      "new": "Bye! Ciao! Adios! Adieu!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 92,
+      "label": "",
+      "original": "Don't be a stranger.\n",
+      "new": "Don't be a stranger.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 93,
+      "label": "",
+      "original": "Let's talk real soon.\n",
+      "new": "Let's talk real soon.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 94,
+      "label": "",
+      "original": "Come see me soon! Buh-bye!\n",
+      "new": "Come see me soon! Buh-bye!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 95,
+      "label": "",
+      "original": "I'm saving you some errands.\n",
+      "new": "I'm saving you some errands.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 96,
+      "label": "",
+      "original": "OK, so I'll catch you later!\n",
+      "new": "OK, so I'll catch you later!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 97,
+      "label": "",
+      "original": "I'm off! Keep it real.\n",
+      "new": "I'm off! Keep it real.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 98,
+      "label": "",
+      "original": "I think that's all for now.\n",
+      "new": "I think that's all for now.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 99,
+      "label": "",
+      "original": "Catch you later!\n",
+      "new": "Catch you later!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 100,
+      "label": "",
+      "original": "Stop by when you get time.\n",
+      "new": "Stop by when you get time.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 101,
+      "label": "",
+      "original": "Drop me a line, OK?\n",
+      "new": "Drop me a line, OK?\n"
+    },
+    {
+      "group": "mailc",
+      "index": 102,
+      "label": "",
+      "original": "I'll write you again soon.\n",
+      "new": "I'll write you again soon.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 103,
+      "label": "",
+      "original": "That's all for now. Yep!\n",
+      "new": "That's all for now. Yep!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 104,
+      "label": "",
+      "original": "Drop inーwe'll hang out!\n",
+      "new": "Drop inーwe'll hang out!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 105,
+      "label": "",
+      "original": "Come byーwe'll chew the fat!\n",
+      "new": "Come byーwe'll chew the fat!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 106,
+      "label": "",
+      "original": "See you again. Adios!\n",
+      "new": "See you again. Adios!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 107,
+      "label": "",
+      "original": "I'm tapped. Bye!\n",
+      "new": "I'm tapped. Bye!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 108,
+      "label": "",
+      "original": "Let's chill together, OK?\n",
+      "new": "Let's chill together, OK?\n"
+    },
+    {
+      "group": "mailc",
+      "index": 109,
+      "label": "",
+      "original": "Nothing left to say. See you!\n",
+      "new": "Nothing left to say. See you!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 110,
+      "label": "",
+      "original": "Write back. I'll be waiting!\n",
+      "new": "Write back. I'll be waiting!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 111,
+      "label": "",
+      "original": "Well, until next time, goodbye.\n",
+      "new": "Well, until next time, goodbye.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 112,
+      "label": "",
+      "original": "That's the end of my letter!\n",
+      "new": "That's the end of my letter!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 113,
+      "label": "",
+      "original": "I'll write again...someday.\n",
+      "new": "I'll write again...someday.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 114,
+      "label": "",
+      "original": "Stay healthy!\n",
+      "new": "Stay healthy!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 115,
+      "label": "",
+      "original": "Bye for now!\n",
+      "new": "Bye for now!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 116,
+      "label": "",
+      "original": "Anyhew, talk to you later.\n",
+      "new": "Anyhew, talk to you later.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 117,
+      "label": "",
+      "original": "Hmm...yep, that's it. I'm done.\n",
+      "new": "Hmm...yep, that's it. I'm done.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 118,
+      "label": "",
+      "original": "I guess that's it for now.\n",
+      "new": "I guess that's it for now.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 119,
+      "label": "",
+      "original": "I might write, so stay home.\n",
+      "new": "I might write, so stay home.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 120,
+      "label": "",
+      "original": "Drop in again sometime.\n",
+      "new": "Drop in again sometime.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 121,
+      "label": "",
+      "original": "Let's get together real soon.\n",
+      "new": "Let's get together real soon.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 122,
+      "label": "",
+      "original": "I can't wait to write again!\n",
+      "new": "I can't wait to write again!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 123,
+      "label": "",
+      "original": "That's the end of my letter.\n",
+      "new": "That's the end of my letter.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 124,
+      "label": "",
+      "original": "Try to exercise more, OK?\n",
+      "new": "Try to exercise more, OK?\n"
+    },
+    {
+      "group": "mailc",
+      "index": 125,
+      "label": "",
+      "original": "Nothing else to write. Bye.\n",
+      "new": "Nothing else to write. Bye.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 126,
+      "label": "",
+      "original": "<<STR_FREE1>> signing off!",
+      "new": "<<STR_FREE1>> signing off!"
+    },
+    {
+      "group": "mailc",
+      "index": 127,
+      "label": "",
+      "original": "Take care, <<STR_FREE0>>!",
+      "new": "Take care, <<STR_FREE0>>!"
+    },
+    {
+      "group": "mailc",
+      "index": 128,
+      "label": "",
+      "original": "All right, that's all. Bye.\n",
+      "new": "All right, that's all. Bye.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 129,
+      "label": "",
+      "original": "See you later. Much later.\n",
+      "new": "See you later. Much later.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 130,
+      "label": "",
+      "original": "I'm sick of writing now.\n",
+      "new": "I'm sick of writing now.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 131,
+      "label": "",
+      "original": "See you...if I have to.\n",
+      "new": "See you...if I have to.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 132,
+      "label": "",
+      "original": "That's all, so stop reading!\n",
+      "new": "That's all, so stop reading!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 133,
+      "label": "",
+      "original": "Write again, will ya? Jeez.\n",
+      "new": "Write again, will ya? Jeez.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 134,
+      "label": "",
+      "original": "I'll write again later. Maybe.\n",
+      "new": "I'll write again later. Maybe.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 135,
+      "label": "",
+      "original": "That's it until there's more.\n",
+      "new": "That's it until there's more.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 136,
+      "label": "",
+      "original": "Come visit, or else!\n",
+      "new": "Come visit, or else!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 137,
+      "label": "",
+      "original": "Give me a shout sometime.\n",
+      "new": "Give me a shout sometime.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 138,
+      "label": "",
+      "original": "Don't stay up too late.\n",
+      "new": "Don't stay up too late.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 139,
+      "label": "",
+      "original": "Nothing left to say. Bye.\n",
+      "new": "Nothing left to say. Bye.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 140,
+      "label": "",
+      "original": "Stop by sometime.\n",
+      "new": "Stop by sometime.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 141,
+      "label": "",
+      "original": "Stop reading now. Bye.\n",
+      "new": "Stop reading now. Bye.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 142,
+      "label": "",
+      "original": "That's it for today.\n",
+      "new": "That's it for today.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 143,
+      "label": "",
+      "original": "I'm done until next time.\n",
+      "new": "I'm done until next time.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 144,
+      "label": "",
+      "original": "Whew, I'm done. Finally.\n",
+      "new": "Whew, I'm done. Finally.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 145,
+      "label": "",
+      "original": "Don't worry, I'll write again.\n",
+      "new": "Don't worry, I'll write again.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 146,
+      "label": "",
+      "original": "Take care, you hear me?\n",
+      "new": "Take care, you hear me?\n"
+    },
+    {
+      "group": "mailc",
+      "index": 147,
+      "label": "",
+      "original": "I think that wraps it up.\n",
+      "new": "I think that wraps it up.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 148,
+      "label": "",
+      "original": "See you around.\n",
+      "new": "See you around.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 149,
+      "label": "",
+      "original": "Finished! Hoo-ah!\n",
+      "new": "Finished! Hoo-ah!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 150,
+      "label": "",
+      "original": "What? I'm out of paper!?\n",
+      "new": "What? I'm out of paper!?\n"
+    },
+    {
+      "group": "mailc",
+      "index": 151,
+      "label": "",
+      "original": "See if I write you again!\n",
+      "new": "See if I write you again!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 152,
+      "label": "",
+      "original": "Time to get out and be seen.\n",
+      "new": "Time to get out and be seen.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 153,
+      "label": "",
+      "original": "Time for fishing. Bye.\n",
+      "new": "Time for fishing. Bye.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 154,
+      "label": "",
+      "original": "Bye now. What? I'm done!\n",
+      "new": "Bye now. What? I'm done!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 155,
+      "label": "",
+      "original": "OK, I'm sick of writing.\n",
+      "new": "OK, I'm sick of writing.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 156,
+      "label": "",
+      "original": "Good letter, eh? RIGHT?\n",
+      "new": "Good letter, eh? RIGHT?\n"
+    },
+    {
+      "group": "mailc",
+      "index": 157,
+      "label": "",
+      "original": "I want <<STR_FREE3>>!!!",
+      "new": "I want <<STR_FREE3>>!!!"
+    },
+    {
+      "group": "mailc",
+      "index": 158,
+      "label": "",
+      "original": "Hey! Clean your room!\n",
+      "new": "Hey! Clean your room!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 159,
+      "label": "",
+      "original": "Brush before you go to bed!\n",
+      "new": "Brush before you go to bed!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 160,
+      "label": "",
+      "original": "I've gone on long enough.\n",
+      "new": "I've gone on long enough.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 161,
+      "label": "",
+      "original": "Take care of yourself.\n",
+      "new": "Take care of yourself.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 162,
+      "label": "",
+      "original": "Brush your teeth after meals.\n",
+      "new": "Brush your teeth after meals.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 163,
+      "label": "",
+      "original": "Tah-tah.\n",
+      "new": "Tah-tah.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 164,
+      "label": "",
+      "original": "Let's chat again.\n",
+      "new": "Let's chat again.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 165,
+      "label": "",
+      "original": "Do write again.\n",
+      "new": "Do write again.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 166,
+      "label": "",
+      "original": "I shall write again.\n",
+      "new": "I shall write again.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 167,
+      "label": "",
+      "original": "Let's have tea sometime.\n",
+      "new": "Let's have tea sometime.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 168,
+      "label": "",
+      "original": "Drop by anytime, please.\n",
+      "new": "Drop by anytime, please.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 169,
+      "label": "",
+      "original": "I'd love to see you soon.\n",
+      "new": "I'd love to see you soon.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 170,
+      "label": "",
+      "original": "I really must run now.\n",
+      "new": "I really must run now.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 171,
+      "label": "",
+      "original": "Don't be a stranger.\n",
+      "new": "Don't be a stranger.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 172,
+      "label": "",
+      "original": "Until we meet again, adieu.\n",
+      "new": "Until we meet again, adieu.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 173,
+      "label": "",
+      "original": "I look forward to your aid.\n",
+      "new": "I look forward to your aid.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 174,
+      "label": "",
+      "original": "Let's chat on the morrow.\n",
+      "new": "Let's chat on the morrow.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 175,
+      "label": "",
+      "original": "I hope to see you again.\n",
+      "new": "I hope to see you again.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 176,
+      "label": "",
+      "original": "May your tomorrow be lovely.\n",
+      "new": "May your tomorrow be lovely.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 177,
+      "label": "",
+      "original": "I'm finished for today.\n",
+      "new": "I'm finished for today.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 178,
+      "label": "",
+      "original": "Reply to me. Immediately!\n",
+      "new": "Reply to me. Immediately!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 179,
+      "label": "",
+      "original": "You MUST reply. I insist.\n",
+      "new": "You MUST reply. I insist.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 180,
+      "label": "",
+      "original": "I hope I hear from you.\n",
+      "new": "I hope I hear from you.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 181,
+      "label": "",
+      "original": "I believe I am done writing.\n",
+      "new": "I believe I am done writing.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 182,
+      "label": "",
+      "original": "I await your witty reply.\n",
+      "new": "I await your witty reply.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 183,
+      "label": "",
+      "original": "Do take care of yourself.\n",
+      "new": "Do take care of yourself.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 184,
+      "label": "",
+      "original": "Let's meet again soon.\n",
+      "new": "Let's meet again soon.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 185,
+      "label": "",
+      "original": "Did my reply bring you joy?\n",
+      "new": "Did my reply bring you joy?\n"
+    },
+    {
+      "group": "mailc",
+      "index": 186,
+      "label": "",
+      "original": "I'll sneak off to see you.\n",
+      "new": "I'll sneak off to see you.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 187,
+      "label": "",
+      "original": "I must finish for today.\n",
+      "new": "I must finish for today.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 188,
+      "label": "",
+      "original": "Treasure this letter, my dear.\n",
+      "new": "Treasure this letter, my dear.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 189,
+      "label": "",
+      "original": "Come by and help me again.\n",
+      "new": "Come by and help me again.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 190,
+      "label": "",
+      "original": "Toodles for now!\n",
+      "new": "Toodles for now!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 191,
+      "label": "",
+      "original": "Au revoir for now.\n",
+      "new": "Au revoir for now.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 192,
+      "label": "",
+      "original": "Right, so...goodbye.\n",
+      "new": "Right, so...goodbye.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 193,
+      "label": "",
+      "original": "Well, time for lunch.\n",
+      "new": "Well, time for lunch.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 194,
+      "label": "",
+      "original": "Zzz... Why did I write that?\n",
+      "new": "Zzz... Why did I write that?\n"
+    },
+    {
+      "group": "mailc",
+      "index": 195,
+      "label": "",
+      "original": "A B C-ya!\n",
+      "new": "A B C-ya!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 196,
+      "label": "",
+      "original": "Drop by again.\n",
+      "new": "Drop by again.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 197,
+      "label": "",
+      "original": "Come on over whenever.\n",
+      "new": "Come on over whenever.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 198,
+      "label": "",
+      "original": "Come by again. I'm waiting.\n",
+      "new": "Come by again. I'm waiting.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 199,
+      "label": "",
+      "original": "Catch ya later. Take care.\n",
+      "new": "Catch ya later. Take care.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 200,
+      "label": "",
+      "original": "I'll be here all day, so....\n",
+      "new": "I'll be here all day, so....\n"
+    },
+    {
+      "group": "mailc",
+      "index": 201,
+      "label": "",
+      "original": "Here's mud in your eye!\n",
+      "new": "Here's mud in your eye!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 202,
+      "label": "",
+      "original": "See you around. Later!\n",
+      "new": "See you around. Later!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 203,
+      "label": "",
+      "original": "Boy, I wrote a lot. I'm tired.\n",
+      "new": "Boy, I wrote a lot. I'm tired.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 204,
+      "label": "",
+      "original": "Stay cool! Hasta la vista.\n",
+      "new": "Stay cool! Hasta la vista.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 205,
+      "label": "",
+      "original": "No more writing! I'm beat!\n",
+      "new": "No more writing! I'm beat!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 206,
+      "label": "",
+      "original": "Until next time, farewell.\n",
+      "new": "Until next time, farewell.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 207,
+      "label": "",
+      "original": "Bye-bye. Take care.\n",
+      "new": "Bye-bye. Take care.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 208,
+      "label": "",
+      "original": "Gotta get some exercise. Bye.\n",
+      "new": "Gotta get some exercise. Bye.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 209,
+      "label": "",
+      "original": "Don't forget about me, OK?\n",
+      "new": "Don't forget about me, OK?\n"
+    },
+    {
+      "group": "mailc",
+      "index": 210,
+      "label": "",
+      "original": "What did I just write?\n",
+      "new": "What did I just write?\n"
+    },
+    {
+      "group": "mailc",
+      "index": 211,
+      "label": "",
+      "original": "Hope you stop by soon.\n",
+      "new": "Hope you stop by soon.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 212,
+      "label": "",
+      "original": "I guess I'll see you around.\n",
+      "new": "I guess I'll see you around.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 213,
+      "label": "",
+      "original": "That's all for now. I'm off.\n",
+      "new": "That's all for now. I'm off.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 214,
+      "label": "",
+      "original": "That's it for today. Buh-bye.\n",
+      "new": "That's it for today. Buh-bye.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 215,
+      "label": "",
+      "original": "Smell you later!\n",
+      "new": "Smell you later!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 216,
+      "label": "",
+      "original": "You coming by soon?\n",
+      "new": "You coming by soon?\n"
+    },
+    {
+      "group": "mailc",
+      "index": 217,
+      "label": "",
+      "original": "I'm outta here. Bye.\n",
+      "new": "I'm outta here. Bye.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 218,
+      "label": "",
+      "original": "Don't get hit by any rocks.\n",
+      "new": "Don't get hit by any rocks.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 219,
+      "label": "",
+      "original": "I'm tired. Goodbye.\n",
+      "new": "I'm tired. Goodbye.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 220,
+      "label": "",
+      "original": "Swing by anytime, pal.\n",
+      "new": "Swing by anytime, pal.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 221,
+      "label": "",
+      "original": "Ugh. I feel sick now. Bye.\n",
+      "new": "Ugh. I feel sick now. Bye.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 222,
+      "label": "",
+      "original": "Bye for now.\n",
+      "new": "Bye for now.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 223,
+      "label": "",
+      "original": "Just stop by sometime, OK?\n",
+      "new": "Just stop by sometime, OK?\n"
+    },
+    {
+      "group": "mailc",
+      "index": 224,
+      "label": "",
+      "original": "Have a nice day. See you!\n",
+      "new": "Have a nice day. See you!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 225,
+      "label": "",
+      "original": "Be seeing you! Take care....\n",
+      "new": "Be seeing you! Take care....\n"
+    },
+    {
+      "group": "mailc",
+      "index": 226,
+      "label": "",
+      "original": "Take your vitamins, OK?\n",
+      "new": "Take your vitamins, OK?\n"
+    },
+    {
+      "group": "mailc",
+      "index": 227,
+      "label": "",
+      "original": "Well, I have to be running.\n",
+      "new": "Well, I have to be running.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 228,
+      "label": "",
+      "original": "Please visit us again.\n",
+      "new": "Please visit us again.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 229,
+      "label": "",
+      "original": "Come back real soon!\n",
+      "new": "Come back real soon!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 230,
+      "label": "",
+      "original": "That about wraps it up. Bye.\n",
+      "new": "That about wraps it up. Bye.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 231,
+      "label": "",
+      "original": "Let's get together again.\n",
+      "new": "Let's get together again.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 232,
+      "label": "",
+      "original": "Stop by anytime.\n",
+      "new": "Stop by anytime.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 233,
+      "label": "",
+      "original": "Stop in and say hello soon!\n",
+      "new": "Stop in and say hello soon!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 234,
+      "label": "",
+      "original": "I guess that's it for today.\n",
+      "new": "I guess that's it for today.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 235,
+      "label": "",
+      "original": "Don't forget me, OK?\n",
+      "new": "Don't forget me, OK?\n"
+    },
+    {
+      "group": "mailc",
+      "index": 236,
+      "label": "",
+      "original": "Farewell until next time.\n",
+      "new": "Farewell until next time.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 237,
+      "label": "",
+      "original": "Don't be a stranger, OK?\n",
+      "new": "Don't be a stranger, OK?\n"
+    },
+    {
+      "group": "mailc",
+      "index": 238,
+      "label": "",
+      "original": "I'm off to sing! Tra-la-la!\n",
+      "new": "I'm off to sing! Tra-la-la!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 239,
+      "label": "",
+      "original": "See you in the near future.\n",
+      "new": "See you in the near future.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 240,
+      "label": "",
+      "original": "Hope tomorrow goes well.\n",
+      "new": "Hope tomorrow goes well.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 241,
+      "label": "",
+      "original": "See you again. Adieu!\n",
+      "new": "See you again. Adieu!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 242,
+      "label": "",
+      "original": "Be good! Bye-bye.\n",
+      "new": "Be good! Bye-bye.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 243,
+      "label": "",
+      "original": "Toodle for now! Take care.\n",
+      "new": "Toodle for now! Take care.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 244,
+      "label": "",
+      "original": "Next time, stay longer!\n",
+      "new": "Next time, stay longer!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 245,
+      "label": "",
+      "original": "You're always welcome here.\n",
+      "new": "You're always welcome here.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 246,
+      "label": "",
+      "original": "Come and see me sometime.\n",
+      "new": "Come and see me sometime.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 247,
+      "label": "",
+      "original": "So, take good care now, OK?\n",
+      "new": "So, take good care now, OK?\n"
+    },
+    {
+      "group": "mailc",
+      "index": 248,
+      "label": "",
+      "original": "Let's get together soon.\n",
+      "new": "Let's get together soon.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 249,
+      "label": "",
+      "original": "Sorry about my handwriting.\n",
+      "new": "Sorry about my handwriting.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 250,
+      "label": "",
+      "original": "Stop by <<STR_FREE14>> again!\n",
+      "new": "Stop by <<STR_FREE14>> again!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 251,
+      "label": "",
+      "original": "See ya later, alligator!!!\n",
+      "new": "See ya later, alligator!!!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 252,
+      "label": "",
+      "original": "What a bizarre letter. Weird!\n",
+      "new": "What a bizarre letter. Weird!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 253,
+      "label": "",
+      "original": "I hope you don't forget me.\n",
+      "new": "I hope you don't forget me.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 254,
+      "label": "",
+      "original": "Thanks for being a friend.\n",
+      "new": "Thanks for being a friend.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 255,
+      "label": "",
+      "original": "I think about you often.\n",
+      "new": "I think about you often.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 256,
+      "label": "",
+      "original": "Omigosh! I'm late! Bye-bye!\n",
+      "new": "Omigosh! I'm late! Bye-bye!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 257,
+      "label": "",
+      "original": "See you! Don't ever change!\n",
+      "new": "See you! Don't ever change!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 258,
+      "label": "",
+      "original": "I gotta jet, but stay cool!\n",
+      "new": "I gotta jet, but stay cool!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 259,
+      "label": "",
+      "original": "Okey-dokey, that's all. Bye!\n",
+      "new": "Okey-dokey, that's all. Bye!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 260,
+      "label": "",
+      "original": "Stop by, and we'll gossip!\n",
+      "new": "Stop by, and we'll gossip!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 261,
+      "label": "",
+      "original": "Promise you'll come visit me!\n",
+      "new": "Promise you'll come visit me!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 262,
+      "label": "",
+      "original": "I'll write soon, I swear!\n",
+      "new": "I'll write soon, I swear!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 263,
+      "label": "",
+      "original": "We should get together soon.\n",
+      "new": "We should get together soon.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 264,
+      "label": "",
+      "original": "Swing by anytime. OK?\n",
+      "new": "Swing by anytime. OK?\n"
+    },
+    {
+      "group": "mailc",
+      "index": 265,
+      "label": "",
+      "original": "Next time, come see me first!\n",
+      "new": "Next time, come see me first!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 266,
+      "label": "",
+      "original": "Come back real soon, OK?\n",
+      "new": "Come back real soon, OK?\n"
+    },
+    {
+      "group": "mailc",
+      "index": 267,
+      "label": "",
+      "original": "I've written enough. Bye!\n",
+      "new": "I've written enough. Bye!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 268,
+      "label": "",
+      "original": "Come by, and we'll hang out.\n",
+      "new": "Come by, and we'll hang out.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 269,
+      "label": "",
+      "original": "After a while, crocodile!\n",
+      "new": "After a while, crocodile!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 270,
+      "label": "",
+      "original": "You need to come back soon.\n",
+      "new": "You need to come back soon.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 271,
+      "label": "",
+      "original": "That's all she wrote! Bye!\n",
+      "new": "That's all she wrote! Bye!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 272,
+      "label": "",
+      "original": "I'll write again later.\n",
+      "new": "I'll write again later.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 273,
+      "label": "",
+      "original": "Let's see.... Oh yeah, bye.\n",
+      "new": "Let's see.... Oh yeah, bye.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 274,
+      "label": "",
+      "original": "Promise to come by again.\n",
+      "new": "Promise to come by again.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 275,
+      "label": "",
+      "original": "Can't wait to see you again.\n",
+      "new": "Can't wait to see you again.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 276,
+      "label": "",
+      "original": "Stop by anytime!\n",
+      "new": "Stop by anytime!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 277,
+      "label": "",
+      "original": "Hope to see you real soon!\n",
+      "new": "Hope to see you real soon!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 278,
+      "label": "",
+      "original": "Well, that's a wrap. I'm off!\n",
+      "new": "Well, that's a wrap. I'm off!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 279,
+      "label": "",
+      "original": "Be well, don't smell! Ciao!\n",
+      "new": "Be well, don't smell! Ciao!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 280,
+      "label": "",
+      "original": "Come visit me, got that!?\n",
+      "new": "Come visit me, got that!?\n"
+    },
+    {
+      "group": "mailc",
+      "index": 281,
+      "label": "",
+      "original": "Swing by sometime soon.\n",
+      "new": "Swing by sometime soon.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 282,
+      "label": "",
+      "original": "Behave yourself! Ciao!\n",
+      "new": "Behave yourself! Ciao!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 283,
+      "label": "",
+      "original": "Behave yourself! Buh-bye!\n",
+      "new": "Behave yourself! Buh-bye!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 284,
+      "label": "",
+      "original": "Tah-tah for now!\n",
+      "new": "Tah-tah for now!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 285,
+      "label": "",
+      "original": "We should have a PJ party!\n",
+      "new": "We should have a PJ party!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 286,
+      "label": "",
+      "original": "That's all for now. G'bye!\n",
+      "new": "That's all for now. G'bye!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 287,
+      "label": "",
+      "original": "I guess that's all. See ya!\n",
+      "new": "I guess that's all. See ya!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 288,
+      "label": "",
+      "original": "Catch you later, buddy!\n",
+      "new": "Catch you later, buddy!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 289,
+      "label": "",
+      "original": "Roll on over sometime.\n",
+      "new": "Roll on over sometime.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 290,
+      "label": "",
+      "original": "Stick a fork in me. I'm done.\n",
+      "new": "Stick a fork in me. I'm done.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 291,
+      "label": "",
+      "original": "Catch you later.\n",
+      "new": "Catch you later.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 292,
+      "label": "",
+      "original": "Surf on. I'm outta here.\n",
+      "new": "Surf on. I'm outta here.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 293,
+      "label": "",
+      "original": "You're welcome here anytime.\n",
+      "new": "You're welcome here anytime.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 294,
+      "label": "",
+      "original": "Don't strain yourself, OK?\n",
+      "new": "Don't strain yourself, OK?\n"
+    },
+    {
+      "group": "mailc",
+      "index": 295,
+      "label": "",
+      "original": "Later, gator! Hurr hur hur!\n",
+      "new": "Later, gator! Hurr hur hur!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 296,
+      "label": "",
+      "original": "Don't be a stranger!\n",
+      "new": "Don't be a stranger!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 297,
+      "label": "",
+      "original": "Let's shoot the breeze again.\n",
+      "new": "Let's shoot the breeze again.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 298,
+      "label": "",
+      "original": "Adios, muchacho. Take care.\n",
+      "new": "Adios, muchacho. Take care.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 299,
+      "label": "",
+      "original": "Writing hurts my brain! Bye!\n",
+      "new": "Writing hurts my brain! Bye!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 300,
+      "label": "",
+      "original": "Come overーwe'll hang out!\n",
+      "new": "Come overーwe'll hang out!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 301,
+      "label": "",
+      "original": "Bye for now!\n",
+      "new": "Bye for now!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 302,
+      "label": "",
+      "original": "Take care, and see me soon!\n",
+      "new": "Take care, and see me soon!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 303,
+      "label": "",
+      "original": "That's it. I'm done! Bye!\n",
+      "new": "That's it. I'm done! Bye!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 304,
+      "label": "",
+      "original": "Swing by when you can.\n",
+      "new": "Swing by when you can.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 305,
+      "label": "",
+      "original": "Smell you later! Hah!\n",
+      "new": "Smell you later! Hah!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 306,
+      "label": "",
+      "original": "Don't forget to floss! Bye!\n",
+      "new": "Don't forget to floss! Bye!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 307,
+      "label": "",
+      "original": "I've got nothing else to say.\n",
+      "new": "I've got nothing else to say.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 308,
+      "label": "",
+      "original": "See you 'round.\n",
+      "new": "See you 'round.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 309,
+      "label": "",
+      "original": "Well, gotta go! See ya!\n",
+      "new": "Well, gotta go! See ya!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 310,
+      "label": "",
+      "original": "Don't forget <<STR_FREE14>>!\n",
+      "new": "Don't forget <<STR_FREE14>>!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 311,
+      "label": "",
+      "original": "Promise to come back soon.\n",
+      "new": "Promise to come back soon.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 312,
+      "label": "",
+      "original": "You've got to come by again.\n",
+      "new": "You've got to come by again.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 313,
+      "label": "",
+      "original": "My best to <<STR_FREE15>>.\n",
+      "new": "My best to <<STR_FREE15>>.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 314,
+      "label": "",
+      "original": "Hasta luego!\n",
+      "new": "Hasta luego!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 315,
+      "label": "",
+      "original": "Yep, that's it. Goodbye.\n",
+      "new": "Yep, that's it. Goodbye.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 316,
+      "label": "",
+      "original": "Until next time, farewell!\n",
+      "new": "Until next time, farewell!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 317,
+      "label": "",
+      "original": "Take care of yourself.\n",
+      "new": "Take care of yourself.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 318,
+      "label": "",
+      "original": "Bye from me, <<STR_FREE1>>.\n",
+      "new": "Bye from me, <<STR_FREE1>>.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 319,
+      "label": "",
+      "original": "Keep it real, <<STR_FREE0>>!\n",
+      "new": "Keep it real, <<STR_FREE0>>!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 320,
+      "label": "",
+      "original": "Yeah, see ya. Later. BYE.\n",
+      "new": "Yeah, see ya. Later. BYE.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 321,
+      "label": "",
+      "original": "Be seeing you. Count on it.\n",
+      "new": "Be seeing you. Count on it.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 322,
+      "label": "",
+      "original": "This letter's done, got it?\n",
+      "new": "This letter's done, got it?\n"
+    },
+    {
+      "group": "mailc",
+      "index": 323,
+      "label": "",
+      "original": "See you around.\n",
+      "new": "See you around.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 324,
+      "label": "",
+      "original": "OK then...fine. I'm done.\n",
+      "new": "OK then...fine. I'm done.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 325,
+      "label": "",
+      "original": "When are you coming over?\n",
+      "new": "When are you coming over?\n"
+    },
+    {
+      "group": "mailc",
+      "index": 326,
+      "label": "",
+      "original": "Wash behind your ears! Bye!\n",
+      "new": "Wash behind your ears! Bye!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 327,
+      "label": "",
+      "original": "OK. That's enough. Bye.\n",
+      "new": "OK. That's enough. Bye.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 328,
+      "label": "",
+      "original": "Why are you home? Go out!\n",
+      "new": "Why are you home? Go out!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 329,
+      "label": "",
+      "original": "Why don't you come visit?\n",
+      "new": "Why don't you come visit?\n"
+    },
+    {
+      "group": "mailc",
+      "index": 330,
+      "label": "",
+      "original": "Don't stay up too late.\n",
+      "new": "Don't stay up too late.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 331,
+      "label": "",
+      "original": "Huh? Oh, yeah...goodbye.\n",
+      "new": "Huh? Oh, yeah...goodbye.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 332,
+      "label": "",
+      "original": "Jeez, why am I still writing?\n",
+      "new": "Jeez, why am I still writing?\n"
+    },
+    {
+      "group": "mailc",
+      "index": 333,
+      "label": "",
+      "original": "I'm done writing now.\n",
+      "new": "I'm done writing now.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 334,
+      "label": "",
+      "original": "Hey, I'm done! Quit reading!\n",
+      "new": "Hey, I'm done! Quit reading!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 335,
+      "label": "",
+      "original": "Talk to you later. Or not.\n",
+      "new": "Talk to you later. Or not.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 336,
+      "label": "",
+      "original": "That about wraps it up.\n",
+      "new": "That about wraps it up.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 337,
+      "label": "",
+      "original": "Enough of this. I'm done.\n",
+      "new": "Enough of this. I'm done.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 338,
+      "label": "",
+      "original": "Wash behind your ears. Bye.\n",
+      "new": "Wash behind your ears. Bye.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 339,
+      "label": "",
+      "original": "I need to use the toilet. Bye.\n",
+      "new": "I need to use the toilet. Bye.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 340,
+      "label": "",
+      "original": "You just watch yourself. Bye.\n",
+      "new": "You just watch yourself. Bye.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 341,
+      "label": "",
+      "original": "That's all...for now.\n",
+      "new": "That's all...for now.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 342,
+      "label": "",
+      "original": "GAH! Cramp! I hate writing.\n",
+      "new": "GAH! Cramp! I hate writing.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 343,
+      "label": "",
+      "original": "The door's open. Come on by.\n",
+      "new": "The door's open. Come on by.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 344,
+      "label": "",
+      "original": "What, you're still reading?\n",
+      "new": "What, you're still reading?\n"
+    },
+    {
+      "group": "mailc",
+      "index": 345,
+      "label": "",
+      "original": "I'm going fishing. Aloooha!\n",
+      "new": "I'm going fishing. Aloooha!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 346,
+      "label": "",
+      "original": "OUCH! Stupid pen! See ya.\n",
+      "new": "OUCH! Stupid pen! See ya.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 347,
+      "label": "",
+      "original": "Stop by <<STR_FREE14>> again.",
+      "new": "Stop by <<STR_FREE14>> again."
+    },
+    {
+      "group": "mailc",
+      "index": 348,
+      "label": "",
+      "original": "I'm telling you, COME VISIT!\n",
+      "new": "I'm telling you, COME VISIT!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 349,
+      "label": "",
+      "original": "Say hi to...oh, forget it.\n",
+      "new": "Say hi to...oh, forget it.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 350,
+      "label": "",
+      "original": "Let's stay friends, OK?\n",
+      "new": "Let's stay friends, OK?\n"
+    },
+    {
+      "group": "mailc",
+      "index": 351,
+      "label": "",
+      "original": "Good luck with everything.\n",
+      "new": "Good luck with everything.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 352,
+      "label": "",
+      "original": "And so, I bid you adieu.\n",
+      "new": "And so, I bid you adieu.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 353,
+      "label": "",
+      "original": "Farewell. Be good.\n",
+      "new": "Farewell. Be good.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 354,
+      "label": "",
+      "original": "Take of yourself. So long.\n",
+      "new": "Take of yourself. So long.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 355,
+      "label": "",
+      "original": "Goodbye until next time.\n",
+      "new": "Goodbye until next time.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 356,
+      "label": "",
+      "original": "Come by for tea. We'll chat.\n",
+      "new": "Come by for tea. We'll chat.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 357,
+      "label": "",
+      "original": "I'll be watching you.\n",
+      "new": "I'll be watching you.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 358,
+      "label": "",
+      "original": "I insist you see me soon.\n",
+      "new": "I insist you see me soon.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 359,
+      "label": "",
+      "original": "Let's get together soon.\n",
+      "new": "Let's get together soon.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 360,
+      "label": "",
+      "original": "My door is always open.\n",
+      "new": "My door is always open.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 361,
+      "label": "",
+      "original": "Let's have tea and scones!\n",
+      "new": "Let's have tea and scones!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 362,
+      "label": "",
+      "original": "I have nothing more to say.\n",
+      "new": "I have nothing more to say.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 363,
+      "label": "",
+      "original": "I hope to see you again.\n",
+      "new": "I hope to see you again.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 364,
+      "label": "",
+      "original": "Until our paths cross again.\n",
+      "new": "Until our paths cross again.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 365,
+      "label": "",
+      "original": "Good day. Stay well.\n",
+      "new": "Good day. Stay well.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 366,
+      "label": "",
+      "original": "We should meet for tea.\n",
+      "new": "We should meet for tea.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 367,
+      "label": "",
+      "original": "Best wishes, <<STR_FREE0>>.\n",
+      "new": "Best wishes, <<STR_FREE0>>.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 368,
+      "label": "",
+      "original": "Toodle-oo!\n",
+      "new": "Toodle-oo!\n"
+    },
+    {
+      "group": "mailc",
+      "index": 369,
+      "label": "",
+      "original": "Tah-tah, my dear.\n",
+      "new": "Tah-tah, my dear.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 370,
+      "label": "",
+      "original": "Let me see.... That's all.\n",
+      "new": "Let me see.... That's all.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 371,
+      "label": "",
+      "original": "Do drop by soon.\n",
+      "new": "Do drop by soon.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 372,
+      "label": "",
+      "original": "I WILL be seeing you. Ciao.\n",
+      "new": "I WILL be seeing you. Ciao.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 373,
+      "label": "",
+      "original": "I'm done for today. Be well.\n",
+      "new": "I'm done for today. Be well.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 374,
+      "label": "",
+      "original": "Stop byーperhaps we'll talk.\n",
+      "new": "Stop byーperhaps we'll talk.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 375,
+      "label": "",
+      "original": "Do take care, my dear.\n",
+      "new": "Do take care, my dear.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 376,
+      "label": "",
+      "original": "I anticipate your next visit.\n",
+      "new": "I anticipate your next visit.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 377,
+      "label": "",
+      "original": "Farewell for now.\n",
+      "new": "Farewell for now.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 378,
+      "label": "",
+      "original": "I'll slip out to see you soon.\n",
+      "new": "I'll slip out to see you soon.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 379,
+      "label": "",
+      "original": "Tah-tah for now.\n",
+      "new": "Tah-tah for now.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 380,
+      "label": "",
+      "original": "Treasure this letter. Always.\n",
+      "new": "Treasure this letter. Always.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 381,
+      "label": "",
+      "original": "Let's rendezvous again soon.\n",
+      "new": "Let's rendezvous again soon.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 382,
+      "label": "",
+      "original": "Auf wiedersehen, my dear.\n",
+      "new": "Auf wiedersehen, my dear.\n"
+    },
+    {
+      "group": "mailc",
+      "index": 383,
+      "label": "",
+      "original": "Arrivederci, my friend.\n",
+      "new": "Arrivederci, my friend.\n"
+    }
+  ]
+}

--- a/dialog/prompt.txt
+++ b/dialog/prompt.txt
@@ -1,0 +1,229 @@
+========================================================================
+ANIMAL CROSSING (GameCube) DIALOG REWRITE — MODEL INSTRUCTIONS
+========================================================================
+
+YOUR TASK
+---------
+You are rewriting the in-game text of Animal Crossing. You are given a JSON
+file whose "entries" array holds every text entry in the game. For each entry
+you may rewrite the "new" field with your own version of the text. You must
+keep the game working: that means preserving every control code and the
+conversation wiring exactly, and only changing the human-readable words.
+
+Rewrite goals (unless the user says otherwise):
+  * Keep the same MEANING, INTENT, and TONE as the original line.
+  * Keep it natural, in-character, and consistent across connected messages.
+  * Keep roughly the same LENGTH and line structure so it fits the text box.
+
+Do NOT invent new mechanics, remove menus/choices, or change who a message
+jumps to. You are a translator/rewriter, not a game designer.
+
+Everything you need is in the JSON itself (see the "flow" field and the rules
+below): the text, how entries connect, and which entries are safe to edit. You
+also have access to the game's decompiled source and the tooling, so you may
+consult them for deeper context if useful (e.g. src/game/m_msg_main.c_inc and
+m_msg_cursol.c_inc describe how the flow codes are interpreted), but the JSON
+alone is sufficient to do the rewrite correctly.
+
+
+THE JSON YOU ARE EDITING
+------------------------
+The file is one of:
+  * dialog.json  — the main villager/character dialog (resource "message").
+  * mail.json    — the letters villagers mail you (resource "mail").
+
+Each element of "entries" looks like this:
+
+  {
+    "group": "maila",              // ONLY in mail.json; identifies the blob
+    "index": 2503,                 // stable numeric ID of this entry
+    "label": "",                   // optional human hint; may be ""
+    "original": "....<<MSGEND>>",  // the shipped text (DO NOT CHANGE)
+    "new": "....<<MSGEND>>",       // <-- THE ONLY FIELD YOU EDIT
+    "flow": { ... },               // optional; how this entry connects (read only)
+    "decode_error": true           // optional; see rule below
+  }
+
+RULES (these are hard requirements):
+  1. Edit ONLY the "new" field. Never change group, index, label, original,
+     flow, or decode_error.
+  2. If an entry has "decode_error": true, DO NOT edit it. Leave "new" exactly
+     equal to "original". It cannot be safely re-encoded.
+  3. If you are not changing an entry, leave "new" identical to "original".
+     Only entries whose "new" differs from "original" get rebuilt.
+  4. Preserve EVERY control code token (anything written as <<...>>) exactly:
+     same name, same [hex bytes], same order, same position relative to the
+     words. These codes are the game's wiring — deleting, reordering, or
+     altering one can corrupt the text box or break the conversation.
+  5. Keep "\n" line breaks sensible. A text line should be about the same
+     visible width as the original (~26-30 characters). Do not make lines much
+     longer or you will overflow the on-screen box.
+
+
+CONTROL CODES: WHAT THEY MEAN
+-----------------------------
+Control codes appear as <<NAME>> or <<NAME [HH HH ...]>> where HH are hex
+bytes. You must copy them verbatim. Here is what the common ones do so you can
+place your words correctly around them. (You never need to write new codes —
+just keep the existing ones.)
+
+Text pacing / layout (appear mid-text):
+  <<PAUSE [xx]>>   Pause for a moment (dramatic beat). Keep it where it was.
+  <<BTN>>          Wait for the player to press a button, then continue on a
+                   NEW PAGE of the SAME entry. Think of it as a page break.
+  <<MSGCLEAR>>     Clear the text box to start a fresh page (same entry).
+  <<SPACE>>        A literal space produced by a code.
+  <<TEXTCOLOR ..>>, <<COLORCHARS ..>>, <<LINEOFS ..>>, <<CHARSCALE ..>>,
+  <<LINESCALE ..>>, <<LINETYPE ..>>  Visual formatting. Leave as-is.
+
+Speaker portrait / emotion (usually at the start of a page):
+  <<DEMONPC0 [..]>>, <<DEMONPC1 [..]>>, <<DEMONPC2 [..]>>, <<DEMONPCQST [..]>>,
+  <<DEMOPLR [..]>>  Set the on-screen character pose/expression. The bytes pick
+                    the emotion/animation. Contiguous entries that share the
+                    same DEMONPCx tag+bytes are the same speaker in the same
+                    mood — keep your rewrite in that mood.
+  <<MSGCONTENTS_NORMAL/ANGRY/SAD/FUN/SLEEPY/GLOOMY>>  Voice/emotion of the line.
+  <<VOICETRUE>> / <<VOICEFALSE>>  Voice on/off.
+
+Substituted words (the game inserts real text at runtime — write around them,
+never inside them):
+  <<STR_PLAYERNAME>>   The player's name.
+  <<STR_TALKNAME>>     The name the speaker calls the player.
+  <<STR_TAIL>>         The villager's catchphrase (e.g. their signature word).
+  <<STR_FREE0>> .. <<STR_FREE19>>  Context words the game fills in (an item, a
+                       place, a name, etc.). Keep them; treat each as a noun/
+                       phrase placeholder in the sentence.
+  <<STR_ITEM0>>..<<STR_ITEM4>>   An item name.
+  <<STR_YEAR/MONTH/WEEK/DAY/HOUR/MIN/SEC/AMPM>>  Date/time pieces.
+  <<STR_COUNTRYNAME>>, <<STR_ISLANDNAME>>, <<STR_RNDNUM>>, <<STR_MAIL>>  etc.
+  Rule of thumb: any <<STR_...>> is a blank the game fills in. Keep it and make
+  the surrounding sentence read naturally with it in place.
+
+Conversation flow (appear at the END of an entry — DO NOT MOVE OR CHANGE):
+  <<MSGEND>>            The conversation ends here.
+  <<MSGCONTINUE>>       There is more; the game continues to another entry.
+  <<SETNEXTMSG0 [hi lo]>> .. <<SETNEXTMSG5 [hi lo]>>  Set the next entry index
+                       (the two bytes are a big-endian index, e.g. [09 C9] =
+                       decimal 2505). SETNEXTMSG0/1/... correspond to the
+                       player's menu choice 0/1/...
+  <<SETFORCEMSG [hi lo]>>  Force the next entry index regardless of choice.
+  <<SETNEXTMSGRND2/3/4 [...]>>  Randomly pick one of several next indices.
+  <<SETNEXTMSGRNDSECTION [b b m m]>>  Randomly pick an index in a range.
+  <<MALEFEMALECHK [.. ..]>>  Branch to a different index by player gender.
+  <<OPENCHOICE>>       Show a yes/no (or multi) menu.
+  <<SETSELSTR2/3/.. [ids]>>  The option labels for the menu.
+  <<FORCENEXT>>        Advance automatically without waiting for a button.
+
+
+HOW ENTRIES CONNECT (THIS IS THE IMPORTANT PART)
+------------------------------------------------
+Entries are NOT connected by being next to each other in the file. They are
+connected by the flow codes above. Use the "flow" field on each entry to
+navigate:
+
+  "flow": {
+    "continues": true,      // ends with <<MSGCONTINUE>>
+    "ends": true,           // ends with <<MSGEND>>
+    "choice": true,         // shows a menu (<<OPENCHOICE>>)
+    "next": [2505, 2523],   // explicit indices this entry jumps to
+    "next_range": [b, m]    // (rare) a random range of next indices
+  }
+
+Read it like this:
+  * flow.next present  -> this entry jumps to those exact indices. When the
+    entry is a CHOICE, next[0] is where option 0 goes, next[1] is where option
+    1 goes, and so on. To rewrite consistently, rewrite this entry AND all of
+    its next targets together so the question and every answer still match.
+  * flow.choice true   -> keep the branching intact. If you reword the question,
+    make sure both answer branches still make sense as replies.
+  * flow.continues true but NO flow.next -> this is a "runtime pool": the game
+    picks the successor in code, not from the text. Treat this entry as a
+    SELF-CONTAINED beat. It must read well on its own and match the tone of the
+    surrounding entries (look at neighbours with the same DEMONPCx tag).
+  * flow.ends true     -> a natural stopping point; wrap up the thought.
+
+Walking a full conversation:
+  Start at an entry, then follow flow.next repeatedly to visit every entry in
+  the conversation tree (mind that branches can rejoin or loop). Look each
+  "next" value up by matching it against another entry's "index" in the SAME
+  "entries" array — that is all the wiring you need; it is contained entirely in
+  this JSON. Rewrite the whole tree as one coherent scene.
+
+  You can also have the connected tree printed for you with:
+      python tools/dialog_tool.py trace --json dialog/dialog.json --index N
+  which lists the linked entries with CHOICE / END / CONTINUE markers. This is
+  optional — the flow.next fields already give you the same information.
+
+
+A WORKED EXAMPLE
+----------------
+Entry 2503 (K.K. / intro) ends with:
+   ...ready to hop on that train?<<SETSELSTR2 [00 6E 00 6F]>><<BTN>>
+   <<OPENCHOICE>><<SETNEXTMSG0 [09 C9]>><<SETNEXTMSG1 [09 DB]>><<FORCENEXT>>
+Its flow is: { "continues": true, "choice": true, "next": [2505, 2523] }
+Meaning: it asks a yes/no question; choosing option 0 goes to entry 2505,
+option 1 goes to entry 2523. So if you reword 2503's question, also reword
+2505 and 2523 so the two replies still fit the new question. Keep the
+<<SETSELSTR2>>, <<OPENCHOICE>>, <<SETNEXTMSG0/1>>, <<BTN>>, <<FORCENEXT>>
+codes exactly where they are.
+
+
+MAIL LETTERS (mail.json only)
+-----------------------------
+mail.json holds the letters villagers and the game mail you. It has four groups
+(the "group" field on each entry). Mail entries do NOT use the flow/menu codes;
+they are plain letter text that ends with newline(s) and uses <<STR_...>>
+substitutions (e.g. <<STR_FREE0>> = a name the game fills in). They are wired
+together differently than dialog:
+
+  * group "mail"  — complete letter BODIES used as-is (event/system/store mail,
+    birthday notes, etc.). Each entry is one whole body; rewrite it as a
+    self-contained letter.
+
+  * groups "maila", "mailb", "mailc" — INTERCHANGEABLE FRAGMENTS. To build a
+    villager's letter, the game concatenates exactly one "maila" + one "mailb" +
+    one "mailc", in that order, choosing each independently. So:
+        maila = opening line(s)      (e.g. "Hello, <<STR_FREE0>>. Thanks...")
+        mailb = middle line(s)       (e.g. "Somebody dumped this here...")
+        mailc = closing line(s)      (e.g. "That's all for me...")
+    Because the three are mixed and matched, EACH fragment must:
+      - read naturally on its own,
+      - flow smoothly after ANY maila / into ANY mailc (never reference a
+        specific other fragment),
+      - keep its trailing newline(s) so the next fragment starts on a new line,
+      - stay grammatically complete (don't end mid-sentence expecting a
+        specific continuation).
+
+  * SIZE LIMIT: each "maila", "mailb", and "mailc" entry must stay small — the
+    game only reserves 200 bytes per fragment and will fail to load a longer
+    one. Keep each fragment about the same length as its original (a few short
+    lines). The same "keep lines short" rule as dialog applies to mail bodies.
+
+Do not try to make maila/mailb/mailc into a single continuous sentence across
+groups; treat each as a standalone, tone-matching building block.
+
+
+PERSONALITY & CONSISTENCY
+-------------------------
+* Villager dialog is shared by personality type, not by a single character; the
+  specific name is injected via <<STR_...>> codes. Match the mood implied by the
+  emotion codes and the original wording (grumpy, cheerful, sleepy, etc.).
+* Keep a character's voice consistent across all entries in the same
+  conversation tree and across contiguous entries sharing the same speaker tag.
+* Preserve the function of each line: a greeting stays a greeting, a question
+  stays a question (with the same number of answers), a goodbye stays a goodbye.
+
+
+OUTPUT
+------
+Return the full JSON file with the same structure, with your rewritten "new"
+fields filled in. Follow all rules above. Specifically:
+  * Keep every entry; do not add, remove, reorder, or renumber.
+  * Change ONLY "new". Copy "index", "group", "label", "original", "flow", and
+    "decode_error" through unchanged.
+  * Leave "new" identical to "original" for any entry you are not rewriting and
+    for any entry with "decode_error": true.
+  * Output JSON only — no commentary, no markdown fences, no explanations.
+  * If you are unsure whether a token is a control code, leave it exactly as
+    written. When in doubt, preserve rather than change.
+========================================================================

--- a/tools/dialog_tool.py
+++ b/tools/dialog_tool.py
@@ -51,6 +51,7 @@ are preserved verbatim instead of being round-tripped.
 import argparse
 import json
 import os
+import re
 import struct
 import sys
 
@@ -260,6 +261,85 @@ def encode_message(text):
 
 
 # ---------------------------------------------------------------------------
+# Conversation flow analysis
+# ---------------------------------------------------------------------------
+# Which control codes carry an explicit "next message" index, and how their
+# argument bytes map to u16 indices. See src/game/m_msg_cursol.c_inc.
+_TOKEN_RE = re.compile(r"<<([A-Z0-9_]+)(?: \[([0-9A-Fa-f ]+)\])?>>")
+
+# Single u16 target (SETFORCEMSG maps to the "force" next-message handler).
+_FLOW_SINGLE = {
+    "SETFORCEMSG",
+    "SETNEXTMSG0", "SETNEXTMSG1", "SETNEXTMSG2",
+    "SETNEXTMSG3", "SETNEXTMSG4", "SETNEXTMSG5",
+}
+# Every 2 argument bytes is a candidate target (random pick / gender branch).
+_FLOW_MULTI = {
+    "SETNEXTMSGRND2", "SETNEXTMSGRND3", "SETNEXTMSGRND4",
+    "MALEFEMALECHK",
+}
+# base + max: the game picks a random index in [base, max].
+_FLOW_SECTION = {"SETNEXTMSGRNDSECTION"}
+
+
+def _hex_u16s(hex_args):
+    b = bytes(int(x, 16) for x in hex_args.split())
+    return [int.from_bytes(b[i:i + 2], "big") for i in range(0, len(b) - 1, 2)]
+
+
+def _analyze_flow(text):
+    """Summarise how a decoded message connects to others.
+
+    Returns a dict with any of ``continues`` / ``ends`` / ``choice`` (bools) and
+    ``next`` (list of explicit target indices), or ``None`` when the entry has
+    no flow-control codes. ``continues`` without ``next`` means the successor is
+    chosen by the villager's code at runtime, not stored in the text.
+    """
+    continues = ends = choice = False
+    section = None
+    nexts = []
+    for name, args in _TOKEN_RE.findall(text):
+        if name == "MSGCONTINUE":
+            continues = True
+        elif name == "MSGEND":
+            ends = True
+        elif name == "OPENCHOICE":
+            choice = True
+        elif name in _FLOW_SINGLE and args:
+            vals = _hex_u16s(args)
+            if vals and vals[0] != 0xFFFF:
+                nexts.append(vals[0])
+        elif name in _FLOW_MULTI and args:
+            nexts.extend(v for v in _hex_u16s(args) if v != 0xFFFF)
+        elif name in _FLOW_SECTION and args:
+            vals = _hex_u16s(args)
+            if len(vals) >= 2:
+                nexts.extend(vals[:2])
+                section = [vals[0], vals[1]]
+
+    # De-duplicate while preserving order.
+    seen = set()
+    ordered = []
+    for v in nexts:
+        if v not in seen:
+            seen.add(v)
+            ordered.append(v)
+
+    flow = {}
+    if continues:
+        flow["continues"] = True
+    if ends:
+        flow["ends"] = True
+    if choice:
+        flow["choice"] = True
+    if ordered:
+        flow["next"] = ordered
+    if section is not None:
+        flow["next_range"] = section
+    return flow or None
+
+
+# ---------------------------------------------------------------------------
 # extract
 # ---------------------------------------------------------------------------
 def _build_document(archive, resource_name, source_name, include_empty):
@@ -299,6 +379,9 @@ def _build_document(archive, resource_name, source_name, include_empty):
             entry["label"] = labels.get(index, "")
             entry["original"] = text
             entry["new"] = text
+            flow = _analyze_flow(text)
+            if flow:
+                entry["flow"] = flow
             if had_error:
                 entry["decode_error"] = True
             out_entries.append(entry)
@@ -572,6 +655,94 @@ def _default_out_iso(in_iso):
 
 
 # ---------------------------------------------------------------------------
+# annotate / trace (conversation flow)
+# ---------------------------------------------------------------------------
+def cmd_annotate(args):
+    """Add/refresh the per-entry ``flow`` field on an existing JSON in place.
+
+    Preserves your edits (``new`` is never touched); only recomputes ``flow``
+    from ``original`` and refreshes known ``label`` values.
+    """
+    document = _load_json(args.json)
+    resource_name = _resolve_resource_name(document, args.resource)
+    labels = RESOURCE_LABELS.get(resource_name, {})
+
+    annotated = 0
+    for entry in document["entries"]:
+        original = entry.get("original", "")
+        flow = _analyze_flow(original)
+        if flow:
+            entry["flow"] = flow
+            annotated += 1
+        elif "flow" in entry:
+            del entry["flow"]
+        if labels and "group" not in entry:
+            try:
+                lbl = labels.get(int(entry["index"]), "")
+            except (KeyError, TypeError, ValueError):
+                lbl = ""
+            if lbl:
+                entry["label"] = lbl
+
+    _write_document(document, args.json)
+    if not args.quiet:
+        print(f"Annotated {annotated} entries with flow info in {args.json}")
+
+
+def _strip_codes(text):
+    return re.sub(r"<<[^>]*>>", "", text).replace("\n", " ").strip()
+
+
+def cmd_trace(args):
+    """Print the conversation tree reachable from a starting index."""
+    document = _load_json(args.json)
+    by_index = {}
+    for entry in document["entries"]:
+        # Trace follows message indices; for multi-group JSONs the first entry
+        # for a given index wins (mail rarely uses cross-entry jumps).
+        by_index.setdefault(int(entry["index"]), entry)
+
+    lines = []
+    visited = set()
+
+    def snippet(entry):
+        s = _strip_codes(entry.get("original", ""))
+        return (s[:70] + "...") if len(s) > 70 else s
+
+    def walk(index, depth, prefix):
+        entry = by_index.get(index)
+        if entry is None:
+            lines.append(f"{prefix}[{index}] (empty / not in JSON)")
+            return
+        flow = entry.get("flow", {})
+        tags = []
+        if flow.get("choice"):
+            tags.append("CHOICE")
+        if flow.get("ends"):
+            tags.append("END")
+        if flow.get("continues") and not flow.get("next"):
+            tags.append("CONTINUE\u2192runtime")
+        tag = f" ({', '.join(tags)})" if tags else ""
+        lines.append(f"{prefix}[{index}]{tag} {snippet(entry)!r}")
+
+        if index in visited:
+            lines.append(f"{prefix}    \u21ba (already shown)")
+            return
+        visited.add(index)
+
+        nxt = flow.get("next", [])
+        if depth >= args.max_depth:
+            if nxt:
+                lines.append(f"{prefix}    ... (max depth {args.max_depth})")
+            return
+        for target in nxt:
+            walk(target, depth + 1, prefix + "    ")
+
+    walk(args.index, 0, "")
+    print("\n".join(lines))
+
+
+# ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
 def main(argv=None):
@@ -674,6 +845,32 @@ def main(argv=None):
         help="Archive compression (default: match the source archive).",
     )
     p_apply_iso.set_defaults(func=cmd_apply_iso)
+
+    p_annotate = sub.add_parser(
+        "annotate",
+        help="Add/refresh per-entry conversation 'flow' info in a JSON in place.",
+    )
+    p_annotate.add_argument("--json", required=True, help="Path to the JSON to annotate.")
+    p_annotate.add_argument(
+        "--resource", choices=sorted(RESOURCES), default=None,
+        help="Override the resource (default: read from the JSON, else message).",
+    )
+    p_annotate.set_defaults(func=cmd_annotate)
+
+    p_trace = sub.add_parser(
+        "trace",
+        help="Print the conversation tree reachable from a starting index.",
+    )
+    p_trace.add_argument("--json", required=True, help="Path to the dialog JSON.")
+    p_trace.add_argument(
+        "--index", required=True, type=lambda s: int(s, 0),
+        help="Starting message index (decimal or 0x hex).",
+    )
+    p_trace.add_argument(
+        "--max-depth", type=int, default=25,
+        help="Maximum tree depth to follow (default: 25).",
+    )
+    p_trace.set_defaults(func=cmd_trace)
 
     args = parser.parse_args(argv)
     try:

--- a/tools/dialog_tool.py
+++ b/tools/dialog_tool.py
@@ -1,0 +1,527 @@
+#!/usr/bin/env python3
+"""dialog_tool.py - JSON-driven villager/character dialog for ac-decomp.
+
+Animal Crossing stores *all* in-game dialog as two binary blobs that live
+inside ``forest_2nd.arc``:
+
+* ``message_data.bin``       - the raw text bytes for every message, concatenated.
+* ``message_data_table.bin`` - a table of big-endian ``u32`` *cumulative end
+                               offsets*. Entry ``i`` occupies
+                               ``data[table[i-1] : table[i]]`` (entry 0 starts
+                               at offset 0). The game looks messages up purely
+                               by integer index (see ``mMsg_Get_BodyParam`` /
+                               ``mMsg_LoadMsgData`` in ``src/game``).
+
+There is no per-villager grouping in the data itself: every villager of a given
+personality shares the same message entries and the specific name is injected at
+runtime via control codes such as ``<<STR_TALKNAME>>``. Because of that, the
+natural editable unit is a single message index.
+
+This tool provides these commands:
+
+``extract`` / ``extract-iso``
+    Read ``forest_2nd.arc`` (from a loose file or straight out of a GameCube
+    ``.iso``) and produce a JSON file. Each entry contains the message
+    ``index``, a best-effort ``label`` (a human friendly name for the ranges
+    that are known from the source), the decoded ``original`` text and a ``new``
+    field (pre-filled with the original) that you overwrite with your rewritten
+    dialog.
+
+``build``
+    Read that JSON plus the original ``forest_2nd.arc`` and write a new
+    ``forest_2nd.arc`` in which any entry whose ``new`` text differs from its
+    ``original`` is re-encoded. Entries you did not touch are copied byte for
+    byte from the source, so an untouched JSON reproduces the original archive
+    exactly.
+
+``apply-iso``
+    The one-shot workflow: read the original ``.iso``, pull ``forest_2nd.arc``
+    out of it, apply the JSON overrides, and write a patched ``.iso`` with the
+    rebuilt archive. Only that one file (and its FST entry) changes.
+
+The text codec (character map + control codes) is shared with ``msg_tool.py``.
+Because ``msg_tool.CHAR_MAP`` contains a handful of duplicate glyphs, re-encoding
+is not guaranteed to be byte-identical, which is exactly why unchanged entries
+are preserved verbatim instead of being round-tripped.
+"""
+
+import argparse
+import json
+import os
+import struct
+import sys
+
+# Ensure sibling modules (msg_tool, pyjkernel) are importable regardless of CWD.
+_TOOLS_DIR = os.path.dirname(os.path.abspath(__file__))
+if _TOOLS_DIR not in sys.path:
+    sys.path.insert(0, _TOOLS_DIR)
+
+import msg_tool  # noqa: E402  (shared text codec)
+import pyjkernel  # noqa: E402  (RARC archive read/write)
+import gcm  # noqa: E402  (GameCube disc image read/patch)
+
+# forest_2nd.arc's path inside a retail Animal Crossing GameCube disc.
+ISO_ARC_PATH = "files/forest_2nd.arc"
+
+
+DATA_FILE_NAME = "message_data.bin"
+TABLE_FILE_NAME = "message_data_table.bin"
+
+JSON_VERSION = 1
+
+# Best-effort labels for message ranges that are named in the source
+# (see include/m_msg_data.h and friends). Anything not listed simply gets an
+# empty label - it is purely a human-readable hint and never affects the build.
+KNOWN_LABELS = {
+    0x048A: "MSG_CARPETPEDDLER_START",
+    0x1B93: "MSG_TOTAKEKE_START",
+    0x2B54: "MSG_SANTA_WISH_FTR",
+    0x2B55: "MSG_SANTA_WISH_WALL",
+    0x2B56: "MSG_SANTA_WISH_CARPET",
+    0x2B57: "MSG_SANTA_WISH_CLOTH",
+    0x3280: "MSG_SONCHO_EVENTS",
+    0x3391: "MSG_HARVEST_FESTIVAL",
+    0x33F4: "MSG_SONCHO_LIGHTHOUSE_1",
+    0x340B: "MSG_SONCHO_LIGHTHOUSE_2",
+}
+
+
+class DialogError(Exception):
+    """Raised for user-facing, recoverable errors."""
+
+
+# ---------------------------------------------------------------------------
+# Archive helpers
+# ---------------------------------------------------------------------------
+def _walk_files(archive):
+    """Yield ``(full_path, JKRArchiveFile)`` for every file in the archive."""
+
+    def recurse(folder_path):
+        for file in archive.list_files(folder_path):
+            yield folder_path + "/" + file.name, file
+        for sub in archive.list_folders(folder_path):
+            yield from recurse(folder_path + "/" + sub)
+
+    yield from recurse(archive.root_name)
+
+
+def _find_message_files(archive):
+    """Locate the message data + table files inside the archive.
+
+    Returns ``(data_file, table_file)`` accessors. Raises ``DialogError`` when
+    either is missing.
+    """
+    data_file = None
+    table_file = None
+    for _path, file in _walk_files(archive):
+        name = file.name.lower()
+        if name == DATA_FILE_NAME:
+            data_file = file
+        elif name == TABLE_FILE_NAME:
+            table_file = file
+
+    if data_file is None or table_file is None:
+        missing = []
+        if data_file is None:
+            missing.append(DATA_FILE_NAME)
+        if table_file is None:
+            missing.append(TABLE_FILE_NAME)
+        raise DialogError(
+            "Archive does not contain " + " and ".join(missing) + ". "
+            "Are you sure this is forest_2nd.arc?"
+        )
+    return data_file, table_file
+
+
+def _parse_table(table_bytes):
+    """Parse the message table into a list of cumulative end offsets."""
+    count = len(table_bytes) // 4
+    return list(struct.unpack(">" + "I" * count, bytes(table_bytes[: count * 4])))
+
+
+def _split_entries(data_bytes, table):
+    """Split the concatenated data into ``[(index, raw_bytes), ...]``."""
+    entries = []
+    prev_end = 0
+    for index, end in enumerate(table):
+        # The table is monotonic; guard against malformed data just in case.
+        start = 0 if index == 0 else prev_end
+        if end < start:
+            # Empty / placeholder entry - keep the index but no bytes.
+            entries.append((index, b""))
+            continue
+        entries.append((index, bytes(data_bytes[start:end])))
+        prev_end = end
+    return entries
+
+
+def _open_arc_bytes(raw):
+    """Open a RARC archive from raw bytes, returning ``(archive, compression)``."""
+    compression = pyjkernel.jkrcomp.check_compression(bytes(raw))
+    archive = pyjkernel.from_archive_buffer(bytearray(raw), True)
+    return archive, compression
+
+
+def _load_arc(path):
+    with open(path, "rb") as f:
+        raw = f.read()
+    return _open_arc_bytes(raw)
+
+
+# ---------------------------------------------------------------------------
+# Text codec (built on top of msg_tool's tables)
+# ---------------------------------------------------------------------------
+def decode_message(raw):
+    """Decode raw message bytes into editable text with ``<<CMD>>`` tokens.
+
+    Returns ``(text, had_error)``. ``had_error`` is True when a control code
+    could not be decoded; such entries should not be edited by hand because
+    re-encoding them is not possible. Their original bytes are preserved on
+    build regardless.
+    """
+    parts = []
+    had_error = False
+    i = 0
+    n = len(raw)
+    while i < n:
+        byte = raw[i]
+        if byte == 0x7F:
+            try:
+                token, size = msg_tool.decode_control_code(bytearray(raw), i)
+            except ValueError:
+                had_error = True
+                parts.append("<<RAW [%02X]>>" % byte)
+                i += 1
+                continue
+            parts.append(token)
+            i += size
+        else:
+            parts.append(msg_tool.CHAR_MAP[byte])
+            i += 1
+    return "".join(parts), had_error
+
+
+def encode_message(text):
+    """Encode editable text back into raw message bytes.
+
+    Raises ``DialogError`` with a helpful message on invalid content.
+    """
+    try:
+        return bytes(msg_tool.encode_entry(text))
+    except ValueError as exc:
+        raise DialogError(str(exc))
+
+
+# ---------------------------------------------------------------------------
+# extract
+# ---------------------------------------------------------------------------
+def _build_document(archive, source_name, include_empty):
+    """Decode every message in ``archive`` into a dialog JSON document.
+
+    Returns ``(document, skipped_empty)``.
+    """
+    data_file, table_file = _find_message_files(archive)
+    table = _parse_table(table_file.data)
+    entries = _split_entries(data_file.data, table)
+
+    out_entries = []
+    skipped_empty = 0
+    for index, raw in entries:
+        if len(raw) == 0 and not include_empty:
+            skipped_empty += 1
+            continue
+        text, had_error = decode_message(raw)
+        entry = {
+            "index": index,
+            "label": KNOWN_LABELS.get(index, ""),
+            "original": text,
+            "new": text,
+        }
+        if had_error:
+            entry["decode_error"] = True
+        out_entries.append(entry)
+
+    document = {
+        "version": JSON_VERSION,
+        "source_arc": source_name,
+        "data_file": data_file.name,
+        "table_file": table_file.name,
+        "entry_count": len(table),
+        "entries": out_entries,
+    }
+    return document, skipped_empty
+
+
+def _write_document(document, out_path):
+    os.makedirs(os.path.dirname(os.path.abspath(out_path)), exist_ok=True)
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(document, f, ensure_ascii=False, indent=2)
+
+
+def cmd_extract(args):
+    archive, _compression = _load_arc(args.arc)
+    document, skipped_empty = _build_document(
+        archive, os.path.basename(args.arc), args.include_empty
+    )
+    _write_document(document, args.out)
+
+    if not args.quiet:
+        print(
+            f"Extracted {len(document['entries'])} message(s) "
+            f"({skipped_empty} empty skipped) to {args.out}"
+        )
+
+
+def cmd_extract_iso(args):
+    disc = gcm.Gcm(args.iso)
+    gf = disc.find(ISO_ARC_PATH)
+    if gf is None:
+        raise DialogError(
+            f"{args.iso} does not contain {ISO_ARC_PATH}. "
+            "Is this a US Animal Crossing GameCube disc image?"
+        )
+    archive, _compression = _open_arc_bytes(disc.read_file(gf))
+    document, skipped_empty = _build_document(archive, gf.name, args.include_empty)
+    _write_document(document, args.out)
+
+    if not args.quiet:
+        print(
+            f"Extracted {len(document['entries'])} message(s) "
+            f"({skipped_empty} empty skipped) from {os.path.basename(args.iso)} "
+            f"to {args.out}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# build
+# ---------------------------------------------------------------------------
+def _load_json(path):
+    with open(path, "r", encoding="utf-8") as f:
+        document = json.load(f)
+    if not isinstance(document, dict) or "entries" not in document:
+        raise DialogError(f"{path} is not a valid dialog JSON (missing 'entries').")
+    return document
+
+
+def _collect_overrides(document):
+    """Return ``{index: new_text}`` for entries whose text was changed."""
+    overrides = {}
+    for entry in document["entries"]:
+        try:
+            index = int(entry["index"])
+        except (KeyError, TypeError, ValueError):
+            raise DialogError("An entry is missing a valid integer 'index'.")
+
+        new_text = entry.get("new")
+        original_text = entry.get("original")
+        if new_text is None:
+            continue
+        # Only re-encode entries that actually changed. This keeps untouched
+        # data byte-for-byte identical to the source archive.
+        if new_text == original_text:
+            continue
+        if entry.get("decode_error"):
+            raise DialogError(
+                f"Entry {index} was flagged with decode_error and cannot be "
+                "edited safely. Revert its 'new' text to match 'original'."
+            )
+        overrides[index] = new_text
+    return overrides
+
+
+def _rebuild_message_bins(data_bytes, table, overrides):
+    """Return ``(new_data, new_table)`` bytes with overrides applied."""
+    entries = _split_entries(data_bytes, table)
+
+    new_data = bytearray()
+    new_table = bytearray()
+    for index, raw in entries:
+        if index in overrides:
+            raw = encode_message(overrides[index])
+        new_data += raw
+        new_table += struct.pack(">I", len(new_data))
+
+    # Preserve the original data padding when nothing shifted, otherwise pad to
+    # a 32-byte boundary to match the game's alignment expectations.
+    if len(new_data) < len(data_bytes):
+        new_data += data_bytes[len(new_data):]
+    elif len(new_data) % 32 != 0:
+        new_data += b"\x00" * (32 - (len(new_data) % 32))
+
+    return bytes(new_data), bytes(new_table)
+
+
+def _apply_overrides_to_archive(archive, overrides):
+    """Apply ``{index: new_text}`` overrides in-place to ``archive``.
+
+    Only touches ``message_data.bin`` / ``message_data_table.bin``. When there
+    are no overrides the archive is left completely untouched, so re-packing it
+    reproduces the source bytes.
+    """
+    if not overrides:
+        return
+    data_file, table_file = _find_message_files(archive)
+    table = _parse_table(table_file.data)
+    new_data, new_table = _rebuild_message_bins(data_file.data, table, overrides)
+    data_file.data = bytearray(new_data)
+    table_file.data = bytearray(new_table)
+
+
+def _resolve_compression(name, detected):
+    if name == "auto":
+        return detected
+    return {
+        "none": pyjkernel.jkrcomp.JKRCompression.NONE,
+        "szs": pyjkernel.jkrcomp.JKRCompression.SZS,
+        "szp": pyjkernel.jkrcomp.JKRCompression.SZP,
+    }[name]
+
+
+def cmd_build(args):
+    document = _load_json(args.json)
+    overrides = _collect_overrides(document)
+
+    archive, compression = _load_arc(args.in_arc)
+    compression = _resolve_compression(args.compression, compression)
+    _apply_overrides_to_archive(archive, overrides)
+
+    os.makedirs(os.path.dirname(os.path.abspath(args.out_arc)), exist_ok=True)
+    pyjkernel.write_archive_file(archive, args.out_arc, True, compression, 9)
+
+    if not args.quiet:
+        print(
+            f"Applied {len(overrides)} dialog change(s); wrote {args.out_arc}"
+        )
+
+
+def cmd_apply_iso(args):
+    document = _load_json(args.json)
+    overrides = _collect_overrides(document)
+
+    disc = gcm.Gcm(args.iso)
+    gf = disc.find(ISO_ARC_PATH)
+    if gf is None:
+        raise DialogError(
+            f"{args.iso} does not contain {ISO_ARC_PATH}. "
+            "Is this a US Animal Crossing GameCube disc image?"
+        )
+
+    archive, compression = _open_arc_bytes(disc.read_file(gf))
+    compression = _resolve_compression(args.compression, compression)
+    _apply_overrides_to_archive(archive, overrides)
+    new_arc = pyjkernel.write_archive_buffer(archive, True, compression, 9)
+
+    out_iso = args.out or _default_out_iso(args.iso)
+    if not args.quiet:
+        print(f"Copying disc image to {out_iso} ...")
+    info = disc.replace_file(gf, bytes(new_arc), out_iso)
+
+    if not args.quiet:
+        print(
+            f"Applied {len(overrides)} dialog change(s) to {ISO_ARC_PATH} "
+            f"({info['old_size']} -> {info['new_size']} bytes, {info['mode']}).\n"
+            f"Wrote {out_iso}"
+        )
+
+
+def _default_out_iso(in_iso):
+    base, ext = os.path.splitext(in_iso)
+    return f"{base} (dialog){ext or '.iso'}"
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Extract or rebuild Animal Crossing dialog via JSON."
+    )
+    parser.add_argument(
+        "-q", "--quiet", action="store_true", help="Suppress progress output."
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_extract = sub.add_parser(
+        "extract", help="Decode forest_2nd.arc dialog into an editable JSON file."
+    )
+    p_extract.add_argument(
+        "--arc", required=True, help="Path to the source forest_2nd.arc."
+    )
+    p_extract.add_argument(
+        "--out", required=True, help="Path of the JSON file to write."
+    )
+    p_extract.add_argument(
+        "--include-empty",
+        action="store_true",
+        help="Also emit empty/placeholder message slots.",
+    )
+    p_extract.set_defaults(func=cmd_extract)
+
+    p_extract_iso = sub.add_parser(
+        "extract-iso",
+        help="Decode dialog straight out of a GameCube .iso into a JSON file.",
+    )
+    p_extract_iso.add_argument(
+        "--iso", required=True, help="Path to the Animal Crossing .iso."
+    )
+    p_extract_iso.add_argument(
+        "--out", required=True, help="Path of the JSON file to write."
+    )
+    p_extract_iso.add_argument(
+        "--include-empty",
+        action="store_true",
+        help="Also emit empty/placeholder message slots.",
+    )
+    p_extract_iso.set_defaults(func=cmd_extract_iso)
+
+    p_build = sub.add_parser(
+        "build", help="Apply a dialog JSON back into a forest_2nd.arc."
+    )
+    p_build.add_argument("--json", required=True, help="Path to the dialog JSON.")
+    p_build.add_argument(
+        "--in-arc", required=True, help="Path to the original forest_2nd.arc."
+    )
+    p_build.add_argument(
+        "--out-arc", required=True, help="Path of the rebuilt forest_2nd.arc."
+    )
+    p_build.add_argument(
+        "--compression",
+        choices=["auto", "none", "szs", "szp"],
+        default="auto",
+        help="Output compression (default: match the source archive).",
+    )
+    p_build.set_defaults(func=cmd_build)
+
+    p_apply_iso = sub.add_parser(
+        "apply-iso",
+        help="One shot: apply a dialog JSON and write a patched .iso.",
+    )
+    p_apply_iso.add_argument(
+        "--iso", required=True, help="Path to the original Animal Crossing .iso."
+    )
+    p_apply_iso.add_argument(
+        "--json", required=True, help="Path to the dialog JSON."
+    )
+    p_apply_iso.add_argument(
+        "--out",
+        help="Path of the patched .iso (default: '<name> (dialog).iso').",
+    )
+    p_apply_iso.add_argument(
+        "--compression",
+        choices=["auto", "none", "szs", "szp"],
+        default="auto",
+        help="Archive compression (default: match the source archive).",
+    )
+    p_apply_iso.set_defaults(func=cmd_apply_iso)
+
+    args = parser.parse_args(argv)
+    try:
+        args.func(args)
+    except DialogError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/dialog_tool.py
+++ b/tools/dialog_tool.py
@@ -1,21 +1,24 @@
 #!/usr/bin/env python3
-"""dialog_tool.py - JSON-driven villager/character dialog for ac-decomp.
+"""dialog_tool.py - JSON-driven text editing for ac-decomp.
 
-Animal Crossing stores *all* in-game dialog as two binary blobs that live
-inside ``forest_2nd.arc``:
+Animal Crossing stores editable text as pairs of binary blobs: a data blob of
+concatenated text plus a table of big-endian ``u32`` *cumulative end offsets*.
+Entry ``i`` occupies ``data[table[i-1] : table[i]]`` (entry 0 starts at offset
+0) and the game looks entries up purely by integer index.
 
-* ``message_data.bin``       - the raw text bytes for every message, concatenated.
-* ``message_data_table.bin`` - a table of big-endian ``u32`` *cumulative end
-                               offsets*. Entry ``i`` occupies
-                               ``data[table[i-1] : table[i]]`` (entry 0 starts
-                               at offset 0). The game looks messages up purely
-                               by integer index (see ``mMsg_Get_BodyParam`` /
-                               ``mMsg_LoadMsgData`` in ``src/game``).
+Two such resources are supported:
 
-There is no per-villager grouping in the data itself: every villager of a given
-personality shares the same message entries and the specific name is injected at
-runtime via control codes such as ``<<STR_TALKNAME>>``. Because of that, the
-natural editable unit is a single message index.
+* ``message`` - the main villager/character dialog, in ``forest_2nd.arc`` as
+  ``message_data.bin`` / ``message_data_table.bin`` (one group).
+* ``mail`` - the letters villagers send, in ``forest_1st.arc`` split across four
+  groups (``mail``, ``maila``, ``mailb``, ``mailc``), each its own
+  ``*_data.bin`` / ``*_data_table.bin`` pair.
+
+There is no per-villager grouping in the data itself: villagers of a given
+personality share the same entries and the specific name is injected at runtime
+via control codes such as ``<<STR_TALKNAME>>`` / ``<<STR_FREE0>>``. Because of
+that, the natural editable unit is a single entry index (plus its group, for
+multi-group resources like mail).
 
 This tool provides these commands:
 
@@ -60,12 +63,34 @@ import msg_tool  # noqa: E402  (shared text codec)
 import pyjkernel  # noqa: E402  (RARC archive read/write)
 import gcm  # noqa: E402  (GameCube disc image read/patch)
 
-# forest_2nd.arc's path inside a retail Animal Crossing GameCube disc.
-ISO_ARC_PATH = "files/forest_2nd.arc"
+# Editable resources. Each resource lives in one archive and is made up of one
+# or more (data, table) blob pairs, all in the same format (a text blob plus a
+# table of big-endian u32 cumulative end offsets). "message" is the main dialog
+# in forest_2nd.arc; "mail" is the letters villagers send, which live in
+# forest_1st.arc split across four blobs.
+RESOURCES = {
+    "message": {
+        "iso_path": "files/forest_2nd.arc",
+        "arc_name": "forest_2nd.arc",
+        "groups": [
+            {"name": "message",
+             "data": "message_data.bin",
+             "table": "message_data_table.bin"},
+        ],
+    },
+    "mail": {
+        "iso_path": "files/forest_1st.arc",
+        "arc_name": "forest_1st.arc",
+        "groups": [
+            {"name": "mail", "data": "mail_data.bin", "table": "mail_data_table.bin"},
+            {"name": "maila", "data": "maila_data.bin", "table": "maila_data_table.bin"},
+            {"name": "mailb", "data": "mailb_data.bin", "table": "mailb_data_table.bin"},
+            {"name": "mailc", "data": "mailc_data.bin", "table": "mailc_data_table.bin"},
+        ],
+    },
+}
 
-
-DATA_FILE_NAME = "message_data.bin"
-TABLE_FILE_NAME = "message_data_table.bin"
+DEFAULT_RESOURCE = "message"
 
 JSON_VERSION = 1
 
@@ -85,9 +110,23 @@ KNOWN_LABELS = {
     0x340B: "MSG_SONCHO_LIGHTHOUSE_2",
 }
 
+# Only the "message" resource has named ranges in the source.
+RESOURCE_LABELS = {"message": KNOWN_LABELS}
+
 
 class DialogError(Exception):
     """Raised for user-facing, recoverable errors."""
+
+
+def _get_resource(name):
+    """Return the resource definition for ``name`` (raises on unknown)."""
+    try:
+        return RESOURCES[name]
+    except KeyError:
+        raise DialogError(
+            f"Unknown resource '{name}'. Choose one of: "
+            + ", ".join(sorted(RESOURCES))
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -105,32 +144,40 @@ def _walk_files(archive):
     yield from recurse(archive.root_name)
 
 
-def _find_message_files(archive):
-    """Locate the message data + table files inside the archive.
+def _find_resource_blobs(archive, resource):
+    """Locate every ``(data, table)`` blob pair for ``resource``.
 
-    Returns ``(data_file, table_file)`` accessors. Raises ``DialogError`` when
-    either is missing.
+    Returns ``{group_name: (data_file, table_file)}``. Raises ``DialogError``
+    when any expected blob is missing.
     """
-    data_file = None
-    table_file = None
-    for _path, file in _walk_files(archive):
-        name = file.name.lower()
-        if name == DATA_FILE_NAME:
-            data_file = file
-        elif name == TABLE_FILE_NAME:
-            table_file = file
+    wanted = {}
+    for group in resource["groups"]:
+        wanted[group["data"].lower()] = (group["name"], "data")
+        wanted[group["table"].lower()] = (group["name"], "table")
 
-    if data_file is None or table_file is None:
-        missing = []
+    found = {g["name"]: {"data": None, "table": None} for g in resource["groups"]}
+    for _path, file in _walk_files(archive):
+        key = wanted.get(file.name.lower())
+        if key is not None:
+            found[key[0]][key[1]] = file
+
+    result = {}
+    missing = []
+    for group in resource["groups"]:
+        data_file = found[group["name"]]["data"]
+        table_file = found[group["name"]]["table"]
         if data_file is None:
-            missing.append(DATA_FILE_NAME)
+            missing.append(group["data"])
         if table_file is None:
-            missing.append(TABLE_FILE_NAME)
+            missing.append(group["table"])
+        result[group["name"]] = (data_file, table_file)
+
+    if missing:
         raise DialogError(
-            "Archive does not contain " + " and ".join(missing) + ". "
-            "Are you sure this is forest_2nd.arc?"
+            f"{resource['arc_name']} is missing: " + ", ".join(missing) + ". "
+            f"Are you sure this is {resource['arc_name']}?"
         )
-    return data_file, table_file
+    return result
 
 
 def _parse_table(table_bytes):
@@ -215,40 +262,59 @@ def encode_message(text):
 # ---------------------------------------------------------------------------
 # extract
 # ---------------------------------------------------------------------------
-def _build_document(archive, source_name, include_empty):
-    """Decode every message in ``archive`` into a dialog JSON document.
+def _build_document(archive, resource_name, source_name, include_empty):
+    """Decode every entry of ``resource_name`` in ``archive`` into a document.
 
-    Returns ``(document, skipped_empty)``.
+    Returns ``(document, skipped_empty)``. Single-group resources (``message``)
+    use a flat schema; multi-group resources (``mail``) tag each entry with its
+    ``group``.
     """
-    data_file, table_file = _find_message_files(archive)
-    table = _parse_table(table_file.data)
-    entries = _split_entries(data_file.data, table)
+    resource = _get_resource(resource_name)
+    blobs = _find_resource_blobs(archive, resource)
+    labels = RESOURCE_LABELS.get(resource_name, {})
+    multi = len(resource["groups"]) > 1
 
     out_entries = []
+    group_info = []
     skipped_empty = 0
-    for index, raw in entries:
-        if len(raw) == 0 and not include_empty:
-            skipped_empty += 1
-            continue
-        text, had_error = decode_message(raw)
-        entry = {
-            "index": index,
-            "label": KNOWN_LABELS.get(index, ""),
-            "original": text,
-            "new": text,
-        }
-        if had_error:
-            entry["decode_error"] = True
-        out_entries.append(entry)
+    for group in resource["groups"]:
+        name = group["name"]
+        data_file, table_file = blobs[name]
+        table = _parse_table(table_file.data)
+        group_info.append({
+            "name": name,
+            "data_file": data_file.name,
+            "table_file": table_file.name,
+            "entry_count": len(table),
+        })
+        for index, raw in _split_entries(data_file.data, table):
+            if len(raw) == 0 and not include_empty:
+                skipped_empty += 1
+                continue
+            text, had_error = decode_message(raw)
+            entry = {}
+            if multi:
+                entry["group"] = name
+            entry["index"] = index
+            entry["label"] = labels.get(index, "")
+            entry["original"] = text
+            entry["new"] = text
+            if had_error:
+                entry["decode_error"] = True
+            out_entries.append(entry)
 
     document = {
         "version": JSON_VERSION,
+        "resource": resource_name,
         "source_arc": source_name,
-        "data_file": data_file.name,
-        "table_file": table_file.name,
-        "entry_count": len(table),
-        "entries": out_entries,
     }
+    if multi:
+        document["groups"] = group_info
+    else:
+        document["data_file"] = group_info[0]["data_file"]
+        document["table_file"] = group_info[0]["table_file"]
+        document["entry_count"] = group_info[0]["entry_count"]
+    document["entries"] = out_entries
     return document, skipped_empty
 
 
@@ -261,32 +327,35 @@ def _write_document(document, out_path):
 def cmd_extract(args):
     archive, _compression = _load_arc(args.arc)
     document, skipped_empty = _build_document(
-        archive, os.path.basename(args.arc), args.include_empty
+        archive, args.resource, os.path.basename(args.arc), args.include_empty
     )
     _write_document(document, args.out)
 
     if not args.quiet:
         print(
-            f"Extracted {len(document['entries'])} message(s) "
+            f"Extracted {len(document['entries'])} {args.resource} entry(ies) "
             f"({skipped_empty} empty skipped) to {args.out}"
         )
 
 
 def cmd_extract_iso(args):
+    resource = _get_resource(args.resource)
     disc = gcm.Gcm(args.iso)
-    gf = disc.find(ISO_ARC_PATH)
+    gf = disc.find(resource["iso_path"])
     if gf is None:
         raise DialogError(
-            f"{args.iso} does not contain {ISO_ARC_PATH}. "
+            f"{args.iso} does not contain {resource['iso_path']}. "
             "Is this a US Animal Crossing GameCube disc image?"
         )
     archive, _compression = _open_arc_bytes(disc.read_file(gf))
-    document, skipped_empty = _build_document(archive, gf.name, args.include_empty)
+    document, skipped_empty = _build_document(
+        archive, args.resource, gf.name, args.include_empty
+    )
     _write_document(document, args.out)
 
     if not args.quiet:
         print(
-            f"Extracted {len(document['entries'])} message(s) "
+            f"Extracted {len(document['entries'])} {args.resource} entry(ies) "
             f"({skipped_empty} empty skipped) from {os.path.basename(args.iso)} "
             f"to {args.out}"
         )
@@ -303,34 +372,62 @@ def _load_json(path):
     return document
 
 
-def _collect_overrides(document):
-    """Return ``{index: new_text}`` for entries whose text was changed."""
-    overrides = {}
+def _resolve_resource_name(document, override):
+    """Pick the resource: explicit CLI override wins, else the JSON's own
+    ``resource`` field, else the default (``message``) for legacy files."""
+    name = override or document.get("resource") or DEFAULT_RESOURCE
+    _get_resource(name)  # validate
+    return name
+
+
+def _collect_overrides(document, resource):
+    """Return ``{group_name: {index: new_text}}`` for changed entries.
+
+    Legacy single-group documents omit ``group`` on their entries; those are
+    attributed to the resource's only group.
+    """
+    default_group = resource["groups"][0]["name"]
+    valid_groups = {g["name"] for g in resource["groups"]}
+    overrides = {g["name"]: {} for g in resource["groups"]}
+
     for entry in document["entries"]:
         try:
             index = int(entry["index"])
         except (KeyError, TypeError, ValueError):
             raise DialogError("An entry is missing a valid integer 'index'.")
 
+        group = entry.get("group", default_group)
+        if group not in valid_groups:
+            raise DialogError(
+                f"Entry {index} references unknown group '{group}' for "
+                f"resource with groups {sorted(valid_groups)}."
+            )
+
         new_text = entry.get("new")
         original_text = entry.get("original")
-        if new_text is None:
-            continue
-        # Only re-encode entries that actually changed. This keeps untouched
-        # data byte-for-byte identical to the source archive.
-        if new_text == original_text:
+        if new_text is None or new_text == original_text:
+            # Only re-encode entries that actually changed, keeping untouched
+            # data byte-for-byte identical to the source.
             continue
         if entry.get("decode_error"):
             raise DialogError(
-                f"Entry {index} was flagged with decode_error and cannot be "
-                "edited safely. Revert its 'new' text to match 'original'."
+                f"Entry {index} (group '{group}') was flagged with decode_error "
+                "and cannot be edited safely. Revert its 'new' text to match "
+                "'original'."
             )
-        overrides[index] = new_text
+        overrides[group][index] = new_text
     return overrides
 
 
 def _rebuild_message_bins(data_bytes, table, overrides):
-    """Return ``(new_data, new_table)`` bytes with overrides applied."""
+    """Return ``(new_data, new_table)`` bytes with ``{index: new_text}``
+    overrides applied.
+
+    The table is recomputed as cumulative end offsets over the actual data, so
+    it stays internally consistent even when an entry changes size. Unused
+    trailing slots (whose original offset was 0) keep their 0 sentinel; every
+    other slot gets the correct running offset.
+    """
     entries = _split_entries(data_bytes, table)
 
     new_data = bytearray()
@@ -338,6 +435,10 @@ def _rebuild_message_bins(data_bytes, table, overrides):
     for index, raw in entries:
         if index in overrides:
             raw = encode_message(overrides[index])
+        if len(raw) == 0 and index < len(table) and table[index] == 0:
+            # Unused padding slot - preserve the original zero sentinel.
+            new_table += struct.pack(">I", 0)
+            continue
         new_data += raw
         new_table += struct.pack(">I", len(new_data))
 
@@ -351,20 +452,28 @@ def _rebuild_message_bins(data_bytes, table, overrides):
     return bytes(new_data), bytes(new_table)
 
 
-def _apply_overrides_to_archive(archive, overrides):
-    """Apply ``{index: new_text}`` overrides in-place to ``archive``.
+def _apply_overrides_to_archive(archive, resource, overrides_by_group):
+    """Apply per-group overrides in-place to ``archive``.
 
-    Only touches ``message_data.bin`` / ``message_data_table.bin``. When there
-    are no overrides the archive is left completely untouched, so re-packing it
-    reproduces the source bytes.
+    Only touches the resource's own blob pairs. Groups with no changes are left
+    completely untouched, so re-packing reproduces the source bytes for them.
     """
-    if not overrides:
+    if not any(overrides_by_group.values()):
         return
-    data_file, table_file = _find_message_files(archive)
-    table = _parse_table(table_file.data)
-    new_data, new_table = _rebuild_message_bins(data_file.data, table, overrides)
-    data_file.data = bytearray(new_data)
-    table_file.data = bytearray(new_table)
+    blobs = _find_resource_blobs(archive, resource)
+    for group in resource["groups"]:
+        overrides = overrides_by_group.get(group["name"])
+        if not overrides:
+            continue
+        data_file, table_file = blobs[group["name"]]
+        table = _parse_table(table_file.data)
+        new_data, new_table = _rebuild_message_bins(data_file.data, table, overrides)
+        data_file.data = bytearray(new_data)
+        table_file.data = bytearray(new_table)
+
+
+def _count_overrides(overrides_by_group):
+    return sum(len(v) for v in overrides_by_group.values())
 
 
 def _resolve_compression(name, detected):
@@ -379,49 +488,82 @@ def _resolve_compression(name, detected):
 
 def cmd_build(args):
     document = _load_json(args.json)
-    overrides = _collect_overrides(document)
+    resource_name = _resolve_resource_name(document, args.resource)
+    resource = _get_resource(resource_name)
+    overrides = _collect_overrides(document, resource)
 
     archive, compression = _load_arc(args.in_arc)
     compression = _resolve_compression(args.compression, compression)
-    _apply_overrides_to_archive(archive, overrides)
+    _apply_overrides_to_archive(archive, resource, overrides)
 
     os.makedirs(os.path.dirname(os.path.abspath(args.out_arc)), exist_ok=True)
     pyjkernel.write_archive_file(archive, args.out_arc, True, compression, 9)
 
     if not args.quiet:
         print(
-            f"Applied {len(overrides)} dialog change(s); wrote {args.out_arc}"
+            f"Applied {_count_overrides(overrides)} {resource_name} change(s); "
+            f"wrote {args.out_arc}"
         )
 
 
 def cmd_apply_iso(args):
-    document = _load_json(args.json)
-    overrides = _collect_overrides(document)
+    json_paths = args.json if isinstance(args.json, list) else [args.json]
 
     disc = gcm.Gcm(args.iso)
-    gf = disc.find(ISO_ARC_PATH)
-    if gf is None:
-        raise DialogError(
-            f"{args.iso} does not contain {ISO_ARC_PATH}. "
-            "Is this a US Animal Crossing GameCube disc image?"
-        )
 
-    archive, compression = _open_arc_bytes(disc.read_file(gf))
-    compression = _resolve_compression(args.compression, compression)
-    _apply_overrides_to_archive(archive, overrides)
-    new_arc = pyjkernel.write_archive_buffer(archive, True, compression, 9)
+    # Merge overrides per resource so multiple JSONs targeting the same archive
+    # (or the same resource) are applied together, and each archive is rebuilt
+    # exactly once.
+    order = []
+    grouped = {}
+    for jpath in json_paths:
+        document = _load_json(jpath)
+        resource_name = _resolve_resource_name(document, args.resource)
+        resource = _get_resource(resource_name)
+        overrides = _collect_overrides(document, resource)
+        if resource_name not in grouped:
+            grouped[resource_name] = {
+                "resource": resource,
+                "overrides": {g["name"]: {} for g in resource["groups"]},
+                "count": 0,
+            }
+            order.append(resource_name)
+        bucket = grouped[resource_name]
+        for group_name, changes in overrides.items():
+            bucket["overrides"][group_name].update(changes)
+        bucket["count"] += _count_overrides(overrides)
+
+    replacements = []
+    summary = []
+    for resource_name in order:
+        bucket = grouped[resource_name]
+        resource = bucket["resource"]
+        gf = disc.find(resource["iso_path"])
+        if gf is None:
+            raise DialogError(
+                f"{args.iso} does not contain {resource['iso_path']}. "
+                "Is this a US Animal Crossing GameCube disc image?"
+            )
+        archive, compression = _open_arc_bytes(disc.read_file(gf))
+        compression = _resolve_compression(args.compression, compression)
+        _apply_overrides_to_archive(archive, resource, bucket["overrides"])
+        new_arc = pyjkernel.write_archive_buffer(archive, True, compression, 9)
+        replacements.append((gf, bytes(new_arc)))
+        summary.append((resource_name, resource["iso_path"], bucket["count"]))
 
     out_iso = args.out or _default_out_iso(args.iso)
     if not args.quiet:
         print(f"Copying disc image to {out_iso} ...")
-    info = disc.replace_file(gf, bytes(new_arc), out_iso)
+    results = disc.replace_files(replacements, out_iso)
 
     if not args.quiet:
-        print(
-            f"Applied {len(overrides)} dialog change(s) to {ISO_ARC_PATH} "
-            f"({info['old_size']} -> {info['new_size']} bytes, {info['mode']}).\n"
-            f"Wrote {out_iso}"
-        )
+        for (resource_name, iso_path, count), result in zip(summary, results):
+            print(
+                f"Applied {count} {resource_name} change(s) to {iso_path} "
+                f"({result['old_size']} -> {result['new_size']} bytes, "
+                f"{result['mode']})."
+            )
+        print(f"Wrote {out_iso}")
 
 
 def _default_out_iso(in_iso):
@@ -442,24 +584,29 @@ def main(argv=None):
     sub = parser.add_subparsers(dest="command", required=True)
 
     p_extract = sub.add_parser(
-        "extract", help="Decode forest_2nd.arc dialog into an editable JSON file."
+        "extract", help="Decode an archive's text (dialog or mail) into JSON."
     )
     p_extract.add_argument(
-        "--arc", required=True, help="Path to the source forest_2nd.arc."
+        "--arc", required=True,
+        help="Path to the source arc (forest_2nd.arc for message, forest_1st.arc for mail).",
     )
     p_extract.add_argument(
         "--out", required=True, help="Path of the JSON file to write."
     )
     p_extract.add_argument(
+        "--resource", choices=sorted(RESOURCES), default=DEFAULT_RESOURCE,
+        help="Which text set to extract (default: message).",
+    )
+    p_extract.add_argument(
         "--include-empty",
         action="store_true",
-        help="Also emit empty/placeholder message slots.",
+        help="Also emit empty/placeholder slots.",
     )
     p_extract.set_defaults(func=cmd_extract)
 
     p_extract_iso = sub.add_parser(
         "extract-iso",
-        help="Decode dialog straight out of a GameCube .iso into a JSON file.",
+        help="Decode dialog or mail straight out of a GameCube .iso into JSON.",
     )
     p_extract_iso.add_argument(
         "--iso", required=True, help="Path to the Animal Crossing .iso."
@@ -468,21 +615,29 @@ def main(argv=None):
         "--out", required=True, help="Path of the JSON file to write."
     )
     p_extract_iso.add_argument(
+        "--resource", choices=sorted(RESOURCES), default=DEFAULT_RESOURCE,
+        help="Which text set to extract (default: message).",
+    )
+    p_extract_iso.add_argument(
         "--include-empty",
         action="store_true",
-        help="Also emit empty/placeholder message slots.",
+        help="Also emit empty/placeholder slots.",
     )
     p_extract_iso.set_defaults(func=cmd_extract_iso)
 
     p_build = sub.add_parser(
-        "build", help="Apply a dialog JSON back into a forest_2nd.arc."
+        "build", help="Apply a dialog/mail JSON back into its source arc."
     )
-    p_build.add_argument("--json", required=True, help="Path to the dialog JSON.")
+    p_build.add_argument("--json", required=True, help="Path to the JSON.")
     p_build.add_argument(
-        "--in-arc", required=True, help="Path to the original forest_2nd.arc."
+        "--in-arc", required=True, help="Path to the original source arc."
     )
     p_build.add_argument(
-        "--out-arc", required=True, help="Path of the rebuilt forest_2nd.arc."
+        "--out-arc", required=True, help="Path of the rebuilt arc."
+    )
+    p_build.add_argument(
+        "--resource", choices=sorted(RESOURCES), default=None,
+        help="Override the resource (default: read from the JSON, else message).",
     )
     p_build.add_argument(
         "--compression",
@@ -494,17 +649,23 @@ def main(argv=None):
 
     p_apply_iso = sub.add_parser(
         "apply-iso",
-        help="One shot: apply a dialog JSON and write a patched .iso.",
+        help="One shot: apply a dialog/mail JSON and write a patched .iso.",
     )
     p_apply_iso.add_argument(
         "--iso", required=True, help="Path to the original Animal Crossing .iso."
     )
     p_apply_iso.add_argument(
-        "--json", required=True, help="Path to the dialog JSON."
+        "--json", required=True, nargs="+",
+        help="One or more JSON files to apply (e.g. dialog.json mail.json). "
+             "All changes are baked into a single output .iso.",
     )
     p_apply_iso.add_argument(
         "--out",
         help="Path of the patched .iso (default: '<name> (dialog).iso').",
+    )
+    p_apply_iso.add_argument(
+        "--resource", choices=sorted(RESOURCES), default=None,
+        help="Override the resource (default: read from the JSON, else message).",
     )
     p_apply_iso.add_argument(
         "--compression",

--- a/tools/gcm.py
+++ b/tools/gcm.py
@@ -1,0 +1,177 @@
+"""Minimal GameCube disc image (GCM / .iso, uncompressed) reader + single-file patcher.
+
+Only supports plain "ISO"/GCM images (not WBFS/CISO/RVZ). Enough to read a single
+file out of the disc and write a modified version back, without external tools.
+"""
+
+from __future__ import annotations
+
+import struct
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+# Disc header (boot.bin) field offsets.
+_OFF_AUDIO_STREAM = 0x08
+_OFF_DOL = 0x420
+_OFF_FST = 0x424
+_OFF_FST_SIZE = 0x428
+_OFF_FST_MAX = 0x42C
+
+_ENTRY_SIZE = 12
+
+
+class GcmError(Exception):
+    pass
+
+
+@dataclass
+class GcmFile:
+    path: str          # full path like "files/forest_2nd.arc"
+    name: str          # basename
+    offset: int        # data offset on disc
+    size: int          # data size
+    entry_index: int   # index into the FST entry table
+    entry_pos: int     # absolute byte position of this entry in the FST
+
+
+class Gcm:
+    def __init__(self, path: Path):
+        self.path = Path(path)
+        with open(self.path, "rb") as f:
+            self.header = f.read(0x440)
+            if len(self.header) < 0x440:
+                raise GcmError("File too small to be a GCM/ISO image.")
+            self.dol_offset = self._u32(self.header, _OFF_DOL)
+            self.fst_offset = self._u32(self.header, _OFF_FST)
+            self.fst_size = self._u32(self.header, _OFF_FST_SIZE)
+            self.audio_streaming = self.header[_OFF_AUDIO_STREAM]
+            f.seek(self.fst_offset)
+            self.fst = f.read(self.fst_size)
+        if len(self.fst) < _ENTRY_SIZE:
+            raise GcmError("FST is empty or unreadable.")
+        self.disc_size = self.path.stat().st_size
+        self.files: List[GcmFile] = []
+        self._parse_fst()
+
+    @staticmethod
+    def _u32(buf: bytes, off: int) -> int:
+        return struct.unpack_from(">I", buf, off)[0]
+
+    def _parse_fst(self) -> None:
+        num_entries = self._u32(self.fst, 8)  # root entry length = total count
+        str_table_off = num_entries * _ENTRY_SIZE
+        if str_table_off > len(self.fst):
+            raise GcmError("FST entry table exceeds FST size; not a valid image.")
+
+        def name_at(name_off: int) -> str:
+            start = str_table_off + name_off
+            end = self.fst.find(b"\x00", start)
+            if end < 0:
+                end = len(self.fst)
+            return self.fst[start:end].decode("shift_jis", errors="replace")
+
+        # Stack of (dir_end_index, dir_path) to reconstruct full paths.
+        stack: List[Tuple[int, str]] = [(num_entries, "")]
+        for i in range(1, num_entries):
+            pos = i * _ENTRY_SIZE
+            flags = self.fst[pos]
+            name_off = struct.unpack_from(">I", self.fst, pos)[0] & 0x00FFFFFF
+            arg1 = self._u32(self.fst, pos + 4)
+            arg2 = self._u32(self.fst, pos + 8)
+            while len(stack) > 1 and i >= stack[-1][0]:
+                stack.pop()
+            parent_path = stack[-1][1]
+            name = name_at(name_off)
+            full = f"{parent_path}{name}" if not parent_path else f"{parent_path}/{name}"
+            if flags & 1:  # directory
+                stack.append((arg2, full))
+            else:
+                self.files.append(
+                    GcmFile(path=full, name=name, offset=arg1, size=arg2,
+                            entry_index=i, entry_pos=pos)
+                )
+
+    def find(self, path: str) -> Optional[GcmFile]:
+        want = path.strip("/").lower()
+        for gf in self.files:
+            if gf.path.lower() == want:
+                return gf
+        # Fall back to basename match.
+        base = want.rsplit("/", 1)[-1]
+        for gf in self.files:
+            if gf.name.lower() == base:
+                return gf
+        return None
+
+    def read_file(self, gf: GcmFile) -> bytes:
+        with open(self.path, "rb") as f:
+            f.seek(gf.offset)
+            return f.read(gf.size)
+
+    def layout(self) -> Dict[str, int]:
+        used_end = max((gf.offset + gf.size) for gf in self.files)
+        used_end = max(used_end, self.fst_offset + self.fst_size)
+        first_user = min((gf.offset for gf in self.files), default=self.fst_offset)
+        return {
+            "disc_size": self.disc_size,
+            "fst_offset": self.fst_offset,
+            "fst_size": self.fst_size,
+            "dol_offset": self.dol_offset,
+            "audio_streaming": self.audio_streaming,
+            "file_count": len(self.files),
+            "first_user_offset": first_user,
+            "used_end": used_end,
+            "free_after_used": self.disc_size - used_end,
+        }
+
+    def replace_file(self, gf: GcmFile, new_data: bytes, out_path: Path) -> Dict[str, int]:
+        """Write a copy of the disc to ``out_path`` with ``gf`` replaced by
+        ``new_data`` and the FST updated accordingly.
+
+        Only the target file's data and its single FST entry are ever changed.
+        No other file moves. Two cases:
+
+        * ``len(new_data) <= gf.size`` - patch in place and zero-pad the slack.
+        * otherwise - append the new data at an aligned position past the end
+          of the disc, zero the old region, and repoint the FST entry.
+
+        The huge region between the FST and the file cluster is *not* free space
+        on this disc (the game reads it by absolute offset), so it is never used.
+        """
+        out_path = Path(out_path)
+        same = out_path.resolve() == self.path.resolve()
+        if not same:
+            import shutil
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(self.path, out_path)
+
+        old_size = gf.size
+        entry_abs = self.fst_offset + gf.entry_pos
+        result = {"old_offset": gf.offset, "old_size": old_size,
+                  "new_size": len(new_data)}
+
+        with open(out_path, "r+b") as f:
+            if len(new_data) <= old_size:
+                f.seek(gf.offset)
+                f.write(new_data)
+                pad = old_size - len(new_data)
+                if pad:
+                    f.write(b"\x00" * pad)
+                new_off = gf.offset
+                result["mode"] = "in-place"
+            else:
+                new_off = (self.disc_size + 0x1F) & ~0x1F
+                f.seek(new_off)
+                f.write(new_data)
+                # Zero the now-dead original region.
+                f.seek(gf.offset)
+                f.write(b"\x00" * old_size)
+                result["mode"] = "appended"
+            # Update the FST entry: [type|nameoff][offset][length].
+            f.seek(entry_abs + 4)
+            f.write(struct.pack(">II", new_off, len(new_data)))
+
+        result["new_offset"] = new_off
+        result["out_disc_size"] = out_path.stat().st_size
+        return result

--- a/tools/gcm.py
+++ b/tools/gcm.py
@@ -126,15 +126,21 @@ class Gcm:
         }
 
     def replace_file(self, gf: GcmFile, new_data: bytes, out_path: Path) -> Dict[str, int]:
-        """Write a copy of the disc to ``out_path`` with ``gf`` replaced by
-        ``new_data`` and the FST updated accordingly.
+        """Convenience wrapper around :meth:`replace_files` for a single file."""
+        return self.replace_files([(gf, new_data)], out_path)[0]
 
-        Only the target file's data and its single FST entry are ever changed.
-        No other file moves. Two cases:
+    def replace_files(self, replacements, out_path: Path):
+        """Write a copy of the disc to ``out_path`` with several files replaced
+        at once and the FST updated accordingly.
+
+        ``replacements`` is a list of ``(GcmFile, new_data)`` pairs. Each target
+        file must be distinct. Only those files' data and their FST entries ever
+        change; no other file moves. For each file, two cases:
 
         * ``len(new_data) <= gf.size`` - patch in place and zero-pad the slack.
-        * otherwise - append the new data at an aligned position past the end
-          of the disc, zero the old region, and repoint the FST entry.
+        * otherwise - append the new data at an aligned position past the end of
+          the disc (a shared, advancing cursor so multiple appended files never
+          overlap), zero the old region, and repoint the FST entry.
 
         The huge region between the FST and the file cluster is *not* free space
         on this disc (the game reads it by absolute offset), so it is never used.
@@ -146,32 +152,51 @@ class Gcm:
             out_path.parent.mkdir(parents=True, exist_ok=True)
             shutil.copyfile(self.path, out_path)
 
-        old_size = gf.size
-        entry_abs = self.fst_offset + gf.entry_pos
-        result = {"old_offset": gf.offset, "old_size": old_size,
-                  "new_size": len(new_data)}
-
+        seen = set()
+        results = []
+        append_cursor = self.disc_size
         with open(out_path, "r+b") as f:
-            if len(new_data) <= old_size:
-                f.seek(gf.offset)
-                f.write(new_data)
-                pad = old_size - len(new_data)
-                if pad:
-                    f.write(b"\x00" * pad)
-                new_off = gf.offset
-                result["mode"] = "in-place"
-            else:
-                new_off = (self.disc_size + 0x1F) & ~0x1F
-                f.seek(new_off)
-                f.write(new_data)
-                # Zero the now-dead original region.
-                f.seek(gf.offset)
-                f.write(b"\x00" * old_size)
-                result["mode"] = "appended"
-            # Update the FST entry: [type|nameoff][offset][length].
-            f.seek(entry_abs + 4)
-            f.write(struct.pack(">II", new_off, len(new_data)))
+            for gf, new_data in replacements:
+                if gf.entry_pos in seen:
+                    raise GcmError(
+                        f"File {gf.path} was given more than once in a single "
+                        "replace_files call."
+                    )
+                seen.add(gf.entry_pos)
 
-        result["new_offset"] = new_off
-        result["out_disc_size"] = out_path.stat().st_size
-        return result
+                old_size = gf.size
+                entry_abs = self.fst_offset + gf.entry_pos
+                if len(new_data) <= old_size:
+                    f.seek(gf.offset)
+                    f.write(new_data)
+                    pad = old_size - len(new_data)
+                    if pad:
+                        f.write(b"\x00" * pad)
+                    new_off = gf.offset
+                    mode = "in-place"
+                else:
+                    new_off = (append_cursor + 0x1F) & ~0x1F
+                    f.seek(new_off)
+                    f.write(new_data)
+                    # Zero the now-dead original region.
+                    f.seek(gf.offset)
+                    f.write(b"\x00" * old_size)
+                    append_cursor = new_off + len(new_data)
+                    mode = "appended"
+                # Update the FST entry: [type|nameoff][offset][length].
+                f.seek(entry_abs + 4)
+                f.write(struct.pack(">II", new_off, len(new_data)))
+
+                results.append({
+                    "path": gf.path,
+                    "old_offset": gf.offset,
+                    "old_size": old_size,
+                    "new_size": len(new_data),
+                    "new_offset": new_off,
+                    "mode": mode,
+                })
+
+        self.disc_size = max(self.disc_size, out_path.stat().st_size)
+        for r in results:
+            r["out_disc_size"] = self.disc_size
+        return results


### PR DESCRIPTION
## Summary

This PR adds a JSON-based workflow for rewriting Animal Crossing text content outside the matching code build, with a single-command path that bakes both villager dialog and villager mail into a patched GameCube ISO.

The main additions are:
- A new text toolchain in [tools/dialog_tool.py](tools/dialog_tool.py) for extracting, annotating, tracing, rebuilding, and applying text resources
- A minimal GameCube disc patcher in [tools/gcm.py](tools/gcm.py) so ISO patching works without external tooling
- Tracked editable JSON sources in [dialog/dialog.json](dialog/dialog.json) and [dialog/mail.json](dialog/mail.json)
- A model-facing rewrite brief in [dialog/prompt.txt](dialog/prompt.txt)
- Updated workflow documentation in [dialog/README.md](dialog/README.md)
- An opt-in post-build archive repack hook in [configure.py](configure.py) for loose-archive workflows

## What This Changes

### Dialog and mail extraction/building

Supports two text resources:
- `message`: main villager/character dialog from `forest_2nd.arc`
- `mail`: villager/system letters from `forest_1st.arc`

Adds these commands:
- `extract`
- `extract-iso`
- `build`
- `apply-iso`
- `annotate`
- `trace`

Untouched entries are preserved byte-for-byte at the message-data level by only re-encoding entries whose `new` text differs from `original`.

### Single ISO workflow

`apply-iso` now accepts multiple JSON files and writes one output ISO containing all selected changes.

That allows a single command such as:

```sh
python dialog_tool.py apply-iso \
  --iso "orig/GAFE01_00/Animal Crossing (USA).iso" \
  --json dialog.json mail.json \
  --out "build/GAFE01_00/Animal Crossing (USA) (modded).iso"